### PR TITLE
Schema bind for objects, nested objects and objects inside arrays

### DIFF
--- a/packages/schema/bind/src/__tests__/cases/sanity/input.graphql
+++ b/packages/schema/bind/src/__tests__/cases/sanity/input.graphql
@@ -62,9 +62,9 @@ type Query @imports(
   ): Int!
 
   objectMethod(
-    object: AnotherType!,
-    optObject: AnotherType,
-    objectArray: [AnotherType!]!,
+    object: AnotherType!
+    optObject: AnotherType
+    objectArray: [AnotherType!]!
     optObjectArray: [AnotherType]
   ): AnotherType
 }

--- a/packages/schema/bind/src/__tests__/cases/sanity/input.graphql
+++ b/packages/schema/bind/src/__tests__/cases/sanity/input.graphql
@@ -60,6 +60,13 @@ type Query @imports(
   queryMethod(
     arg: String!
   ): Int!
+
+  objectMethod(
+    object: AnotherType!,
+    optObject: AnotherType,
+    objectArray: [AnotherType!]!,
+    optObjectArray: [AnotherType]
+  ): AnotherType
 }
 
 type TestImport_Query @imported(

--- a/packages/schema/bind/src/__tests__/cases/sanity/input.graphql
+++ b/packages/schema/bind/src/__tests__/cases/sanity/input.graphql
@@ -85,5 +85,16 @@ type TestImport_Object @imported(
   uri: "testimport.uri.eth",
   type: "Object"
 ) {
+  object: TestImport_AnotherObject!
+  optObject: TestImport_AnotherObject
+  objectArray: [TestImport_AnotherObject!]!
+  optObjectArray: [TestImport_AnotherObject]
+}
+
+type TestImport_AnotherObject @imported(
+  namespace: "TestImport",
+  uri: "testimport.uri.eth",
+  type: "AnotherObject"
+) {
   prop: String!
 }

--- a/packages/schema/bind/src/__tests__/cases/sanity/input.graphql
+++ b/packages/schema/bind/src/__tests__/cases/sanity/input.graphql
@@ -43,6 +43,10 @@ type CustomType {
   uOptArrayOptArray: [[UInt64]]!
   uArrayOptArrayArray: [[[UInt64!]!]]!
   crazyArray: [[[[UInt64!]]!]]
+  object: AnotherType!
+  optObject: AnotherType
+  objectArray: [AnotherType!]!
+  optObjectArray: [AnotherType]
 }
 
 type AnotherType {

--- a/packages/schema/bind/src/__tests__/cases/sanity/input.graphql
+++ b/packages/schema/bind/src/__tests__/cases/sanity/input.graphql
@@ -80,7 +80,11 @@ type TestImport_Query @imported(
     u: UInt!
     optU: UInt
     uArrayArray: [[UInt]]!
-  ): String!
+    object: TestImport_Object!
+    optObject: TestImport_Object
+    objectArray: [TestImport_Object!]!
+    optObjectArray: [TestImport_Object]
+  ): TestImport_Object
 
   anotherMethod(
     arg: [String!]!

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/AnotherType/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/AnotherType/index.ts
@@ -3,7 +3,7 @@ import {
   serializeAnotherType,
   deserializeAnotherType
 } from "./serialization";
-import * as Objects from "../";
+import * as Objects from "..";
 
 export class AnotherType {
   prop: string | null;

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/AnotherType/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/AnotherType/serialization.ts
@@ -10,7 +10,7 @@ import { AnotherType } from "./";
 import * as Objects from "../";
 
 export function serializeAnotherType(type: AnotherType): ArrayBuffer {
-  const objects: ArrayBuffer[] = [
+  const objects: (ArrayBuffer | null)[] = [
     type.circular.toBuffer(),
   ];
   const sizer = new WriteSizer();
@@ -21,13 +21,13 @@ export function serializeAnotherType(type: AnotherType): ArrayBuffer {
   return buffer;
 }
 
-function writeAnotherType(writer: Write, type: AnotherType, objects: ArrayBuffer[]) {
+function writeAnotherType(writer: Write, type: AnotherType, objects: (ArrayBuffer | null)[]) {
   let objectsIdx = 0;
   writer.writeMapLength(2);
   writer.writeString("prop");
   writer.writeNullableString(type.prop);
   writer.writeString("circular");
-  writer.writeBytes(objects[objectsIdx++]);
+  writer.writeNullableBytes(objects[objectsIdx++]);
 }
 
 export function deserializeAnotherType(buffer: ArrayBuffer, type: AnotherType) {

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/AnotherType/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/AnotherType/serialization.ts
@@ -7,7 +7,7 @@ import {
   Nullable
 } from "@web3api/wasm-as";
 import { AnotherType } from "./";
-import * as Objects from "../";
+import * as Objects from "..";
 
 export function serializeAnotherType(type: AnotherType): ArrayBuffer {
   const objects: (ArrayBuffer | null)[] = [

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/AnotherType/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/AnotherType/serialization.ts
@@ -42,8 +42,9 @@ export function deserializeAnotherType(buffer: ArrayBuffer, type: AnotherType) {
       type.prop = reader.readNullableString();
     }
     else if (field == "circular") {
-      type.circular = new Objects.CustomType();
-      type.circular.fromBuffer(reader.readBytes());
+      const object = new Objects.CustomType();
+      object.fromBuffer(reader.readBytes());
+      type.circular = object;
     }
   }
 }

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/AnotherType/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/AnotherType/serialization.ts
@@ -21,7 +21,7 @@ export function serializeAnotherType(type: AnotherType): ArrayBuffer {
   return buffer;
 }
 
-function writeAnotherType(writer: Write, type: AnotherType, objects: (ArrayBuffer | null)[]) {
+function writeAnotherType(writer: Write, type: AnotherType, objects: (ArrayBuffer | null)[]): void {
   let objectsIdx = 0;
   writer.writeMapLength(2);
   writer.writeString("prop");
@@ -30,7 +30,7 @@ function writeAnotherType(writer: Write, type: AnotherType, objects: (ArrayBuffe
   writer.writeNullableBytes(objects[objectsIdx++]);
 }
 
-export function deserializeAnotherType(buffer: ArrayBuffer, type: AnotherType) {
+export function deserializeAnotherType(buffer: ArrayBuffer, type: AnotherType): void {
   const reader = new ReadDecoder(buffer);
   var numFields = reader.readMapLength();
 

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/index.ts
@@ -29,6 +29,10 @@ export class CustomType {
   uOptArrayOptArray: Array<Array<Nullable<u64>> | null>;
   uArrayOptArrayArray: Array<Array<Array<u64>> | null>;
   crazyArray: Array<Array<Array<Array<u64> | null>> | null> | null;
+  object: Objects.AnotherType;
+  optObject: Nullable<Objects.AnotherType>;
+  objectArray: Array<Objects.AnotherType>;
+  optObjectArray: Array<Nullable<Objects.AnotherType>> | null;
 
   toBuffer(): ArrayBuffer {
     return serializeCustomType(this);

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/index.ts
@@ -3,7 +3,7 @@ import {
   serializeCustomType,
   deserializeCustomType
 } from "./serialization";
-import * as Objects from "../";
+import * as Objects from "..";
 
 export class CustomType {
   str: string;

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/index.ts
@@ -30,9 +30,9 @@ export class CustomType {
   uArrayOptArrayArray: Array<Array<Array<u64>> | null>;
   crazyArray: Array<Array<Array<Array<u64> | null>> | null> | null;
   object: Objects.AnotherType;
-  optObject: Nullable<Objects.AnotherType>;
+  optObject: Objects.AnotherType | null;
   objectArray: Array<Objects.AnotherType>;
-  optObjectArray: Array<Nullable<Objects.AnotherType>> | null;
+  optObjectArray: Array<Objects.AnotherType | null> | null;
 
   toBuffer(): ArrayBuffer {
     return serializeCustomType(this);

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/serialization.ts
@@ -7,7 +7,7 @@ import {
   Nullable
 } from "@web3api/wasm-as";
 import { CustomType } from "./";
-import * as Objects from "../";
+import * as Objects from "..";
 
 export function serializeCustomType(type: CustomType): ArrayBuffer {
   const objects: (ArrayBuffer | null)[] = [

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/serialization.ts
@@ -110,7 +110,7 @@ function writeCustomType(writer: Write, type: CustomType, objects: (ArrayBuffer 
     writer.writeBytes(item.toBuffer());
   });
   writer.writeString("optObjectArray");
-  writer.writeNullableArray(type.optObjectArray, (writer: Write, item: Nullable<Objects.AnotherType>): void => {
+  writer.writeNullableArray(type.optObjectArray, (writer: Write, item: Objects.AnotherType | null): void => {
     writer.writeNullableBytes(item ? item.toBuffer() : null);
   });
 }
@@ -229,7 +229,7 @@ export function deserializeCustomType(buffer: ArrayBuffer, type: CustomType): vo
     }
     else if (field == "optObject") {
       var bytes = reader.readNullableBytes();
-      var object: Nullable<Objects.AnotherType>;
+      var object: Objects.AnotherType | null;
       if (bytes) {
         object = new Objects.AnotherType();
         object.fromBuffer(bytes);
@@ -246,9 +246,9 @@ export function deserializeCustomType(buffer: ArrayBuffer, type: CustomType): vo
       });
     }
     else if (field == "optObjectArray") {
-      type.optObjectArray = reader.readNullableArray((reader: Read): Nullable<Objects.AnotherType> => {
+      type.optObjectArray = reader.readNullableArray((reader: Read): Objects.AnotherType | null => {
         var bytes = reader.readNullableBytes();
-        var object: Nullable<Objects.AnotherType>;
+        var object: Objects.AnotherType | null;
         if (bytes) {
           object = new Objects.AnotherType();
           object.fromBuffer(bytes);

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/serialization.ts
@@ -228,13 +228,11 @@ export function deserializeCustomType(buffer: ArrayBuffer, type: CustomType): vo
       type.object = object;
     }
     else if (field == "optObject") {
-      var bytes = reader.readNullableBytes();
-      var object: Objects.AnotherType | null;
+      const bytes = reader.readNullableBytes();
+      var object: Objects.AnotherType | null = null;
       if (bytes) {
         object = new Objects.AnotherType();
         object.fromBuffer(bytes);
-      } else {
-        object = null;
       }
       type.optObject = object;
     }
@@ -247,13 +245,11 @@ export function deserializeCustomType(buffer: ArrayBuffer, type: CustomType): vo
     }
     else if (field == "optObjectArray") {
       type.optObjectArray = reader.readNullableArray((reader: Read): Objects.AnotherType | null => {
-        var bytes = reader.readNullableBytes();
-        var object: Objects.AnotherType | null;
+        const bytes = reader.readNullableBytes();
+        var object: Objects.AnotherType | null = null;
         if (bytes) {
           object = new Objects.AnotherType();
           object.fromBuffer(bytes);
-        } else {
-          object = null;
         }
         return object;
       });

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/CustomType/serialization.ts
@@ -11,7 +11,8 @@ import * as Objects from "../";
 
 export function serializeCustomType(type: CustomType): ArrayBuffer {
   const objects: (ArrayBuffer | null)[] = [
-    type.object.toBuffer(),type.optObject?.toBuffer(),
+    type.object.toBuffer(),
+    type.optObject ? type.optObject.toBuffer() : null,
   ];
   const sizer = new WriteSizer();
   writeCustomType(sizer, type, objects);
@@ -21,7 +22,7 @@ export function serializeCustomType(type: CustomType): ArrayBuffer {
   return buffer;
 }
 
-function writeCustomType(writer: Write, type: CustomType, objects: (ArrayBuffer | null)[]) {
+function writeCustomType(writer: Write, type: CustomType, objects: (ArrayBuffer | null)[]): void {
   let objectsIdx = 0;
   writer.writeMapLength(27);
   writer.writeString("str");
@@ -114,7 +115,7 @@ function writeCustomType(writer: Write, type: CustomType, objects: (ArrayBuffer 
   });
 }
 
-export function deserializeCustomType(buffer: ArrayBuffer, type: CustomType) {
+export function deserializeCustomType(buffer: ArrayBuffer, type: CustomType): void {
   const reader = new ReadDecoder(buffer);
   var numFields = reader.readMapLength();
 

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/Query/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/Query/index.ts
@@ -1,7 +1,9 @@
 import {
-  Input_queryMethod
+  Input_queryMethod,
+  Input_objectMethod
 } from "./serialization";
 
 export {
-  Input_queryMethod
+  Input_queryMethod,
+  Input_objectMethod
 };

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/Query/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/Query/serialization.ts
@@ -50,6 +50,7 @@ export function serializequeryMethodResult(result: i32): ArrayBuffer {
 function writequeryMethodResult(writer: Write, result: i32): void {
   writer.writeInt32(result);
 }
+
 export class Input_objectMethod {
   object: Objects.AnotherType;
   optObject: Objects.AnotherType | null;
@@ -63,21 +64,29 @@ export function deserializeobjectMethodArgs(argsBuf: ArrayBuffer): Input_objectM
 
   var _object: Objects.AnotherType = new Objects.AnotherType();
   var _objectSet: boolean = false;
-  var _optObject: Objects.AnotherType | null = new Objects.AnotherType();
+  var _optObject: Objects.AnotherType | null = null;
   var _objectArray: Array<Objects.AnotherType> = [];
   var _objectArraySet: boolean = false;
-  var _optObjectArray: Array<Objects.AnotherType | null> | null = [];
+  var _optObjectArray: Array<Objects.AnotherType | null> | null = null;
 
   while (numFields > 0) {
     numFields--;
     const field = reader.readString();
 
     if (field == "object") {
-      _object.fromBuffer(reader.readBytes());
+      const object = new Objects.AnotherType();
+      object.fromBuffer(reader.readBytes());
+      _object = object;
       _objectSet = true;
     }
     else if (field == "optObject") {
-      _optObject.fromBuffer(reader.readBytes());
+      const bytes = reader.readNullableBytes();
+      var object: Objects.AnotherType | null = null;
+      if (bytes) {
+        object = new Objects.AnotherType();
+        object.fromBuffer(bytes);
+      }
+      _optObject = object;
     }
     else if (field == "objectArray") {
       _objectArray = reader.readArray((reader: Read): Objects.AnotherType => {
@@ -89,13 +98,11 @@ export function deserializeobjectMethodArgs(argsBuf: ArrayBuffer): Input_objectM
     }
     else if (field == "optObjectArray") {
       _optObjectArray = reader.readNullableArray((reader: Read): Objects.AnotherType | null => {
-        var bytes = reader.readNullableBytes();
-        var object: Objects.AnotherType | null;
+        const bytes = reader.readNullableBytes();
+        var object: Objects.AnotherType | null = null;
         if (bytes) {
           object = new Objects.AnotherType();
           object.fromBuffer(bytes);
-        } else {
-          object = null;
         }
         return object;
       });

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/Query/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/Query/serialization.ts
@@ -6,7 +6,7 @@ import {
   WriteEncoder,
   Write
 } from "@web3api/wasm-as";
-import * as Objects from "../";
+import * as Objects from "..";
 
 export class Input_queryMethod {
   arg: string;

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/Query/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/Query/serialization.ts
@@ -1,3 +1,4 @@
+import { Nullable } from "@web3api/wasm-as";
 import {
   Read,
   ReadDecoder,
@@ -5,6 +6,7 @@ import {
   WriteEncoder,
   Write
 } from "@web3api/wasm-as";
+import * as Objects from "../";
 
 export class Input_queryMethod {
   arg: string;
@@ -28,7 +30,7 @@ export function deserializequeryMethodArgs(argsBuf: ArrayBuffer): Input_queryMet
   }
 
   if (!_argSet) {
-    throw Error("Missing required argument \"arg: String\"");
+    throw Error("Missing required argument 'arg: String'");
   }
 
   return {
@@ -47,4 +49,83 @@ export function serializequeryMethodResult(result: i32): ArrayBuffer {
 
 function writequeryMethodResult(writer: Write, result: i32): void {
   writer.writeInt32(result);
+}
+export class Input_objectMethod {
+  object: Objects.AnotherType;
+  optObject: Objects.AnotherType | null;
+  objectArray: Array<Objects.AnotherType>;
+  optObjectArray: Array<Objects.AnotherType | null> | null;
+}
+
+export function deserializeobjectMethodArgs(argsBuf: ArrayBuffer): Input_objectMethod {
+  const reader = new ReadDecoder(argsBuf);
+  var numFields = reader.readMapLength();
+
+  var _object: Objects.AnotherType = new Objects.AnotherType();
+  var _objectSet: boolean = false;
+  var _optObject: Objects.AnotherType | null = new Objects.AnotherType();
+  var _objectArray: Array<Objects.AnotherType> = [];
+  var _objectArraySet: boolean = false;
+  var _optObjectArray: Array<Objects.AnotherType | null> | null = [];
+
+  while (numFields > 0) {
+    numFields--;
+    const field = reader.readString();
+
+    if (field == "object") {
+      _object.fromBuffer(reader.readBytes());
+      _objectSet = true;
+    }
+    else if (field == "optObject") {
+      _optObject.fromBuffer(reader.readBytes());
+    }
+    else if (field == "objectArray") {
+      _objectArray = reader.readArray((reader: Read): Objects.AnotherType => {
+        const object = new Objects.AnotherType();
+        object.fromBuffer(reader.readBytes());
+        return object;
+      });
+      _objectArraySet = true;
+    }
+    else if (field == "optObjectArray") {
+      _optObjectArray = reader.readNullableArray((reader: Read): Objects.AnotherType | null => {
+        var bytes = reader.readNullableBytes();
+        var object: Objects.AnotherType | null;
+        if (bytes) {
+          object = new Objects.AnotherType();
+          object.fromBuffer(bytes);
+        } else {
+          object = null;
+        }
+        return object;
+      });
+    }
+  }
+
+  if (!_objectSet) {
+    throw Error("Missing required argument 'object: AnotherType'");
+  }
+  if (!_objectArraySet) {
+    throw Error("Missing required argument 'objectArray: [AnotherType]'");
+  }
+
+  return {
+    object: _object,
+    optObject: _optObject,
+    objectArray: _objectArray,
+    optObjectArray: _optObjectArray
+  };
+}
+
+export function serializeobjectMethodResult(result: Objects.AnotherType | null): ArrayBuffer {
+  const sizer = new WriteSizer();
+  writeobjectMethodResult(sizer, result);
+  const buffer = new ArrayBuffer(sizer.length);
+  const encoder = new WriteEncoder(buffer);
+  writeobjectMethodResult(encoder, result);
+  return buffer;
+}
+
+function writeobjectMethodResult(writer: Write, result: Objects.AnotherType | null): void {
+  writer.writeNullableBytes(result ? result.toBuffer() : null);
 }

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/Query/wrapped.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/Query/wrapped.ts
@@ -1,9 +1,12 @@
 import {
-  queryMethod
+  queryMethod,
+  objectMethod
 } from "../../index";
 import {
   deserializequeryMethodArgs,
-  serializequeryMethodResult
+  serializequeryMethodResult,
+  deserializeobjectMethodArgs,
+  serializeobjectMethodResult
 } from "./serialization";
 
 export function queryMethodWrapped(argsBuf: ArrayBuffer): ArrayBuffer {
@@ -12,4 +15,15 @@ export function queryMethodWrapped(argsBuf: ArrayBuffer): ArrayBuffer {
     arg: args.arg
   });
   return serializequeryMethodResult(result);
+}
+
+export function objectMethodWrapped(argsBuf: ArrayBuffer): ArrayBuffer {
+  const args = deserializeobjectMethodArgs(argsBuf);
+  const result = objectMethod({
+    object: args.object,
+    optObject: args.optObject,
+    objectArray: args.objectArray,
+    optObjectArray: args.optObjectArray
+  });
+  return serializeobjectMethodResult(result);
 }

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/entry.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/entry.ts
@@ -3,11 +3,13 @@ import {
   w3_invoke
 } from "@web3api/wasm-as";
 import {
-  queryMethodWrapped
+  queryMethodWrapped,
+  objectMethodWrapped
 } from "./Query/wrapped";
 
 export function _w3_init(): void {
   w3_add_invoke("queryMethod", queryMethodWrapped);
+  w3_add_invoke("objectMethod", objectMethodWrapped);
 }
 
 export function _w3_invoke(method_size: u32, args_size: u32): bool {

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_AnotherObject/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_AnotherObject/index.ts
@@ -1,0 +1,21 @@
+import { Nullable } from "@web3api/wasm-as";
+import {
+  serializeTestImport_AnotherObject,
+  deserializeTestImport_AnotherObject
+} from "./serialization";
+import * as Objects from "../../";
+
+export class TestImport_AnotherObject {
+
+  public static uri: string = "testimport.uri.eth";
+
+  prop: string;
+
+  toBuffer(): ArrayBuffer {
+    return serializeTestImport_AnotherObject(this);
+  }
+
+  fromBuffer(buffer: ArrayBuffer): void {
+    deserializeTestImport_AnotherObject(buffer, this);
+  }
+}

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_AnotherObject/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_AnotherObject/index.ts
@@ -3,7 +3,7 @@ import {
   serializeTestImport_AnotherObject,
   deserializeTestImport_AnotherObject
 } from "./serialization";
-import * as Objects from "../../";
+import * as Objects from "../..";
 
 export class TestImport_AnotherObject {
 

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_AnotherObject/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_AnotherObject/serialization.ts
@@ -13,10 +13,10 @@ export function serializeTestImport_AnotherObject(type: TestImport_AnotherObject
   const objects: (ArrayBuffer | null)[] = [
   ];
   const sizer = new WriteSizer();
-  writeTestImport_AnotherObject(sizer, type);
+  writeTestImport_AnotherObject(sizer, type, objects);
   const buffer = new ArrayBuffer(sizer.length);
   const encoder = new WriteEncoder(buffer);
-  writeTestImport_AnotherObject(encoder, type);
+  writeTestImport_AnotherObject(encoder, type, objects);
   return buffer;
 }
 

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_AnotherObject/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_AnotherObject/serialization.ts
@@ -7,7 +7,7 @@ import {
   Nullable
 } from "@web3api/wasm-as";
 import { TestImport_AnotherObject } from "./";
-import * as Objects from "../../";
+import * as Objects from "../..";
 
 export function serializeTestImport_AnotherObject(type: TestImport_AnotherObject): ArrayBuffer {
   const objects: (ArrayBuffer | null)[] = [

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_AnotherObject/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_AnotherObject/serialization.ts
@@ -1,0 +1,42 @@
+import {
+  Read,
+  ReadDecoder,
+  Write,
+  WriteSizer,
+  WriteEncoder,
+  Nullable
+} from "@web3api/wasm-as";
+import { TestImport_AnotherObject } from "./";
+import * as Objects from "../../";
+
+export function serializeTestImport_AnotherObject(type: TestImport_AnotherObject): ArrayBuffer {
+  const objects: (ArrayBuffer | null)[] = [
+  ];
+  const sizer = new WriteSizer();
+  writeTestImport_AnotherObject(sizer, type);
+  const buffer = new ArrayBuffer(sizer.length);
+  const encoder = new WriteEncoder(buffer);
+  writeTestImport_AnotherObject(encoder, type);
+  return buffer;
+}
+
+function writeTestImport_AnotherObject(writer: Write, type: TestImport_AnotherObject, objects: (ArrayBuffer | null)[]): void {
+  let objectsIdx = 0;
+  writer.writeMapLength(1);
+  writer.writeString("prop");
+  writer.writeString(type.prop);
+}
+
+export function deserializeTestImport_AnotherObject(buffer: ArrayBuffer, type: TestImport_AnotherObject): void {
+  const reader = new ReadDecoder(buffer);
+  var numFields = reader.readMapLength();
+
+  while (numFields > 0) {
+    numFields--;
+    const field = reader.readString();
+
+    if (field == "prop") {
+      type.prop = reader.readString();
+    }
+  }
+}

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/index.ts
@@ -10,9 +10,9 @@ export class TestImport_Object {
   public static uri: string = "testimport.uri.eth";
 
   object: Objects.TestImport_AnotherObject;
-  optObject: Nullable<Objects.TestImport_AnotherObject>;
+  optObject: Objects.TestImport_AnotherObject | null;
   objectArray: Array<Objects.TestImport_AnotherObject>;
-  optObjectArray: Array<Nullable<Objects.TestImport_AnotherObject>> | null;
+  optObjectArray: Array<Objects.TestImport_AnotherObject | null> | null;
 
   toBuffer(): ArrayBuffer {
     return serializeTestImport_Object(this);

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/index.ts
@@ -3,7 +3,7 @@ import {
   serializeTestImport_Object,
   deserializeTestImport_Object
 } from "./serialization";
-import * as Objects from "../../";
+import * as Objects from "../..";
 
 export class TestImport_Object {
 

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/index.ts
@@ -3,12 +3,16 @@ import {
   serializeTestImport_Object,
   deserializeTestImport_Object
 } from "./serialization";
+import * as Objects from "../../";
 
 export class TestImport_Object {
 
   public static uri: string = "testimport.uri.eth";
 
-  prop: string;
+  object: Objects.TestImport_AnotherObject;
+  optObject: Nullable<Objects.TestImport_AnotherObject>;
+  objectArray: Array<Objects.TestImport_AnotherObject>;
+  optObjectArray: Array<Nullable<Objects.TestImport_AnotherObject>> | null;
 
   toBuffer(): ArrayBuffer {
     return serializeTestImport_Object(this);

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
@@ -15,10 +15,10 @@ export function serializeTestImport_Object(type: TestImport_Object): ArrayBuffer
     type.optObject ? type.optObject.toBuffer() : null,
   ];
   const sizer = new WriteSizer();
-  writeTestImport_Object(sizer, type);
+  writeTestImport_Object(sizer, type, objects);
   const buffer = new ArrayBuffer(sizer.length);
   const encoder = new WriteEncoder(buffer);
-  writeTestImport_Object(encoder, type);
+  writeTestImport_Object(encoder, type, objects);
   return buffer;
 }
 
@@ -53,13 +53,11 @@ export function deserializeTestImport_Object(buffer: ArrayBuffer, type: TestImpo
       type.object = object;
     }
     else if (field == "optObject") {
-      var bytes = reader.readNullableBytes();
-      var object: Objects.TestImport_AnotherObject | null;
+      const bytes = reader.readNullableBytes();
+      var object: Objects.TestImport_AnotherObject | null = null;
       if (bytes) {
         object = new Objects.TestImport_AnotherObject();
         object.fromBuffer(bytes);
-      } else {
-        object = null;
       }
       type.optObject = object;
     }
@@ -72,13 +70,11 @@ export function deserializeTestImport_Object(buffer: ArrayBuffer, type: TestImpo
     }
     else if (field == "optObjectArray") {
       type.optObjectArray = reader.readNullableArray((reader: Read): Objects.TestImport_AnotherObject | null => {
-        var bytes = reader.readNullableBytes();
-        var object: Objects.TestImport_AnotherObject | null;
+        const bytes = reader.readNullableBytes();
+        var object: Objects.TestImport_AnotherObject | null = null;
         if (bytes) {
           object = new Objects.TestImport_AnotherObject();
           object.fromBuffer(bytes);
-        } else {
-          object = null;
         }
         return object;
       });

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
@@ -17,13 +17,13 @@ export function serializeTestImport_Object(type: TestImport_Object): ArrayBuffer
   return buffer;
 }
 
-function writeTestImport_Object(writer: Write, type: TestImport_Object) {
+function writeTestImport_Object(writer: Write, type: TestImport_Object): void {
   writer.writeMapLength(1);
   writer.writeString("prop");
   writer.writeString(type.prop);
 }
 
-export function deserializeTestImport_Object(buffer: ArrayBuffer, type: TestImport_Object) {
+export function deserializeTestImport_Object(buffer: ArrayBuffer, type: TestImport_Object): void {
   const reader = new ReadDecoder(buffer);
   var numFields = reader.readMapLength();
 

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
@@ -7,8 +7,13 @@ import {
   Nullable
 } from "@web3api/wasm-as";
 import { TestImport_Object } from "./";
+import * as Objects from "../../";
 
 export function serializeTestImport_Object(type: TestImport_Object): ArrayBuffer {
+  const objects: (ArrayBuffer | null)[] = [
+    type.object.toBuffer(),
+    type.optObject ? type.optObject.toBuffer() : null,
+  ];
   const sizer = new WriteSizer();
   writeTestImport_Object(sizer, type);
   const buffer = new ArrayBuffer(sizer.length);
@@ -17,10 +22,21 @@ export function serializeTestImport_Object(type: TestImport_Object): ArrayBuffer
   return buffer;
 }
 
-function writeTestImport_Object(writer: Write, type: TestImport_Object): void {
-  writer.writeMapLength(1);
-  writer.writeString("prop");
-  writer.writeString(type.prop);
+function writeTestImport_Object(writer: Write, type: TestImport_Object, objects: (ArrayBuffer | null)[]): void {
+  let objectsIdx = 0;
+  writer.writeMapLength(4);
+  writer.writeString("object");
+  writer.writeNullableBytes(objects[objectsIdx++]);
+  writer.writeString("optObject");
+  writer.writeNullableBytes(objects[objectsIdx++]);
+  writer.writeString("objectArray");
+  writer.writeArray(type.objectArray, (writer: Write, item: Objects.TestImport_AnotherObject): void => {
+    writer.writeBytes(item.toBuffer());
+  });
+  writer.writeString("optObjectArray");
+  writer.writeNullableArray(type.optObjectArray, (writer: Write, item: Nullable<Objects.TestImport_AnotherObject>): void => {
+    writer.writeNullableBytes(item ? item.toBuffer() : null);
+  });
 }
 
 export function deserializeTestImport_Object(buffer: ArrayBuffer, type: TestImport_Object): void {
@@ -31,8 +47,41 @@ export function deserializeTestImport_Object(buffer: ArrayBuffer, type: TestImpo
     numFields--;
     const field = reader.readString();
 
-    if (field == "prop") {
-      type.prop = reader.readString();
+    if (field == "object") {
+      const object = new Objects.TestImport_AnotherObject();
+      object.fromBuffer(reader.readBytes());
+      type.object = object;
+    }
+    else if (field == "optObject") {
+      var bytes = reader.readNullableBytes();
+      var object: Nullable<Objects.TestImport_AnotherObject>;
+      if (bytes) {
+        object = new Objects.TestImport_AnotherObject();
+        object.fromBuffer(bytes);
+      } else {
+        object = null;
+      }
+      type.optObject = object;
+    }
+    else if (field == "objectArray") {
+      type.objectArray = reader.readArray((reader: Read): Objects.TestImport_AnotherObject => {
+        const object = new Objects.TestImport_AnotherObject();
+        object.fromBuffer(reader.readBytes());
+        return object;
+      });
+    }
+    else if (field == "optObjectArray") {
+      type.optObjectArray = reader.readNullableArray((reader: Read): Nullable<Objects.TestImport_AnotherObject> => {
+        var bytes = reader.readNullableBytes();
+        var object: Nullable<Objects.TestImport_AnotherObject>;
+        if (bytes) {
+          object = new Objects.TestImport_AnotherObject();
+          object.fromBuffer(bytes);
+        } else {
+          object = null;
+        }
+        return object;
+      });
     }
   }
 }

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
@@ -7,7 +7,7 @@ import {
   Nullable
 } from "@web3api/wasm-as";
 import { TestImport_Object } from "./";
-import * as Objects from "../../";
+import * as Objects from "../..";
 
 export function serializeTestImport_Object(type: TestImport_Object): ArrayBuffer {
   const objects: (ArrayBuffer | null)[] = [

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
@@ -34,7 +34,7 @@ function writeTestImport_Object(writer: Write, type: TestImport_Object, objects:
     writer.writeBytes(item.toBuffer());
   });
   writer.writeString("optObjectArray");
-  writer.writeNullableArray(type.optObjectArray, (writer: Write, item: Nullable<Objects.TestImport_AnotherObject>): void => {
+  writer.writeNullableArray(type.optObjectArray, (writer: Write, item: Objects.TestImport_AnotherObject | null): void => {
     writer.writeNullableBytes(item ? item.toBuffer() : null);
   });
 }
@@ -54,7 +54,7 @@ export function deserializeTestImport_Object(buffer: ArrayBuffer, type: TestImpo
     }
     else if (field == "optObject") {
       var bytes = reader.readNullableBytes();
-      var object: Nullable<Objects.TestImport_AnotherObject>;
+      var object: Objects.TestImport_AnotherObject | null;
       if (bytes) {
         object = new Objects.TestImport_AnotherObject();
         object.fromBuffer(bytes);
@@ -71,9 +71,9 @@ export function deserializeTestImport_Object(buffer: ArrayBuffer, type: TestImpo
       });
     }
     else if (field == "optObjectArray") {
-      type.optObjectArray = reader.readNullableArray((reader: Read): Nullable<Objects.TestImport_AnotherObject> => {
+      type.optObjectArray = reader.readNullableArray((reader: Read): Objects.TestImport_AnotherObject | null => {
         var bytes = reader.readNullableBytes();
-        var object: Nullable<Objects.TestImport_AnotherObject>;
+        var object: Objects.TestImport_AnotherObject | null;
         if (bytes) {
           object = new Objects.TestImport_AnotherObject();
           object.fromBuffer(bytes);

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Query/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Query/index.ts
@@ -10,7 +10,7 @@ import {
   deserializeanotherMethodResult,
   Input_anotherMethod
 } from "./serialization";
-import * as Objects from "../../";
+import * as Objects from "../..";
 
 export class TestImport_Query {
 

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Query/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Query/index.ts
@@ -10,12 +10,13 @@ import {
   deserializeanotherMethodResult,
   Input_anotherMethod
 } from "./serialization";
+import * as Objects from "../../";
 
 export class TestImport_Query {
 
   public static uri: string = "testimport.uri.eth";
 
-  public static importedMethod(input: Input_importedMethod): string {
+  public static importedMethod(input: Input_importedMethod): Objects.TestImport_Object | null {
     const args = serializeimportedMethodArgs(input);
     const result = w3_subinvoke(
       "testimport.uri.eth",

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Query/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Query/serialization.ts
@@ -69,13 +69,11 @@ function writeimportedMethodArgs(
 
 export function deserializeimportedMethodResult(buffer: ArrayBuffer): Objects.TestImport_Object | null {
   const reader = new ReadDecoder(buffer);
-  var bytes = reader.readNullableBytes();
-  var object: Objects.TestImport_Object | null;
+  const bytes = reader.readNullableBytes();
+  var object: Objects.TestImport_Object | null = null;
   if (bytes) {
     object = new Objects.TestImport_Object();
     object.fromBuffer(bytes);
-  } else {
-    object = null;
   }
 
   return object;

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Query/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Query/serialization.ts
@@ -5,6 +5,7 @@ import {
   WriteEncoder,
   ReadDecoder
 } from "@web3api/wasm-as";
+import * as Objects from "../../";
 
 export class Input_importedMethod {
   str: string;
@@ -12,22 +13,32 @@ export class Input_importedMethod {
   u: u32;
   optU: Nullable<u32>;
   uArrayArray: Array<Array<Nullable<u32>> | null>;
+  object: Objects.TestImport_Object;
+  optObject: Objects.TestImport_Object | null;
+  objectArray: Array<Objects.TestImport_Object>;
+  optObjectArray: Array<Objects.TestImport_Object | null> | null;
 }
 
 export function serializeimportedMethodArgs(input: Input_importedMethod): ArrayBuffer {
+  const objects: (ArrayBuffer | null)[] = [
+    input.object.toBuffer(),
+    input.optObject ? input.optObject.toBuffer() : null,
+  ];
   const sizer = new WriteSizer();
-  writeimportedMethodArgs(sizer, input);
+  writeimportedMethodArgs(sizer, input, objects);
   const buffer = new ArrayBuffer(sizer.length);
   const encoder = new WriteEncoder(buffer);
-  writeimportedMethodArgs(encoder, input);
+  writeimportedMethodArgs(encoder, input, objects);
   return buffer;
 }
 
 function writeimportedMethodArgs(
   writer: Write,
-  input: Input_importedMethod
+  input: Input_importedMethod,
+  objects: (ArrayBuffer | null)[]
 ): void {
-  writer.writeMapLength(5);
+  let objectsIdx = 0;
+  writer.writeMapLength(9);
   writer.writeString("str");
   writer.writeString(input.str);
   writer.writeString("optStr");
@@ -42,11 +53,32 @@ function writeimportedMethodArgs(
       writer.writeNullableUInt32(item);
     });
   });
+  writer.writeString("object");
+  writer.writeNullableBytes(objects[objectsIdx++]);
+  writer.writeString("optObject");
+  writer.writeNullableBytes(objects[objectsIdx++]);
+  writer.writeString("objectArray");
+  writer.writeArray(input.objectArray, (writer: Write, item: Objects.TestImport_Object): void => {
+    writer.writeBytes(item.toBuffer());
+  });
+  writer.writeString("optObjectArray");
+  writer.writeNullableArray(input.optObjectArray, (writer: Write, item: Objects.TestImport_Object | null): void => {
+    writer.writeNullableBytes(item ? item.toBuffer() : null);
+  });
 }
 
-export function deserializeimportedMethodResult(buffer: ArrayBuffer): string {
+export function deserializeimportedMethodResult(buffer: ArrayBuffer): Objects.TestImport_Object | null {
   const reader = new ReadDecoder(buffer);
-  return reader.readString();
+  var bytes = reader.readNullableBytes();
+  var object: Objects.TestImport_Object | null;
+  if (bytes) {
+    object = new Objects.TestImport_Object();
+    object.fromBuffer(bytes);
+  } else {
+    object = null;
+  }
+
+  return object;
 }
 
 export class Input_anotherMethod {
@@ -54,18 +86,22 @@ export class Input_anotherMethod {
 }
 
 export function serializeanotherMethodArgs(input: Input_anotherMethod): ArrayBuffer {
+  const objects: (ArrayBuffer | null)[] = [
+  ];
   const sizer = new WriteSizer();
-  writeanotherMethodArgs(sizer, input);
+  writeanotherMethodArgs(sizer, input, objects);
   const buffer = new ArrayBuffer(sizer.length);
   const encoder = new WriteEncoder(buffer);
-  writeanotherMethodArgs(encoder, input);
+  writeanotherMethodArgs(encoder, input, objects);
   return buffer;
 }
 
 function writeanotherMethodArgs(
   writer: Write,
-  input: Input_anotherMethod
+  input: Input_anotherMethod,
+  objects: (ArrayBuffer | null)[]
 ): void {
+  let objectsIdx = 0;
   writer.writeMapLength(1);
   writer.writeString("arg");
   writer.writeArray(input.arg, (writer: Write, item: string): void => {

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Query/serialization.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/TestImport_Query/serialization.ts
@@ -5,7 +5,7 @@ import {
   WriteEncoder,
   ReadDecoder
 } from "@web3api/wasm-as";
-import * as Objects from "../../";
+import * as Objects from "../..";
 
 export class Input_importedMethod {
   str: string;

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/imported/index.ts
@@ -1,2 +1,3 @@
 export * from "./TestImport_Query";
 export * from "./TestImport_Object";
+export * from "./TestImport_AnotherObject";

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/index.ts
@@ -1,9 +1,11 @@
 import {
-  Input_queryMethod
+  Input_queryMethod,
+  Input_objectMethod
 } from "./Query";
 
 export {
-  Input_queryMethod
+  Input_queryMethod,
+  Input_objectMethod
 };
 
 export * from "./CustomType";

--- a/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/index.ts
+++ b/packages/schema/bind/src/__tests__/cases/sanity/output/wasm-as/index.ts
@@ -11,3 +11,4 @@ export * from "./AnotherType";
 
 export * from "./imported/TestImport_Query";
 export * from "./imported/TestImport_Object";
+export * from "./imported/TestImport_AnotherObject";

--- a/packages/schema/bind/src/bindings/wasm-as/functions.ts
+++ b/packages/schema/bind/src/bindings/wasm-as/functions.ts
@@ -41,8 +41,10 @@ export const toWasmInit: MustacheFunction = () => {
     } else {
       const nullType = toWasm()(value, render);
       const nullable = "Nullable";
+      const nullOptional = "| null";
 
-      if (nullType.substr(0, nullable.length) === nullable) {
+      if (nullType.substr(0, nullable.length) === nullable ||
+          nullType.substr(-nullOptional.length) === nullOptional) {
         return "null";
       }
     }

--- a/packages/schema/bind/src/bindings/wasm-as/functions.ts
+++ b/packages/schema/bind/src/bindings/wasm-as/functions.ts
@@ -1,3 +1,5 @@
+import { isMsgPackType } from "./types";
+
 type MustacheFunction = () => (
   value: string,
   render: (template: string) => string
@@ -41,8 +43,6 @@ export const toWasmInit: MustacheFunction = () => {
       const nullable = "Nullable";
 
       if (nullType.substr(0, nullable.length) === nullable) {
-        return `new Objects.${type}()`;
-      } else {
         return "null";
       }
     }
@@ -132,7 +132,11 @@ const toWasmArray = (type: string, nullable: boolean): string => {
 
 const applyNullable = (type: string, nullable: boolean): string => {
   if (nullable) {
-    if (type.indexOf("Array") === 0 || type.indexOf("string") === 0) {
+    if (
+      type.indexOf("Array") === 0 ||
+      type.indexOf("string") === 0 ||
+      !isMsgPackType(type)
+    ) {
       return `${type} | null`;
     } else {
       return `Nullable<${type}>`;

--- a/packages/schema/bind/src/bindings/wasm-as/functions.ts
+++ b/packages/schema/bind/src/bindings/wasm-as/functions.ts
@@ -41,7 +41,7 @@ export const toWasmInit: MustacheFunction = () => {
       const nullable = "Nullable";
 
       if (nullType.substr(0, nullable.length) === nullable) {
-        return `new ${nullType}()`;
+        return `new Objects.${type}()`;
       } else {
         return "null";
       }
@@ -68,7 +68,7 @@ export const toWasmInit: MustacheFunction = () => {
       case "Boolean":
         return "false";
       default:
-        return `new ${type}()`;
+        return `new Objects.${type}()`;
     }
   };
 };
@@ -114,7 +114,7 @@ export const toWasm: MustacheFunction = () => {
       case "Boolean":
         return applyNullable("bool", nullable);
       default:
-        return applyNullable(type, nullable);
+        return applyNullable("Objects." + type, nullable);
     }
   };
 };

--- a/packages/schema/bind/src/bindings/wasm-as/functions.ts
+++ b/packages/schema/bind/src/bindings/wasm-as/functions.ts
@@ -43,8 +43,10 @@ export const toWasmInit: MustacheFunction = () => {
       const nullable = "Nullable";
       const nullOptional = "| null";
 
-      if (nullType.substr(0, nullable.length) === nullable ||
-          nullType.substr(-nullOptional.length) === nullOptional) {
+      if (
+        nullType.substr(0, nullable.length) === nullable ||
+        nullType.substr(-nullOptional.length) === nullOptional
+      ) {
         return "null";
       }
     }

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/deserialize_array.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/deserialize_array.mustache
@@ -6,3 +6,7 @@ return reader.read{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}((reader: Read): 
   {{> deserialize_array}}
 });
 {{/array}}
+{{#object}}
+{{> deserialize_object}}
+return object;
+{{/object}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/deserialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/deserialize_object.mustache
@@ -1,0 +1,14 @@
+{{#required}}
+const object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+object.fromBuffer(reader.readBytes());
+{{/required}}
+{{^required}}
+var bytes = reader.readNullableBytes();
+var object: {{#toWasm}}{{type}}{{/toWasm}};
+if (bytes) {
+  object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+  object.fromBuffer(bytes);
+} else {
+  object = null;
+}
+{{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/deserialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/deserialize_object.mustache
@@ -1,14 +1,12 @@
 {{#required}}
-const object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+const object = {{#toWasmInit}}{{toGraphQLType}}{{/toWasmInit}};
 object.fromBuffer(reader.readBytes());
 {{/required}}
 {{^required}}
-var bytes = reader.readNullableBytes();
-var object: {{#toWasm}}{{type}}{{/toWasm}};
+const bytes = reader.readNullableBytes();
+var object: {{#toWasm}}{{toGraphQLType}}{{/toWasm}} = null;
 if (bytes) {
-  object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+  object = new Objects.{{type}}();
   object.fromBuffer(bytes);
-} else {
-  object = null;
 }
 {{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/index-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/index-ts.mustache
@@ -3,6 +3,7 @@ import {
   serialize{{type}},
   deserialize{{type}}
 } from "./serialization";
+import * as Objects from "../../";
 
 export class {{type}} {
 
@@ -15,6 +16,9 @@ export class {{type}} {
   {{#array}}
   {{name}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}};
   {{/array}}
+  {{#object}}
+  {{name}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}};
+  {{/object}}
   {{/properties}}
 
   toBuffer(): ArrayBuffer {

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/index-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/index-ts.mustache
@@ -3,7 +3,7 @@ import {
   serialize{{type}},
   deserialize{{type}}
 } from "./serialization";
-import * as Objects from "../../";
+import * as Objects from "../..";
 
 export class {{type}} {
 

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialization-ts.mustache
@@ -17,7 +17,7 @@ export function serialize{{type}}(type: {{type}}): ArrayBuffer {
   return buffer;
 }
 
-function write{{type}}(writer: Write, type: {{type}}) {
+function write{{type}}(writer: Write, type: {{type}}): void {
   writer.writeMapLength({{properties.length}});
   {{#properties}}
   writer.writeString("{{name}}");
@@ -32,7 +32,7 @@ function write{{type}}(writer: Write, type: {{type}}) {
   {{/properties}}
 }
 
-export function deserialize{{type}}(buffer: ArrayBuffer, type: {{type}}) {
+export function deserialize{{type}}(buffer: ArrayBuffer, type: {{type}}): void {
   const reader = new ReadDecoder(buffer);
   var numFields = reader.readMapLength();
 

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialization-ts.mustache
@@ -7,7 +7,7 @@ import {
   Nullable
 } from "@web3api/wasm-as";
 import { {{type}} } from "./";
-import * as Objects from "../../";
+import * as Objects from "../..";
 
 export function serialize{{type}}(type: {{type}}): ArrayBuffer {
   const objects: (ArrayBuffer | null)[] = [

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialization-ts.mustache
@@ -21,10 +21,10 @@ export function serialize{{type}}(type: {{type}}): ArrayBuffer {
     {{/object}}{{/properties}}
   ];
   const sizer = new WriteSizer();
-  write{{type}}(sizer, type);
+  write{{type}}(sizer, type, objects);
   const buffer = new ArrayBuffer(sizer.length);
   const encoder = new WriteEncoder(buffer);
-  write{{type}}(encoder, type);
+  write{{type}}(encoder, type, objects);
   return buffer;
 }
 

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialization-ts.mustache
@@ -7,8 +7,19 @@ import {
   Nullable
 } from "@web3api/wasm-as";
 import { {{type}} } from "./";
+import * as Objects from "../../";
 
 export function serialize{{type}}(type: {{type}}): ArrayBuffer {
+  const objects: (ArrayBuffer | null)[] = [
+    {{#properties}}{{#object}}
+    {{#required}}
+    type.{{name}}.toBuffer(),
+    {{/required}}
+    {{^required}}
+    type.{{name}} ? type.{{name}}.toBuffer() : null,
+    {{/required}}
+    {{/object}}{{/properties}}
+  ];
   const sizer = new WriteSizer();
   write{{type}}(sizer, type);
   const buffer = new ArrayBuffer(sizer.length);
@@ -17,7 +28,8 @@ export function serialize{{type}}(type: {{type}}): ArrayBuffer {
   return buffer;
 }
 
-function write{{type}}(writer: Write, type: {{type}}): void {
+function write{{type}}(writer: Write, type: {{type}}, objects: (ArrayBuffer | null)[]): void {
+  let objectsIdx = 0;
   writer.writeMapLength({{properties.length}});
   {{#properties}}
   writer.writeString("{{name}}");
@@ -29,6 +41,9 @@ function write{{type}}(writer: Write, type: {{type}}): void {
     {{> serialize_array}}
   });
   {{/array}}
+  {{#object}}
+  writer.writeNullableBytes(objects[objectsIdx++]);
+  {{/object}}
   {{/properties}}
 }
 
@@ -50,6 +65,10 @@ export function deserialize{{type}}(buffer: ArrayBuffer, type: {{type}}): void {
         {{> deserialize_array}}
       });
       {{/array}}
+      {{#object}}
+      {{> deserialize_object }}
+      type.{{name}} = object;
+      {{/object}}
     }
     {{/properties}}
   }

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialize_array.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialize_array.mustache
@@ -6,3 +6,6 @@ writer.write{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}(item, (writer: Write, 
   {{> serialize_array}}
 });
 {{/array}}
+{{#object}}
+{{> serialize_object}}
+{{/object}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/object-type/serialize_object.mustache
@@ -1,0 +1,6 @@
+{{#required}}
+writer.writeBytes(item.toBuffer());
+{{/required}}
+{{^required}}
+writer.writeNullableBytes(item ? item.toBuffer() : null);
+{{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/deserialize_array.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/deserialize_array.mustache
@@ -6,3 +6,7 @@ return reader.read{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}((reader: Read): 
   {{> deserialize_array}}
 });
 {{/array}}
+{{#object}}
+{{> deserialize_object}}
+return object;
+{{/object}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/deserialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/deserialize_object.mustache
@@ -1,0 +1,14 @@
+{{#required}}
+const object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+object.fromBuffer(reader.readBytes());
+{{/required}}
+{{^required}}
+var bytes = reader.readNullableBytes();
+var object: {{#toWasm}}{{type}}{{/toWasm}};
+if (bytes) {
+  object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+  object.fromBuffer(bytes);
+} else {
+  object = null;
+}
+{{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/deserialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/deserialize_object.mustache
@@ -1,14 +1,12 @@
 {{#required}}
-const object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+const object = {{#toWasmInit}}{{toGraphQLType}}{{/toWasmInit}};
 object.fromBuffer(reader.readBytes());
 {{/required}}
 {{^required}}
-var bytes = reader.readNullableBytes();
-var object: {{#toWasm}}{{type}}{{/toWasm}};
+const bytes = reader.readNullableBytes();
+var object: {{#toWasm}}{{toGraphQLType}}{{/toWasm}} = null;
 if (bytes) {
-  object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+  object = new Objects.{{type}}();
   object.fromBuffer(bytes);
-} else {
-  object = null;
 }
 {{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/index-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/index-ts.mustache
@@ -11,6 +11,7 @@ import {
   {{/methods}}
 } from "./serialization";
 {{/methods.length}}
+import * as Objects from "../../";
 
 export class {{type}} {
 

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/index-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/index-ts.mustache
@@ -11,7 +11,7 @@ import {
   {{/methods}}
 } from "./serialization";
 {{/methods.length}}
-import * as Objects from "../../";
+import * as Objects from "../..";
 
 export class {{type}} {
 

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/serialization-ts.mustache
@@ -6,6 +6,7 @@ import {
   WriteEncoder,
   ReadDecoder
 } from "@web3api/wasm-as";
+import * as Objects from "../../";
 
 {{#methods}}
 export class Input_{{name}} {
@@ -15,18 +16,30 @@ export class Input_{{name}} {
 }
 
 export function serialize{{name}}Args(input: Input_{{name}}): ArrayBuffer {
+  const objects: (ArrayBuffer | null)[] = [
+    {{#arguments}}{{#object}}
+    {{#required}}
+    input.{{name}}.toBuffer(),
+    {{/required}}
+    {{^required}}
+    input.{{name}} ? input.{{name}}.toBuffer() : null,
+    {{/required}}
+    {{/object}}{{/arguments}}
+  ];
   const sizer = new WriteSizer();
-  write{{name}}Args(sizer, input);
+  write{{name}}Args(sizer, input, objects);
   const buffer = new ArrayBuffer(sizer.length);
   const encoder = new WriteEncoder(buffer);
-  write{{name}}Args(encoder, input);
+  write{{name}}Args(encoder, input, objects);
   return buffer;
 }
 
 function write{{name}}Args(
   writer: Write,
-  input: Input_{{name}}
+  input: Input_{{name}},
+  objects: (ArrayBuffer | null)[]
 ): void {
+  let objectsIdx = 0;
   writer.writeMapLength({{arguments.length}});
   {{#arguments}}
   writer.writeString("{{name}}");
@@ -38,6 +51,9 @@ function write{{name}}Args(
     {{> serialize_array}}
   });
   {{/array}}
+  {{#object}}
+  writer.writeNullableBytes(objects[objectsIdx++]);
+  {{/object}}
   {{/arguments}}
 }
 
@@ -52,6 +68,11 @@ export function deserialize{{name}}Result(buffer: ArrayBuffer): {{#return}}{{#to
     {{> deserialize_array}}
   });
   {{/array}}
+  {{#object}}
+  {{> deserialize_object}}
+
+  return object;
+  {{/object}}
   {{/return}}
 }
 {{^last}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/serialization-ts.mustache
@@ -6,7 +6,7 @@ import {
   WriteEncoder,
   ReadDecoder
 } from "@web3api/wasm-as";
-import * as Objects from "../../";
+import * as Objects from "../..";
 
 {{#methods}}
 export class Input_{{name}} {

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/serialize_array.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/serialize_array.mustache
@@ -6,3 +6,6 @@ writer.write{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}(item, (writer: Write, 
   {{> serialize_array}}
 });
 {{/array}}
+{{#object}}
+{{> serialize_object}}
+{{/object}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/serialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/imported/query-type/serialize_object.mustache
@@ -1,0 +1,6 @@
+{{#required}}
+writer.writeBytes(item.toBuffer());
+{{/required}}
+{{^required}}
+writer.writeNullableBytes(item ? item.toBuffer() : null);
+{{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/object-type/deserialize_array.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/object-type/deserialize_array.mustache
@@ -6,3 +6,7 @@ return reader.read{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}((reader: Read): 
   {{> deserialize_array}}
 });
 {{/array}}
+{{#object}}
+{{> deserialize_object}}
+return object;
+{{/object}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/object-type/deserialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/object-type/deserialize_object.mustache
@@ -1,0 +1,14 @@
+{{#required}}
+const object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+object.fromBuffer(reader.readBytes());
+{{/required}}
+{{^required}}
+var bytes = reader.readNullableBytes();
+var object: {{#toWasm}}{{type}}{{/toWasm}};
+if (bytes) {
+  object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+  object.fromBuffer(bytes);
+} else {
+  object = null;
+}
+{{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/object-type/deserialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/object-type/deserialize_object.mustache
@@ -1,14 +1,12 @@
 {{#required}}
-const object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+const object = {{#toWasmInit}}{{toGraphQLType}}{{/toWasmInit}};
 object.fromBuffer(reader.readBytes());
 {{/required}}
 {{^required}}
-var bytes = reader.readNullableBytes();
-var object: {{#toWasm}}{{type}}{{/toWasm}};
+const bytes = reader.readNullableBytes();
+var object: {{#toWasm}}{{toGraphQLType}}{{/toWasm}} = null;
 if (bytes) {
-  object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+  object = new Objects.{{type}}();
   object.fromBuffer(bytes);
-} else {
-  object = null;
 }
 {{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/object-type/index-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/object-type/index-ts.mustache
@@ -14,7 +14,7 @@ export class {{type}} {
   {{name}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}};
   {{/array}}
   {{#object}}
-  {{name}}: {{#toWasm}}Objects.{{toGraphQLType}}{{/toWasm}};
+  {{name}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}};
   {{/object}}
   {{/properties}}
 

--- a/packages/schema/bind/src/bindings/wasm-as/templates/object-type/index-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/object-type/index-ts.mustache
@@ -3,7 +3,7 @@ import {
   serialize{{type}},
   deserialize{{type}}
 } from "./serialization";
-import * as Objects from "../";
+import * as Objects from "..";
 
 export class {{type}} {
   {{#properties}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialization-ts.mustache
@@ -11,7 +11,7 @@ import * as Objects from "../";
 
 export function serialize{{type}}(type: {{type}}): ArrayBuffer {
   const objects: (ArrayBuffer | null)[] = [
-    {{#properties}}{{#object}}type.{{name}}.toBuffer(),{{/object}}{{/properties}}
+    {{#properties}}{{#object}}type.{{name}}{{^required}}?{{/required}}.toBuffer(),{{/object}}{{/properties}}
   ];
   const sizer = new WriteSizer();
   write{{type}}(sizer, type, objects);
@@ -59,8 +59,8 @@ export function deserialize{{type}}(buffer: ArrayBuffer, type: {{type}}) {
       });
       {{/array}}
       {{#object}}
-      type.{{name}} = {{#toWasmInit}}{{type}}{{/toWasmInit}};
-      type.{{name}}.fromBuffer(reader.readBytes());
+      {{> deserialize_object }}
+      type.{{name}} = object;
       {{/object}}
     }
     {{/properties}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialization-ts.mustache
@@ -7,7 +7,7 @@ import {
   Nullable
 } from "@web3api/wasm-as";
 import { {{type}} } from "./";
-import * as Objects from "../";
+import * as Objects from "..";
 
 export function serialize{{type}}(type: {{type}}): ArrayBuffer {
   const objects: (ArrayBuffer | null)[] = [

--- a/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialization-ts.mustache
@@ -11,7 +11,14 @@ import * as Objects from "../";
 
 export function serialize{{type}}(type: {{type}}): ArrayBuffer {
   const objects: (ArrayBuffer | null)[] = [
-    {{#properties}}{{#object}}type.{{name}}{{^required}}?{{/required}}.toBuffer(),{{/object}}{{/properties}}
+    {{#properties}}{{#object}}
+    {{#required}}
+    type.{{name}}.toBuffer(),
+    {{/required}}
+    {{^required}}
+    type.{{name}} ? type.{{name}}.toBuffer() : null,
+    {{/required}}
+    {{/object}}{{/properties}}
   ];
   const sizer = new WriteSizer();
   write{{type}}(sizer, type, objects);
@@ -21,7 +28,7 @@ export function serialize{{type}}(type: {{type}}): ArrayBuffer {
   return buffer;
 }
 
-function write{{type}}(writer: Write, type: {{type}}, objects: (ArrayBuffer | null)[]) {
+function write{{type}}(writer: Write, type: {{type}}, objects: (ArrayBuffer | null)[]): void {
   let objectsIdx = 0;
   writer.writeMapLength({{properties.length}});
   {{#properties}}
@@ -40,7 +47,7 @@ function write{{type}}(writer: Write, type: {{type}}, objects: (ArrayBuffer | nu
   {{/properties}}
 }
 
-export function deserialize{{type}}(buffer: ArrayBuffer, type: {{type}}) {
+export function deserialize{{type}}(buffer: ArrayBuffer, type: {{type}}): void {
   const reader = new ReadDecoder(buffer);
   var numFields = reader.readMapLength();
 

--- a/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialization-ts.mustache
@@ -10,7 +10,7 @@ import { {{type}} } from "./";
 import * as Objects from "../";
 
 export function serialize{{type}}(type: {{type}}): ArrayBuffer {
-  const objects: ArrayBuffer[] = [
+  const objects: (ArrayBuffer | null)[] = [
     {{#properties}}{{#object}}type.{{name}}.toBuffer(),{{/object}}{{/properties}}
   ];
   const sizer = new WriteSizer();
@@ -21,7 +21,7 @@ export function serialize{{type}}(type: {{type}}): ArrayBuffer {
   return buffer;
 }
 
-function write{{type}}(writer: Write, type: {{type}}, objects: ArrayBuffer[]) {
+function write{{type}}(writer: Write, type: {{type}}, objects: (ArrayBuffer | null)[]) {
   let objectsIdx = 0;
   writer.writeMapLength({{properties.length}});
   {{#properties}}
@@ -35,7 +35,7 @@ function write{{type}}(writer: Write, type: {{type}}, objects: ArrayBuffer[]) {
   });
   {{/array}}
   {{#object}}
-  writer.writeBytes(objects[objectsIdx++]);
+  writer.writeNullableBytes(objects[objectsIdx++]);
   {{/object}}
   {{/properties}}
 }
@@ -59,7 +59,7 @@ export function deserialize{{type}}(buffer: ArrayBuffer, type: {{type}}) {
       });
       {{/array}}
       {{#object}}
-      type.{{name}} = new Objects.{{type}}();
+      type.{{name}} = {{#toWasmInit}}{{type}}{{/toWasmInit}};
       type.{{name}}.fromBuffer(reader.readBytes());
       {{/object}}
     }

--- a/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialize_array.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialize_array.mustache
@@ -6,3 +6,6 @@ writer.write{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}(item, (writer: Write, 
   {{> serialize_array}}
 });
 {{/array}}
+{{#object}}
+{{> serialize_object}}
+{{/object}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/object-type/serialize_object.mustache
@@ -1,0 +1,6 @@
+{{#required}}
+writer.writeBytes(item.toBuffer());
+{{/required}}
+{{^required}}
+writer.writeNullableBytes(item ? item.toBuffer() : null);
+{{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/query-type/deserialize_array.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/query-type/deserialize_array.mustache
@@ -6,3 +6,7 @@ return reader.read{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}((reader: Read): 
   {{> deserialize_array}}
 });
 {{/array}}
+{{#object}}
+{{> deserialize_object}}
+return object;
+{{/object}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/query-type/deserialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/query-type/deserialize_object.mustache
@@ -1,0 +1,14 @@
+{{#required}}
+const object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+object.fromBuffer(reader.readBytes());
+{{/required}}
+{{^required}}
+var bytes = reader.readNullableBytes();
+var object: {{#toWasm}}{{type}}{{/toWasm}};
+if (bytes) {
+  object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+  object.fromBuffer(bytes);
+} else {
+  object = null;
+}
+{{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/query-type/deserialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/query-type/deserialize_object.mustache
@@ -1,14 +1,12 @@
 {{#required}}
-const object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+const object = {{#toWasmInit}}{{toGraphQLType}}{{/toWasmInit}};
 object.fromBuffer(reader.readBytes());
 {{/required}}
 {{^required}}
-var bytes = reader.readNullableBytes();
-var object: {{#toWasm}}{{type}}{{/toWasm}};
+const bytes = reader.readNullableBytes();
+var object: {{#toWasm}}{{toGraphQLType}}{{/toWasm}} = null;
 if (bytes) {
-  object = {{#toWasmInit}}{{type}}{{/toWasmInit}};
+  object = new Objects.{{type}}();
   object.fromBuffer(bytes);
-} else {
-  object = null;
 }
 {{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/query-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/query-type/serialization-ts.mustache
@@ -1,3 +1,4 @@
+import { Nullable } from "@web3api/wasm-as";
 import {
   Read,
   ReadDecoder,
@@ -5,6 +6,7 @@ import {
   WriteEncoder,
   Write
 } from "@web3api/wasm-as";
+import * as Objects from "../";
 
 {{#methods}}
 export class Input_{{name}} {
@@ -39,6 +41,9 @@ export function deserialize{{name}}Args(argsBuf: ArrayBuffer): Input_{{name}} {
         {{> deserialize_array}}
       });
       {{/array}}
+      {{#object}}
+      _{{name}}.fromBuffer(reader.readBytes());
+      {{/object}}
       {{#required}}
       _{{name}}Set = true;
       {{/required}}
@@ -49,7 +54,7 @@ export function deserialize{{name}}Args(argsBuf: ArrayBuffer): Input_{{name}} {
   {{#arguments}}
   {{#required}}
   if (!_{{name}}Set) {
-    throw Error("Missing required argument \"{{name}}: {{type}}\"");
+    throw Error("Missing required argument '{{name}}: {{type}}'");
   }
   {{/required}}
   {{/arguments}}
@@ -81,6 +86,14 @@ function write{{name}}Result(writer: Write, result: {{#return}}{{#toWasm}}{{toGr
     {{> serialize_array}}
   });
   {{/array}}
+  {{#object}}
+  {{#required}}
+  writer.writeBytes(result.toBuffer());
+  {{/required}}
+  {{^required}}
+  writer.writeNullableBytes(result ? result.toBuffer() : null);
+  {{/required}}
+  {{/object}}
   {{/return}}
 }
 {{/methods}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/query-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/query-type/serialization-ts.mustache
@@ -6,7 +6,7 @@ import {
   WriteEncoder,
   Write
 } from "@web3api/wasm-as";
-import * as Objects from "../";
+import * as Objects from "..";
 
 {{#methods}}
 export class Input_{{name}} {

--- a/packages/schema/bind/src/bindings/wasm-as/templates/query-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/query-type/serialization-ts.mustache
@@ -7,8 +7,8 @@ import {
   Write
 } from "@web3api/wasm-as";
 import * as Objects from "..";
-
 {{#methods}}
+
 export class Input_{{name}} {
   {{#arguments}}
   {{name}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}};
@@ -42,7 +42,8 @@ export function deserialize{{name}}Args(argsBuf: ArrayBuffer): Input_{{name}} {
       });
       {{/array}}
       {{#object}}
-      _{{name}}.fromBuffer(reader.readBytes());
+      {{> deserialize_object}}
+      _{{name}} = object;
       {{/object}}
       {{#required}}
       _{{name}}Set = true;

--- a/packages/schema/bind/src/bindings/wasm-as/templates/query-type/serialize_array.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/query-type/serialize_array.mustache
@@ -6,3 +6,6 @@ writer.write{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}(item, (writer: Write, 
   {{> serialize_array}}
 });
 {{/array}}
+{{#object}}
+{{> serialize_object}}
+{{/object}}

--- a/packages/schema/bind/src/bindings/wasm-as/templates/query-type/serialize_object.mustache
+++ b/packages/schema/bind/src/bindings/wasm-as/templates/query-type/serialize_object.mustache
@@ -1,0 +1,6 @@
+{{#required}}
+writer.writeBytes(item.toBuffer());
+{{/required}}
+{{^required}}
+writer.writeNullableBytes(item ? item.toBuffer() : null);
+{{/required}}

--- a/packages/schema/bind/src/bindings/wasm-as/types.ts
+++ b/packages/schema/bind/src/bindings/wasm-as/types.ts
@@ -1,0 +1,20 @@
+const msgPackTypes = {
+  u8: "u8",
+  u16: "u16",
+  u32: "u32",
+  u64: "u64",
+  i8: "i8",
+  i16: "i16",
+  i32: "i32",
+  i64: "i64",
+  string: "strin",
+  bool: "bool",
+};
+
+export type MsgPackTypes = typeof msgPackTypes;
+
+export type MsgPackType = keyof MsgPackTypes;
+
+export function isMsgPackType(type: string): type is MsgPackType {
+  return type in msgPackTypes;
+}


### PR DESCRIPTION
Changes: 
 - make nullable objects be Object | null instead of Nullable<Object> mostly because typescript really doesn't like Nullable and makes it hard to check code
 - add missing return types on deserialize and serialize query methods
 - add support for objects, nested objects and objects in array for imported and user objects and querie

TODO: 
 - circular objects
 - ~~broke something in e2e tests which I need to check~~