### PR TITLE
Handle IPFS Stalling W/ Timeouts & Fallback Providers

### DIFF
--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -96,7 +96,12 @@ export default {
       },
       {
         from: "w3://ens/ipfs.web3api.eth",
-        to: ipfsPlugin({ provider: ipfsProvider }),
+        to: ipfsPlugin({
+          provider: ipfsProvider,
+          fallbackProviders: [
+            "https://ipfs.io"
+          ]
+        }),
       },
       {
         from: "w3://ens/ens.web3api.eth",

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -98,9 +98,7 @@ export default {
         from: "w3://ens/ipfs.web3api.eth",
         to: ipfsPlugin({
           provider: ipfsProvider,
-          fallbackProviders: [
-            "https://ipfs.io"
-          ]
+          fallbackProviders: ["https://ipfs.io"],
         }),
       },
       {

--- a/packages/cli/src/lib/SchemaComposer.ts
+++ b/packages/cli/src/lib/SchemaComposer.ts
@@ -57,7 +57,12 @@ export class SchemaComposer {
     if (ipfsProvider) {
       redirects.push({
         from: "w3://ens/ipfs.web3api.eth",
-        to: ipfsPlugin({ provider: ipfsProvider }),
+        to: ipfsPlugin({
+          provider: ipfsProvider,
+          fallbackProviders: [
+            "https://ipfs.io"
+          ]
+        }),
       });
     }
 

--- a/packages/cli/src/lib/SchemaComposer.ts
+++ b/packages/cli/src/lib/SchemaComposer.ts
@@ -59,9 +59,7 @@ export class SchemaComposer {
         from: "w3://ens/ipfs.web3api.eth",
         to: ipfsPlugin({
           provider: ipfsProvider,
-          fallbackProviders: [
-            "https://ipfs.io"
-          ]
+          fallbackProviders: ["https://ipfs.io"],
         }),
       });
     }

--- a/packages/js/client/src/pluginConfigs/Ipfs.ts
+++ b/packages/js/client/src/pluginConfigs/Ipfs.ts
@@ -6,4 +6,5 @@
 
 export interface IpfsConfig {
   provider: string;
+  fallbackProviders?: string[];
 }

--- a/packages/js/plugins/ipfs/package.json
+++ b/packages/js/plugins/ipfs/package.json
@@ -22,11 +22,12 @@
   "dependencies": {
     "@web3api/core-js": "0.0.1-prealpha.18",
     "cids": "^1.1.4",
-    "ipfs-http-client-lite": "0.3.0",
+    "@dorgjelli-test/ipfs-http-client-lite": "0.3.1",
     "is-ipfs": "1.0.3"
   },
   "devDependencies": {
     "@types/jest": "26.0.8",
+    "abort-controller": "3.0.0",
     "jest": "26.6.3",
     "rimraf": "3.0.2",
     "ts-jest": "26.5.4",

--- a/packages/js/plugins/ipfs/package.json
+++ b/packages/js/plugins/ipfs/package.json
@@ -20,9 +20,10 @@
     "test:watch": "jest --watch --passWithNoTests --verbose"
   },
   "dependencies": {
-    "@web3api/core-js": "0.0.1-prealpha.18",
-    "cids": "^1.1.4",
     "@dorgjelli-test/ipfs-http-client-lite": "0.3.1",
+    "@web3api/core-js": "0.0.1-prealpha.18",
+    "abort-controller": "3.0.0",
+    "cids": "^1.1.4",
     "is-ipfs": "1.0.3"
   },
   "devDependencies": {

--- a/packages/js/plugins/ipfs/schema.graphql
+++ b/packages/js/plugins/ipfs/schema.graphql
@@ -2,7 +2,15 @@
 # https://github.com/Web3-API/monorepo/issues/75
 
 type Query {
-  catFile(cid: String!): Bytes!
+  catFile(
+    cid: String!
+    options: Options
+  ): Bytes!
+
+  resolve(
+    cid: String!
+    options: Options
+  ): ResolveResult
 
   tryResolveUri(
     authority: String!
@@ -18,6 +26,20 @@ type Mutation {
   # TODO: Allow for custom type CID
   # https://github.com/web3-api/monorepo/issues/103
   addFile(data: Bytes!): String!
+}
+
+type ResolveResult {
+  cid: String!
+  provider: String!
+}
+
+type Options {
+  # Timeout (in ms) for the operation.
+  # Fallback providers are used if timeout is reached.
+  timeout: UInt64
+
+  # The IPFS provider to be used
+  provider: String
 }
 
 # TODO: should get replaced with an import

--- a/packages/js/plugins/ipfs/src/index.ts
+++ b/packages/js/plugins/ipfs/src/index.ts
@@ -18,14 +18,22 @@ const isIPFS = require("is-ipfs");
 const createIpfsClient = require("@dorgjelli-test/ipfs-http-client-lite");
 
 interface IpfsClient {
-  add(data: Uint8Array, options?: unknown): Promise<{
-    name: string;
-    hash: CID;
-  }[]>;
+  add(
+    data: Uint8Array,
+    options?: unknown
+  ): Promise<
+    {
+      name: string;
+      hash: CID;
+    }[]
+  >;
 
   cat(cid: string, options?: unknown): Promise<Buffer>;
 
-  resolve(cid: string, options?: unknown): Promise<{
+  resolve(
+    cid: string,
+    options?: unknown
+  ): Promise<{
     path: string;
   }>;
 }
@@ -106,7 +114,7 @@ export class IpfsPlugin extends Plugin {
         const { path } = await ipfs.resolve(cid, options);
         return {
           cid: path,
-          provider
+          provider,
         };
       },
       options
@@ -135,10 +143,7 @@ export class IpfsPlugin extends Plugin {
 
         while (!complete) {
           const controller = new AbortController();
-          const timer = setTimeout(
-            () => controller.abort(),
-            timeout
-          );
+          const timer = setTimeout(() => controller.abort(), timeout);
 
           try {
             result = await exec(ipfs, provider, { signal: controller.signal });
@@ -148,7 +153,11 @@ export class IpfsPlugin extends Plugin {
 
           clearTimeout(timer);
 
-          if (controller.signal.aborted && this._config.fallbackProviders && !providerOverride) {
+          if (
+            controller.signal.aborted &&
+            this._config.fallbackProviders &&
+            !providerOverride
+          ) {
             // Retry with a new provider
             fallbackIdx += 1;
 
@@ -166,7 +175,12 @@ export class IpfsPlugin extends Plugin {
         if (!result) {
           throw Error(
             `${operation}: Timeout has been exceeded, and all providers have been exhausted.\nTimeout: ${timeout}\nProviders: ${
-              providerOverride ? [providerOverride] : [this._config.provider, ...(this._config.fallbackProviders || [])]
+              providerOverride
+                ? [providerOverride]
+                : [
+                    this._config.provider,
+                    ...(this._config.fallbackProviders || []),
+                  ]
             }`
           );
         }

--- a/packages/js/plugins/ipfs/src/manifest.ts
+++ b/packages/js/plugins/ipfs/src/manifest.ts
@@ -8,7 +8,15 @@ export const manifest: PluginManifest = {
 # https://github.com/Web3-API/monorepo/issues/75
 
 type Query {
-  catFile(cid: String!): Bytes!
+  catFile(
+    cid: String!
+    options: Options
+  ): Bytes!
+
+  resolve(
+    cid: String!
+    options: Options
+  ): ResolveResult
 
   tryResolveUri(
     authority: String!
@@ -24,6 +32,20 @@ type Mutation {
   # TODO: Allow for custom type CID
   # https://github.com/web3-api/monorepo/issues/103
   addFile(data: Bytes!): String!
+}
+
+type ResolveResult {
+  cid: String!
+  provider: String!
+}
+
+type Options {
+  # Timeout (in ms) for the operation.
+  # Fallback providers are used if timeout is reached.
+  timeout: UInt64
+
+  # The IPFS provider to be used
+  provider: String
 }
 
 # TODO: should get replaced with an import

--- a/packages/js/plugins/ipfs/src/resolvers.ts
+++ b/packages/js/plugins/ipfs/src/resolvers.ts
@@ -13,15 +13,12 @@ export const mutation = (ipfs: IpfsPlugin): PluginModule => ({
 });
 
 export const query = (ipfs: IpfsPlugin): PluginModule => ({
-  catFile: async (input: {
-    cid: string,
-    options?: Options
-  }) => {
+  catFile: async (input: { cid: string; options?: Options }) => {
     return await ipfs.cat(input.cid, input.options);
   },
   resolve: async (input: {
-    cid: string,
-    options?: Options
+    cid: string;
+    options?: Options;
   }): Promise<ResolveResult> => {
     return await ipfs.resolve(input.cid, input.options);
   },
@@ -35,11 +32,9 @@ export const query = (ipfs: IpfsPlugin): PluginModule => ({
       // Try fetching uri/web3api.yaml
       try {
         return {
-          manifest: await ipfs.catToString(
-            `${input.path}/web3api.yaml`, {
-              timeout: 5000
-            }
-          ),
+          manifest: await ipfs.catToString(`${input.path}/web3api.yaml`, {
+            timeout: 5000,
+          }),
           uri: null,
         };
       } catch (e) {
@@ -50,11 +45,9 @@ export const query = (ipfs: IpfsPlugin): PluginModule => ({
       // Try fetching uri/web3api.yml
       try {
         return {
-          manifest: await ipfs.catToString(
-            `${input.path}/web3api.yml`, {
-              timeout: 5000
-            }
-          ),
+          manifest: await ipfs.catToString(`${input.path}/web3api.yml`, {
+            timeout: 5000,
+          }),
           uri: null,
         };
       } catch (e) {
@@ -69,11 +62,11 @@ export const query = (ipfs: IpfsPlugin): PluginModule => ({
   getFile: async (input: { path: string }) => {
     try {
       const { cid, provider } = await ipfs.resolve(input.path, {
-        timeout: 5000
+        timeout: 5000,
       });
 
       return await ipfs.cat(cid, {
-        provider: provider
+        provider: provider,
       });
     } catch (e) {
       return null;

--- a/packages/js/plugins/ipfs/src/resolvers.ts
+++ b/packages/js/plugins/ipfs/src/resolvers.ts
@@ -1,4 +1,5 @@
 import { IpfsPlugin } from "./";
+import { ResolveResult, Options } from "./types";
 
 import { PluginModule } from "@web3api/core-js";
 
@@ -12,8 +13,17 @@ export const mutation = (ipfs: IpfsPlugin): PluginModule => ({
 });
 
 export const query = (ipfs: IpfsPlugin): PluginModule => ({
-  catFile: async (input: { cid: string }) => {
-    return await ipfs.cat(input.cid);
+  catFile: async (input: {
+    cid: string,
+    options?: Options
+  }) => {
+    return await ipfs.cat(input.cid, input.options);
+  },
+  resolve: async (input: {
+    cid: string,
+    options?: Options
+  }): Promise<ResolveResult> => {
+    return await ipfs.resolve(input.cid, input.options);
   },
   // w3/api-resolver
   tryResolveUri: async (input: { authority: string; path: string }) => {
@@ -25,7 +35,11 @@ export const query = (ipfs: IpfsPlugin): PluginModule => ({
       // Try fetching uri/web3api.yaml
       try {
         return {
-          manifest: await ipfs.catToString(`${input.path}/web3api.yaml`),
+          manifest: await ipfs.catToString(
+            `${input.path}/web3api.yaml`, {
+              timeout: 5000
+            }
+          ),
           uri: null,
         };
       } catch (e) {
@@ -36,7 +50,11 @@ export const query = (ipfs: IpfsPlugin): PluginModule => ({
       // Try fetching uri/web3api.yml
       try {
         return {
-          manifest: await ipfs.catToString(`${input.path}/web3api.yml`),
+          manifest: await ipfs.catToString(
+            `${input.path}/web3api.yml`, {
+              timeout: 5000
+            }
+          ),
           uri: null,
         };
       } catch (e) {
@@ -50,7 +68,13 @@ export const query = (ipfs: IpfsPlugin): PluginModule => ({
   },
   getFile: async (input: { path: string }) => {
     try {
-      return await ipfs.cat(input.path);
+      const { cid, provider } = await ipfs.resolve(input.path, {
+        timeout: 5000
+      });
+
+      return await ipfs.cat(cid, {
+        provider: provider
+      });
     } catch (e) {
       return null;
     }

--- a/packages/js/plugins/ipfs/src/types.ts
+++ b/packages/js/plugins/ipfs/src/types.ts
@@ -1,0 +1,12 @@
+// TODO: generate types from the schema
+// https://github.com/web3-api/monorepo/issues/101
+
+export interface ResolveResult {
+  cid: string;
+  provider: string;
+}
+
+export interface Options {
+  timeout?: number;
+  provider?: string;
+}

--- a/packages/js/test-env/src/index.ts
+++ b/packages/js/test-env/src/index.ts
@@ -50,7 +50,12 @@ export const initTestEnvironment = async (): Promise<TestEnvironment> => {
     },
     {
       from: "w3://ens/ipfs.web3api.eth",
-      to: ipfsPlugin({ provider: ipfs as string }),
+      to: ipfsPlugin({
+        provider: ipfs as string,
+        fallbackProviders: [
+          "https://ipfs.io"
+        ]
+      }),
     },
     {
       from: "w3://ens/ens.web3api.eth",

--- a/packages/js/test-env/src/index.ts
+++ b/packages/js/test-env/src/index.ts
@@ -52,9 +52,7 @@ export const initTestEnvironment = async (): Promise<TestEnvironment> => {
       from: "w3://ens/ipfs.web3api.eth",
       to: ipfsPlugin({
         provider: ipfs as string,
-        fallbackProviders: [
-          "https://ipfs.io"
-        ]
+        fallbackProviders: ["https://ipfs.io"],
       }),
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1371,6 +1371,22 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz#8f03a22a04de437254e8ce8cc84ba39689288752"
   integrity sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==
 
+"@dorgjelli-test/ipfs-http-client-lite@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@dorgjelli-test/ipfs-http-client-lite/-/ipfs-http-client-lite-0.3.1.tgz#5514b4400e0c91ea64e0b5faf426ba808809ddfe"
+  integrity sha512-N96ilOlJnjnprOOIrwKjEA7lu67mbXyGmJO/vOBXQvY9AQw9XrPdIEn0x30bHwQ6pWSwN4RhIgJUy1/A7u/hEg==
+  dependencies:
+    abort-controller "^3.0.0"
+    async-iterator-to-pull-stream "^1.3.0"
+    buffer "^5.2.1"
+    cids "^0.7.1"
+    explain-error "^1.0.4"
+    form-data "^2.4.0"
+    iterable-ndjson "^1.1.0"
+    node-fetch "^2.6.0"
+    pull-stream-to-async-iterator "^1.0.2"
+    querystring "^0.2.0"
+
 "@dsherret/to-absolute-glob@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz#1f6475dc8bd974cea07a2daf3864b317b1dd332c"
@@ -4376,7 +4392,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-abort-controller@^3.0.0:
+abort-controller@3.0.0, abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
   integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
@@ -10744,22 +10760,6 @@ ipfs-core-utils@^0.5.4:
     parse-duration "^0.4.4"
     timeout-abort-controller "^1.1.1"
     uint8arrays "^1.1.0"
-
-ipfs-http-client-lite@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/ipfs-http-client-lite/-/ipfs-http-client-lite-0.3.0.tgz#08d9428fde667b1c602bae6c95e77e04f86c280d"
-  integrity sha512-fmxEctpzqaPd0gooBuvjMwxSoqz15rwjjm2ZF3Ns4Ckz/zz5JEmiDKuwlMOfwkARd5Wsiy2FqQpQEvBTJ8R7Og==
-  dependencies:
-    abort-controller "^3.0.0"
-    async-iterator-to-pull-stream "^1.3.0"
-    buffer "^5.2.1"
-    cids "^0.7.1"
-    explain-error "^1.0.4"
-    form-data "^2.4.0"
-    iterable-ndjson "^1.1.0"
-    node-fetch "^2.6.0"
-    pull-stream-to-async-iterator "^1.0.2"
-    querystring "^0.2.0"
 
 ipfs-http-client@48.1.3:
   version "48.1.3"


### PR DESCRIPTION
When an IPFS node cannot access a requested document, it will hang. In order to work around this, I've added options for:
- Registering fallback providers to try if an operation fails to complete on the default provider.
- Specifying a timeout to be used for a given operation.
- Specifying a provider override to be used for a given operation.
- Added support for the `resolve` API, allowing you to quickly check if a file exists.

closes https://github.com/Web3-API/monorepo/issues/290