### PR TITLE
Parse nested objects and arrays

### DIFF
--- a/packages/schema/parse/src/__tests__/cases/sanity/input.graphql
+++ b/packages/schema/parse/src/__tests__/cases/sanity/input.graphql
@@ -41,6 +41,11 @@ type CustomType {
   uOptArrayOptArray: [[UInt64]]!
   uArrayOptArrayArray: [[[UInt64!]!]]!
   crazyArray: [[[[UInt64!]]!]]
+  objectArray: [UserObject!]!
+  objectArrayArray: [[UserObject!]!]!
+  nestedObject: UserObject!
+  optNestedObject: UserObject
+
 }
 
 type AnotherType {
@@ -61,6 +66,7 @@ type Query @imports(
 
   userObjectMethod(
     userObject: UserObject
+    arrayObject: [UserObject!]!
   ): UserObject!
 
   importedObjectMethod(

--- a/packages/schema/parse/src/__tests__/cases/sanity/input.graphql
+++ b/packages/schema/parse/src/__tests__/cases/sanity/input.graphql
@@ -68,10 +68,6 @@ type Query @imports(
     userObject: UserObject
     arrayObject: [UserObject!]!
   ): UserObject!
-
-  importedObjectMethod(
-    importedObject: TestImport_Object!
-  ): TestImport_Object!
 }
 
 type TestImport_Query @imported(
@@ -90,6 +86,10 @@ type TestImport_Query @imported(
   anotherMethod(
     arg: [String!]!
   ): Int64!
+
+  importedObjectMethod(
+    importedObject: TestImport_Object!
+  ): TestImport_Object!
 }
 
 type TestImport_Mutation @imported(

--- a/packages/schema/parse/src/__tests__/cases/sanity/output.ts
+++ b/packages/schema/parse/src/__tests__/cases/sanity/output.ts
@@ -114,6 +114,35 @@ export const output: TypeInfo = {
             )
           )
         ),
+        createArrayPropertyDefinition(
+          "objectArray",
+          "[UserObject]",
+          true,
+          createObjectDefinition("objectArray", "UserObject", true)
+        ),
+        createArrayPropertyDefinition(
+          "objectArrayArray",
+          "[[UserObject]]",
+          true,
+          createArrayDefinition(
+            "objectArrayArray",
+            "[UserObject]",
+            true,
+            createObjectDefinition("objectArrayArray", "UserObject", true)
+          )
+        ),
+        createObjectPropertyDefinition(
+          "nestedObject",
+          "UserObject",
+          true,
+          []
+        ),
+        createObjectPropertyDefinition(
+          "optNestedObject",
+          "?UserObject",
+          false,
+          []
+        )
       ],
     },
     {
@@ -141,6 +170,11 @@ export const output: TypeInfo = {
           ...createMethodDefinition("query", "userObjectMethod"),
           arguments: [
             createObjectPropertyDefinition("userObject", "?UserObject", false, []),
+            createArrayPropertyDefinition("arrayObject", "[UserObject]", true, createObjectDefinition(
+              "arrayObject",
+              "UserObject",
+              true
+            )),
           ],
           return: createObjectPropertyDefinition(
             "userObjectMethod",

--- a/packages/schema/parse/src/__tests__/cases/sanity/output.ts
+++ b/packages/schema/parse/src/__tests__/cases/sanity/output.ts
@@ -140,19 +140,13 @@ export const output: TypeInfo = {
         {
           ...createMethodDefinition("query", "userObjectMethod"),
           arguments: [
-            createObjectPropertyDefinition("userObject", "?UserObject", false, [
-              createScalarPropertyDefinition("fieldA", "?String", false),
-              createScalarPropertyDefinition("fieldB", "Int", true),
-            ]),
+            createObjectPropertyDefinition("userObject", "?UserObject", false, []),
           ],
           return: createObjectPropertyDefinition(
             "userObjectMethod",
             "UserObject",
             true,
-            [
-              createScalarPropertyDefinition("fieldA", "?String", false),
-              createScalarPropertyDefinition("fieldB", "Int", true),
-            ]
+            []
           ),
         },
         {
@@ -163,16 +157,15 @@ export const output: TypeInfo = {
                 "importedObject",
                 "TestImport_Object",
                 true,
-                [createScalarPropertyDefinition("prop", "String", true)]
+                []
               ),
               object: {
                 ...createObjectDefinition(
                   "importedObject",
                   "TestImport_Object",
                   true,
-                  [createScalarPropertyDefinition("prop", "String", true)]
+                  []
                 ),
-                kind: DefinitionKind.ImportedObject
               }
             }
           ],
@@ -181,16 +174,15 @@ export const output: TypeInfo = {
               "importedObjectMethod",
               "TestImport_Object",
               true,
-              [createScalarPropertyDefinition("prop", "String", true)]
+              []
             ),
             object: {
               ...createObjectDefinition(
                 "importedObjectMethod",
                 "TestImport_Object",
                 true,
-                [createScalarPropertyDefinition("prop", "String", true)]
+                []
               ),
-              kind: DefinitionKind.ImportedObject
             }
           }
         },

--- a/packages/schema/parse/src/__tests__/cases/sanity/output.ts
+++ b/packages/schema/parse/src/__tests__/cases/sanity/output.ts
@@ -10,7 +10,6 @@ import {
   createObjectPropertyDefinition,
   createImportedObjectDefinition,
   createImportedQueryDefinition,
-  DefinitionKind,
 } from "../../../typeInfo";
 
 export const output: TypeInfo = {

--- a/packages/schema/parse/src/__tests__/cases/sanity/output.ts
+++ b/packages/schema/parse/src/__tests__/cases/sanity/output.ts
@@ -182,43 +182,6 @@ export const output: TypeInfo = {
             []
           ),
         },
-        {
-          ...createMethodDefinition("query", "importedObjectMethod"),
-          arguments: [
-            {
-              ...createObjectPropertyDefinition(
-                "importedObject",
-                "TestImport_Object",
-                true,
-                []
-              ),
-              object: {
-                ...createObjectDefinition(
-                  "importedObject",
-                  "TestImport_Object",
-                  true,
-                  []
-                ),
-              }
-            }
-          ],
-          return: {
-            ...createObjectPropertyDefinition(
-              "importedObjectMethod",
-              "TestImport_Object",
-              true,
-              []
-            ),
-            object: {
-              ...createObjectDefinition(
-                "importedObjectMethod",
-                "TestImport_Object",
-                true,
-                []
-              ),
-            }
-          }
-        },
       ],
     },
   ],
