### PR TITLE
Add tsconfig to as package

### DIFF
--- a/packages/wasm-as/tsconfig.json
+++ b/packages/wasm-as/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "assemblyscript/std/assembly.json",
+    "include": [
+      "./assembly/**/*.ts"
+    ]
+}


### PR DESCRIPTION
Quick fix to get better type hinting in IDE-s.

There is a bunch of type and compile errors, I didn't commit fix for those.
Unfortunately, in typescript, function decorators (@external) are not allowed so it's gonna throw errors if you try to run type checking (`tsc --noEmit`). Afaik, as recommendation is to rename exports in separate file to avoid `@external` type errors.