@@ -282,7 +245,44 @@ export const output: TypeInfo = {
             "Int64",
             true
           ),
-        }
+        },
+        {
+          ...createMethodDefinition("query", "importedObjectMethod"),
+          arguments: [
+            {
+              ...createObjectPropertyDefinition(
+                "importedObject",
+                "TestImport_Object",
+                true,
+                []
+              ),
+              object: {
+                ...createObjectDefinition(
+                  "importedObject",
+                  "TestImport_Object",
+                  true,
+                  []
+                ),
+              }
+            }
+          ],
+          return: {
+            ...createObjectPropertyDefinition(
+              "importedObjectMethod",
+              "TestImport_Object",
+              true,
+              []
+            ),
+            object: {
+              ...createObjectDefinition(
+                "importedObjectMethod",
+                "TestImport_Object",
+                true,
+                []
+              ),
+            }
+          }
+        },
       ],
     },
     {

--- a/packages/schema/parse/src/extract/imported-object-types.ts
+++ b/packages/schema/parse/src/extract/imported-object-types.ts
@@ -1,7 +1,7 @@
 import {
   TypeInfo,
   ImportedObjectDefinition,
-  createImportedObjectDefinition
+  createImportedObjectDefinition,
 } from "../typeInfo";
 import {
   extractFieldDefinition,
@@ -22,7 +22,10 @@ import {
   ValueNode,
 } from "graphql";
 
-const visitorEnter = (importedObjectTypes: ImportedObjectDefinition[], state: State) => ({
+const visitorEnter = (
+  importedObjectTypes: ImportedObjectDefinition[],
+  state: State
+) => ({
   ObjectTypeDefinition: (node: ObjectTypeDefinitionNode) => {
     if (!node.directives) {
       return;

--- a/packages/schema/parse/src/extract/imported-object-types.ts
+++ b/packages/schema/parse/src/extract/imported-object-types.ts
@@ -1,4 +1,8 @@
-import { TypeInfo, createImportedObjectDefinition } from "../typeInfo";
+import {
+  TypeInfo,
+  ImportedObjectDefinition,
+  createImportedObjectDefinition
+} from "../typeInfo";
 import {
   extractFieldDefinition,
   extractListType,
@@ -18,7 +22,7 @@ import {
   ValueNode,
 } from "graphql";
 
-const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
+const visitorEnter = (importedObjectTypes: ImportedObjectDefinition[], state: State) => ({
   ObjectTypeDefinition: (node: ObjectTypeDefinitionNode) => {
     if (!node.directives) {
       return;
@@ -86,7 +90,7 @@ const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
       type
     );
 
-    typeInfo.importedObjectTypes.push(importedType);
+    importedObjectTypes.push(importedType);
     state.currentType = importedType;
   },
   NonNullType: (_node: NonNullTypeNode) => {
@@ -103,7 +107,7 @@ const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
   },
 });
 
-const visitorLeave = (typeInfo: TypeInfo, state: State) => ({
+const visitorLeave = (state: State) => ({
   ObjectTypeDefinition: (_node: ObjectTypeDefinitionNode) => {
     state.currentType = undefined;
   },
@@ -122,7 +126,7 @@ export function extractImportedObjectTypes(
   const state: State = {};
 
   visit(astNode, {
-    enter: visitorEnter(typeInfo, state),
-    leave: visitorLeave(typeInfo, state),
+    enter: visitorEnter(typeInfo.importedObjectTypes, state),
+    leave: visitorLeave(state),
   });
 }

--- a/packages/schema/parse/src/extract/imported-query-types.ts
+++ b/packages/schema/parse/src/extract/imported-query-types.ts
@@ -2,7 +2,7 @@ import {
   TypeInfo,
   ImportedQueryDefinition,
   createImportedQueryDefinition,
-  createMethodDefinition
+  createMethodDefinition,
 } from "../typeInfo";
 import {
   extractInputValueDefinition,
@@ -24,7 +24,10 @@ import {
   ValueNode,
 } from "graphql";
 
-const visitorEnter = (importedQueryTypes: ImportedQueryDefinition[], state: State) => ({
+const visitorEnter = (
+  importedQueryTypes: ImportedQueryDefinition[],
+  state: State
+) => ({
   ObjectTypeDefinition: (node: ObjectTypeDefinitionNode) => {
     if (!node.directives) {
       return;

--- a/packages/schema/parse/src/extract/imported-query-types.ts
+++ b/packages/schema/parse/src/extract/imported-query-types.ts
@@ -123,7 +123,7 @@ const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
     state.nonNullType = true;
   },
   NamedType: (node: NamedTypeNode) => {
-    extractNamedType(node, state, typeInfo);
+    extractNamedType(node, state);
   },
   ListType: (_node: ListTypeNode) => {
     extractListType(state);

--- a/packages/schema/parse/src/extract/imported-query-types.ts
+++ b/packages/schema/parse/src/extract/imported-query-types.ts
@@ -1,7 +1,8 @@
 import {
   TypeInfo,
+  ImportedQueryDefinition,
   createImportedQueryDefinition,
-  createMethodDefinition,
+  createMethodDefinition
 } from "../typeInfo";
 import {
   extractInputValueDefinition,
@@ -23,7 +24,7 @@ import {
   ValueNode,
 } from "graphql";
 
-const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
+const visitorEnter = (importedQueryTypes: ImportedQueryDefinition[], state: State) => ({
   ObjectTypeDefinition: (node: ObjectTypeDefinitionNode) => {
     if (!node.directives) {
       return;
@@ -95,7 +96,7 @@ const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
       typeName,
       type
     );
-    typeInfo.importedQueryTypes.push(importedType);
+    importedQueryTypes.push(importedType);
     state.currentImport = importedType;
   },
   FieldDefinition: (node: FieldDefinitionNode) => {
@@ -130,7 +131,7 @@ const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
   },
 });
 
-const visitorLeave = (typeInfo: TypeInfo, state: State) => ({
+const visitorLeave = (state: State) => ({
   ObjectTypeDefinition: (_node: ObjectTypeDefinitionNode) => {
     state.currentImport = undefined;
   },
@@ -153,7 +154,7 @@ export function extractImportedQueryTypes(
   const state: State = {};
 
   visit(astNode, {
-    enter: visitorEnter(typeInfo, state),
-    leave: visitorLeave(typeInfo, state),
+    enter: visitorEnter(typeInfo.importedQueryTypes, state),
+    leave: visitorLeave(state),
   });
 }

--- a/packages/schema/parse/src/extract/object-types-utils.ts
+++ b/packages/schema/parse/src/extract/object-types-utils.ts
@@ -1,0 +1,78 @@
+import {
+  createArrayDefinition,
+  createPropertyDefinition,
+  createScalarDefinition,
+  ObjectDefinition,
+  PropertyDefinition,
+} from "../typeInfo";
+
+import { FieldDefinitionNode, NamedTypeNode } from "graphql";
+
+export interface State {
+  currentType?: ObjectDefinition;
+  currentProperty?: PropertyDefinition | undefined;
+  nonNullType?: boolean;
+}
+
+export function extractFieldDefinition(
+  node: FieldDefinitionNode,
+  state: State
+): void {
+  const importDef = state.currentType;
+
+  if (!importDef) {
+    return;
+  }
+
+  if (node.arguments && node.arguments.length > 0) {
+    throw Error(
+      `Imported types cannot have methods. See type "${importDef.name}"`
+    );
+  }
+
+  const property = createPropertyDefinition(node.name.value);
+
+  state.currentProperty = property;
+  importDef.properties.push(property);
+}
+
+export function extractNamedType(node: NamedTypeNode, state: State): void {
+  const property = state.currentProperty;
+
+  if (!property) {
+    return;
+  }
+
+  if (property.scalar) {
+    return;
+  }
+
+  const modifier = state.nonNullType ? "" : "?";
+
+  property.scalar = createScalarDefinition(
+    property.name,
+    modifier + node.name.value,
+    state.nonNullType
+  );
+  state.nonNullType = false;
+}
+
+export function extractListType(state: State): void {
+  const property = state.currentProperty;
+
+  if (!property) {
+    return;
+  }
+
+  if (property.scalar) {
+    return;
+  }
+
+  property.array = createArrayDefinition(
+    property.name,
+    "TBD",
+    state.nonNullType
+  );
+  state.currentProperty = property.array;
+  state.nonNullType = false;
+}

--- a/packages/schema/parse/src/extract/object-types-utils.ts
+++ b/packages/schema/parse/src/extract/object-types-utils.ts
@@ -1,7 +1,9 @@
 import {
   createArrayDefinition,
+  createObjectDefinition,
   createPropertyDefinition,
   createScalarDefinition,
+  isScalar,
   ObjectDefinition,
   PropertyDefinition,
 } from "../typeInfo";
@@ -49,11 +51,20 @@ export function extractNamedType(node: NamedTypeNode, state: State): void {
 
   const modifier = state.nonNullType ? "" : "?";
 
-  property.scalar = createScalarDefinition(
-    property.name,
-    modifier + node.name.value,
-    state.nonNullType
-  );
+  if (isScalar(node.name.value)) {
+    property.scalar = createScalarDefinition(
+      property.name,
+      modifier + node.name.value,
+      state.nonNullType
+    );
+  } else {
+    property.object = createObjectDefinition(
+      property.name,
+      modifier + node.name.value,
+      state.nonNullType
+    );
+  }
+
   state.nonNullType = false;
 }
 

--- a/packages/schema/parse/src/extract/object-types.ts
+++ b/packages/schema/parse/src/extract/object-types.ts
@@ -1,4 +1,8 @@
-import { TypeInfo, createObjectDefinition } from "../typeInfo";
+import {
+  TypeInfo,
+  ObjectDefinition,
+  createObjectDefinition
+} from "../typeInfo";
 import {
   extractFieldDefinition,
   extractListType,
@@ -17,7 +21,7 @@ import {
   DirectiveNode,
 } from "graphql";
 
-const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
+const visitorEnter = (objectTypes: ObjectDefinition[], state: State) => ({
   ObjectTypeDefinition: (node: TypeDefinitionNode) => {
     // Skip non-custom types
     if (node.name.value === "Query" || node.name.value === "Mutation") {
@@ -36,7 +40,7 @@ const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
 
     // Create a new TypeDefinition
     const type = createObjectDefinition(node.name.value);
-    typeInfo.objectTypes.push(type);
+    objectTypes.push(type);
     state.currentType = type;
   },
   NonNullType: (_node: NonNullTypeNode) => {
@@ -53,7 +57,7 @@ const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
   },
 });
 
-const visitorLeave = (schemaInfo: TypeInfo, state: State) => ({
+const visitorLeave = (state: State) => ({
   ObjectTypeDefinition: (_node: TypeDefinitionNode) => {
     state.currentType = undefined;
   },
@@ -72,7 +76,7 @@ export function extractObjectTypes(
   const state: State = {};
 
   visit(astNode, {
-    enter: visitorEnter(typeInfo, state),
-    leave: visitorLeave(typeInfo, state),
+    enter: visitorEnter(typeInfo.objectTypes, state),
+    leave: visitorLeave(state),
   });
 }

--- a/packages/schema/parse/src/extract/object-types.ts
+++ b/packages/schema/parse/src/extract/object-types.ts
@@ -1,7 +1,7 @@
 import {
   TypeInfo,
   ObjectDefinition,
-  createObjectDefinition
+  createObjectDefinition,
 } from "../typeInfo";
 import {
   extractFieldDefinition,

--- a/packages/schema/parse/src/extract/query-types.ts
+++ b/packages/schema/parse/src/extract/query-types.ts
@@ -1,5 +1,6 @@
 import {
   TypeInfo,
+  QueryDefinition,
   createQueryDefinition,
   createMethodDefinition,
 } from "../typeInfo";
@@ -21,7 +22,7 @@ import {
   visit,
 } from "graphql";
 
-const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
+const visitorEnter = (queryTypes: QueryDefinition[], state: State) => ({
   ObjectTypeDefinition: (node: ObjectTypeDefinitionNode) => {
     const nodeName = node.name.value;
 
@@ -30,7 +31,7 @@ const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
     }
 
     const query = createQueryDefinition(nodeName, nodeName);
-    typeInfo.queryTypes.push(query);
+    queryTypes.push(query);
     state.currentQuery = query;
   },
   FieldDefinition: (node: FieldDefinitionNode) => {
@@ -59,7 +60,7 @@ const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
   },
 });
 
-const visitorLeave = (typeInfo: TypeInfo, state: State) => ({
+const visitorLeave = (state: State) => ({
   ObjectTypeDefinition: (_node: ObjectTypeDefinitionNode) => {
     state.currentQuery = undefined;
   },
@@ -82,7 +83,7 @@ export function extractQueryTypes(
   const state: State = {};
 
   visit(astNode, {
-    enter: visitorEnter(typeInfo, state),
-    leave: visitorLeave(typeInfo, state),
+    enter: visitorEnter(typeInfo.queryTypes, state),
+    leave: visitorLeave(state),
   });
 }

--- a/packages/schema/parse/src/extract/query-types.ts
+++ b/packages/schema/parse/src/extract/query-types.ts
@@ -52,7 +52,7 @@ const visitorEnter = (typeInfo: TypeInfo, state: State) => ({
     state.nonNullType = true;
   },
   NamedType: (node: NamedTypeNode) => {
-    extractNamedType(node, state, typeInfo);
+    extractNamedType(node, state);
   },
   ListType: (_node: ListTypeNode) => {
     extractListType(state);

--- a/packages/schema/parse/src/transform/finalizePropertyDef.ts
+++ b/packages/schema/parse/src/transform/finalizePropertyDef.ts
@@ -25,8 +25,7 @@ function populatePropertyType(property: PropertyDefinition) {
   } else if (property.object) {
     propertyType = property.object;
   } else {
-    // Error case
-    return;
+    throw Error("Property type is undefined, this should never happen.");
   }
 
   property.type = propertyType.type;

--- a/packages/schema/parse/src/transform/finalizePropertyDef.ts
+++ b/packages/schema/parse/src/transform/finalizePropertyDef.ts
@@ -41,7 +41,7 @@ function populateArrayType(array: ArrayDefinition) {
     if (currentArray.array) {
       currentArray = currentArray.array;
       populateArrayType(currentArray);
-    } else if (currentArray.scalar) {
+    } else if (currentArray.scalar || currentArray.object) {
       baseTypeFound = true;
     } else {
       throw Error(
@@ -56,8 +56,10 @@ function populateArrayType(array: ArrayDefinition) {
 
   if (array.array) {
     array.item = array.array;
-  } else {
+  } else if (array.scalar) {
     array.item = array.scalar;
+  } else {
+    array.item = array.object;
   }
 
   if (!array.item) {

--- a/packages/schema/parse/src/typeInfo/definitions.ts
+++ b/packages/schema/parse/src/typeInfo/definitions.ts
@@ -112,7 +112,10 @@ export function createArrayDefinition(
         ? (item as ScalarDefinition)
         : null,
     kind: DefinitionKind.Array,
-    object: null,
+    object:
+      item && isKind(item, DefinitionKind.Object)
+        ? (item as ObjectDefinition)
+        : null,
     item: item ? item : null,
   };
 }

--- a/packages/schema/parse/src/typeInfo/definitions.ts
+++ b/packages/schema/parse/src/typeInfo/definitions.ts
@@ -140,19 +140,17 @@ export function createPropertyDefinition(
   };
 }
 
-export function createObjectPropertyDefinition(
+export function createArrayPropertyDefinition(
   name: string,
   type: string,
   required: boolean,
-  properties: PropertyDefinition[]
+  item: GenericDefinition
 ): PropertyDefinition {
   return createPropertyDefinition(
     name,
     type,
     required,
-    undefined,
-    undefined,
-    createObjectDefinition(name, type, required, properties)
+    createArrayDefinition(name, type, required, item)
   );
 }
 
@@ -170,18 +168,19 @@ export function createScalarPropertyDefinition(
   );
 }
 
-export function createArrayPropertyDefinition(
+export function createObjectPropertyDefinition(
   name: string,
   type: string,
   required: boolean,
-  item: GenericDefinition
+  properties: PropertyDefinition[]
 ): PropertyDefinition {
   return createPropertyDefinition(
     name,
     type,
     required,
-    createArrayDefinition(name, type, required, item),
-    undefined
+    undefined,
+    undefined,
+    createObjectDefinition(name, type, required, properties)
   );
 }
 

--- a/packages/schema/parse/src/typeInfo/index.ts
+++ b/packages/schema/parse/src/typeInfo/index.ts
@@ -7,6 +7,7 @@ import {
 } from "./definitions";
 
 export * from "./definitions";
+export * from "./scalars";
 
 import deepEqual from "deep-equal";
 

--- a/packages/schema/parse/src/typeInfo/scalars.ts
+++ b/packages/schema/parse/src/typeInfo/scalars.ts
@@ -1,17 +1,17 @@
-export const supportedScalars = [
-  "UInt",
-  "UInt8",
-  "UInt16",
-  "UInt32",
-  "UInt64",
-  "Int",
-  "Int8",
-  "Int16",
-  "Int32",
-  "Int64",
-  "String",
-];
+export const SupportedScalars = {
+  UInt: "UInt",
+  UInt8: "UInt8",
+  UInt16: "UInt16",
+  UInt32: "UInt32",
+  UInt64: "UInt64",
+  Int: "Int",
+  Int8: "Int8",
+  Int16: "Int16",
+  Int32: "Int32",
+  Int64: "Int64",
+  String: "String",
+};
 
 export function isScalar(type: string): boolean {
-  return supportedScalars.includes(type);
+  return type in SupportedScalars;
 }

--- a/packages/schema/parse/src/typeInfo/scalars.ts
+++ b/packages/schema/parse/src/typeInfo/scalars.ts
@@ -1,0 +1,17 @@
+export const supportedScalars = [
+  "UInt",
+  "UInt8",
+  "UInt16",
+  "UInt32",
+  "UInt64",
+  "Int",
+  "Int8",
+  "Int16",
+  "Int32",
+  "Int64",
+  "String",
+];
+
+export function isScalar(type: string): boolean {
+  return supportedScalars.includes(type);
+}


### PR DESCRIPTION
Changes: 
 - add support for parsing nested objects
 - add support for objects in arrays 
 - remove typeInfo dependecy from query types parsing
 - defined currently supported scalars
 - matched imported object and user object Schema and extracted code to object-types-utils

TODO:
 - add imported object type property parsing to query and object extraction (@dOrgJelli)
 - Bind and Compose I will do in separate PRs after we finish parse

Issues: 
 - Closes: #106 
