### PR TITLE
Shared Types: Composer Fixes

### DIFF
--- a/packages/cli/src/__tests__/unit/SchemaComposer.spec.ts
+++ b/packages/cli/src/__tests__/unit/SchemaComposer.spec.ts
@@ -13,6 +13,10 @@ describe("SchemaComposer validation", () => {
       project,
     });
     const schema = await composer.getComposedSchemas();
-    expect(schema).toEqual(composedSchema);
+    expect({
+      query: schema.query?.schema,
+      mutation: schema.mutation?.schema,
+      combined: schema.combined?.schema,
+    }).toEqual(composedSchema);
   });
 });

--- a/packages/cli/src/__tests__/unit/SchemaComposer.spec.ts
+++ b/packages/cli/src/__tests__/unit/SchemaComposer.spec.ts
@@ -2,6 +2,8 @@ import path from "path";
 import { SchemaComposer, Project } from "../../lib";
 import { composedSchema } from "../project/sample";
 
+import { ComposerFilter } from "@web3api/schema-compose";
+
 describe("SchemaComposer validation", () => {
   const manifestPath = path.join(__dirname, "../project", "web3api.yaml");
 
@@ -12,7 +14,7 @@ describe("SchemaComposer validation", () => {
     const composer = new SchemaComposer({
       project,
     });
-    const schema = await composer.getComposedSchemas();
+    const schema = await composer.getComposedSchemas(ComposerFilter.Schema);
     expect({
       query: schema.query?.schema,
       mutation: schema.mutation?.schema,

--- a/packages/cli/src/lib/CodeGenerator.ts
+++ b/packages/cli/src/lib/CodeGenerator.ts
@@ -4,7 +4,6 @@ import { step, withSpinner } from "./helpers";
 import { intlMsg } from "./intl";
 
 import { OutputDirectory, writeDirectory } from "@web3api/schema-bind";
-import { parseSchema } from "@web3api/schema-parse";
 import path from "path";
 import fs, { readFileSync } from "fs";
 import * as gluegun from "gluegun";
@@ -46,8 +45,15 @@ export class CodeGenerator {
 
       // Get the fully composed schema
       const composed = await schemaComposer.getComposedSchemas();
-      const typeInfo = parseSchema(composed.combined || "");
-      this._schema = composed.combined;
+
+      if (!composed.combined) {
+        throw Error(
+          `CodeGenerator: The schema does not exist, please define one.`
+        );
+      }
+
+      const typeInfo = composed.combined.typeInfo;
+      this._schema = composed.combined.schema;
 
       // Check the generation file if it has the proper run() method
       // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention

--- a/packages/cli/src/lib/Compiler.ts
+++ b/packages/cli/src/lib/Compiler.ts
@@ -12,7 +12,6 @@ import fs, { readFileSync } from "fs";
 import * as gluegun from "gluegun";
 import { Ora } from "ora";
 import * as asc from "assemblyscript/cli/asc";
-import { SchemaInfo } from "@web3api/schema-compose";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const fsExtra = require("fs-extra");
@@ -91,22 +90,22 @@ export class Compiler {
         // Generate code next to the module entry point file
         if (!composed[moduleName]) {
           throw Error(
-            `Compiler: Missing schema for the module "${moduleName}"`
+            `compileWeb3Api: Missing SchemaInfo for the module "${moduleName}"`
+          );
+        }
+
+        if (!composed[moduleName]?.schema) {
+          throw Error(
+            `compileWeb3Api: Missing schema for the module "${moduleName}"`
           );
         }
 
         switch (moduleName) {
           case "mutation":
-            this._generateCode(
-              directory,
-              (composed.mutation as SchemaInfo).schema
-            );
+            this._generateCode(directory, composed.mutation?.schema as string);
             break;
           case "query":
-            this._generateCode(
-              directory,
-              (composed.query as SchemaInfo).schema
-            );
+            this._generateCode(directory, composed.query?.schema as string);
             break;
           default:
             throw Error(`Compiler: Unsupported module type "${moduleName}"`);

--- a/packages/cli/src/lib/SchemaComposer.ts
+++ b/packages/cli/src/lib/SchemaComposer.ts
@@ -4,13 +4,18 @@
 import { Project } from "./Project";
 
 import { Manifest, Uri, Web3ApiClient, UriRedirect } from "@web3api/client-js";
-import { composeSchema, ComposerOutput } from "@web3api/schema-compose";
+import {
+  composeSchema,
+  ComposerOutput,
+  ComposerFilter,
+} from "@web3api/schema-compose";
 import { ensPlugin } from "@web3api/ens-plugin-js";
 import { ethereumPlugin } from "@web3api/ethereum-plugin-js";
 import { ipfsPlugin } from "@web3api/ipfs-plugin-js";
 import fs from "fs";
 import path from "path";
 import * as gluegun from "gluegun";
+import { SchemaFile } from "@web3api/schema-compose";
 
 export interface SchemaConfig {
   project: Project;
@@ -67,7 +72,9 @@ export class SchemaComposer {
     this._client = new Web3ApiClient({ redirects });
   }
 
-  public async getComposedSchemas(): Promise<ComposerOutput> {
+  public async getComposedSchemas(
+    output: ComposerFilter = ComposerFilter.All
+  ): Promise<ComposerOutput> {
     if (this._composerOutput) {
       return Promise.resolve(this._composerOutput);
     }
@@ -77,26 +84,24 @@ export class SchemaComposer {
     const manifest = await project.getManifest();
     const querySchemaPath = manifest.query?.schema.file;
     const mutationSchemaPath = manifest.mutation?.schema.file;
+    const getSchema = (schemaPath?: string): SchemaFile | undefined =>
+      schemaPath
+        ? {
+            schema: this._fetchLocalSchema(schemaPath),
+            absolutePath: schemaPath,
+          }
+        : undefined;
 
     this._composerOutput = await composeSchema({
       schemas: {
-        query: querySchemaPath
-          ? {
-              schema: this._fetchLocalSchema(querySchemaPath),
-              absolutePath: querySchemaPath,
-            }
-          : undefined,
-        mutation: mutationSchemaPath
-          ? {
-              schema: this._fetchLocalSchema(mutationSchemaPath),
-              absolutePath: mutationSchemaPath,
-            }
-          : undefined,
+        query: getSchema(querySchemaPath),
+        mutation: getSchema(mutationSchemaPath),
       },
       resolvers: {
         external: (uri: string) => this._fetchExternalSchema(uri, manifest),
         local: (path: string) => Promise.resolve(this._fetchLocalSchema(path)),
       },
+      output,
     });
 
     return this._composerOutput;

--- a/packages/core-apis/api-resolver/schema.graphql
+++ b/packages/core-apis/api-resolver/schema.graphql
@@ -6,7 +6,7 @@ type Query {
 
   getFile(
     path: String!
-  ): Bytes # TODO: https://github.com/web3-api/monorepo/issues/100
+  ): Bytes
 }
 
 type MaybeUriOrManifest {

--- a/packages/js/plugins/ethereum/src/Connection.ts
+++ b/packages/js/plugins/ethereum/src/Connection.ts
@@ -2,7 +2,6 @@ import { Signer, ethers } from "ethers";
 import {
   ExternalProvider,
   JsonRpcProvider,
-  WebSocketProvider,
   Web3Provider,
   Networkish,
 } from "@ethersproject/providers";
@@ -53,7 +52,7 @@ export class Connection {
     return new Connection({
       provider: ethers.providers.getDefaultProvider(
         ethers.providers.getNetwork(networkish)
-      ) as JsonRpcProvider,
+      ) as unknown as JsonRpcProvider,
     });
   }
 
@@ -70,9 +69,9 @@ export class Connection {
     this._config.provider = provider;
 
     if (typeof provider === "string") {
-      this._client = ethers.providers.getDefaultProvider(provider) as
-        | JsonRpcProvider
-        | WebSocketProvider;
+      this._client = ethers.providers.getDefaultProvider(
+        provider
+      ) as unknown as JsonRpcProvider;
     } else {
       if ((provider as JsonRpcProvider).anyNetwork !== undefined) {
         this._client = provider as JsonRpcProvider;

--- a/packages/js/plugins/ethereum/src/Connection.ts
+++ b/packages/js/plugins/ethereum/src/Connection.ts
@@ -50,9 +50,9 @@ export class Connection {
 
   static fromNetwork(networkish: Networkish): Connection {
     return new Connection({
-      provider: ethers.providers.getDefaultProvider(
+      provider: (ethers.providers.getDefaultProvider(
         ethers.providers.getNetwork(networkish)
-      ) as unknown as JsonRpcProvider,
+      ) as unknown) as JsonRpcProvider,
     });
   }
 
@@ -69,9 +69,9 @@ export class Connection {
     this._config.provider = provider;
 
     if (typeof provider === "string") {
-      this._client = ethers.providers.getDefaultProvider(
+      this._client = (ethers.providers.getDefaultProvider(
         provider
-      ) as unknown as JsonRpcProvider;
+      ) as unknown) as JsonRpcProvider;
     } else {
       if ((provider as JsonRpcProvider).anyNetwork !== undefined) {
         this._client = provider as JsonRpcProvider;

--- a/packages/schema/bind/src/__tests__/test-cases.spec.ts
+++ b/packages/schema/bind/src/__tests__/test-cases.spec.ts
@@ -15,7 +15,11 @@ describe("Web3API Binding Test Suite", () => {
           const expectedOutput = readDirectory(directory);
           const output = bindSchema(name as TargetLanguage, test.inputSchema);
 
-          const alphabetical = (a, b) => {
+          interface Named {
+            name: string;
+          }
+
+          const alphabetical = (a: Named, b: Named) => {
             if (a.name < b.name) {
               return -1;
             }

--- a/packages/schema/compose/src/__tests__/index.ts
+++ b/packages/schema/compose/src/__tests__/index.ts
@@ -1,4 +1,4 @@
-import { ComposerOutput, ComposerOptions } from "..";
+import { ComposerOutput, ComposerOptions, ComposerFilter } from "..";
 
 import path from "path";
 import { readdirSync, readFileSync, Dirent, existsSync } from "fs";
@@ -121,6 +121,7 @@ export function fetchTestCases(): TestCases {
           external: resolveExternal,
           local: resolveLocal,
         },
+        output: ComposerFilter.All
       },
       output: {
         query: querySchema && queryTypeInfo ? {

--- a/packages/schema/compose/src/__tests__/index.ts
+++ b/packages/schema/compose/src/__tests__/index.ts
@@ -3,36 +3,46 @@ import { ComposerOutput, ComposerOptions } from "..";
 import path from "path";
 import { readdirSync, readFileSync, Dirent, existsSync } from "fs";
 
-import {GetPathToComposeTestFiles} from "@web3api/test-cases"
+import { TypeInfo } from "@web3api/schema-parse";
+import { GetPathToComposeTestFiles } from "@web3api/test-cases"
 
 const root = GetPathToComposeTestFiles();
 
-export type TestCases = {
+export interface TestCase {
   name: string;
   input: ComposerOptions;
   output: ComposerOutput;
-}[];
+}
+
+type TestCases = {
+  promise: Promise<TestCase | undefined>;
+  name: string;
+}[]
 
 export function fetchTestCases(): TestCases {
-  const cases: TestCases = [];
 
-  const importCase = (dirent: Dirent) => {
+  const importCase = async (dirent: Dirent): Promise<TestCase | undefined> => {
     // The case must be a folder
     if (!dirent.isDirectory()) {
-      return;
+      return undefined;
+    }
+
+    const getFilePath = (
+      subpath: string,
+      absolute = false
+    ): string => {
+      if (absolute) {
+        return subpath
+      } else {
+        return path.join(root, dirent.name, subpath);
+      }
     }
 
     const fetchIfExists = (
       subpath: string,
       absolute = false
     ): string | undefined => {
-      let filePath: string;
-
-      if (absolute) {
-        filePath = subpath;
-      } else {
-        filePath = path.join(root, dirent.name, subpath);
-      }
+      const filePath = getFilePath(subpath, absolute);
 
       if (existsSync(filePath)) {
         return readFileSync(filePath, { encoding: "utf-8" });
@@ -41,14 +51,38 @@ export function fetchTestCases(): TestCases {
       }
     };
 
+    const importIfExists = async (
+      subpath: string,
+      absolute = false
+    ): Promise<TypeInfo | undefined> => {
+      const filePath = getFilePath(subpath, absolute);
+
+      if (existsSync(filePath)) {
+        const module = await import(filePath);
+
+        if (!module.typeInfo) {
+          throw Error(
+            `Required named export "typeInfo" is missing in ${filePath}`
+          );
+        }
+
+        return module.typeInfo as TypeInfo;
+      } else {
+        return undefined;
+      }
+    }
+
     // Fetch the input schemas
     const queryInput = fetchIfExists("input/query.graphql");
     const mutationInput = fetchIfExists("input/mutation.graphql");
 
     // Fetch the output schemas
-    const queryOutput = fetchIfExists("output/query.graphql");
-    const mutationOutput = fetchIfExists("output/mutation.graphql");
-    const schemaOutput = fetchIfExists("output/schema.graphql");
+    const querySchema = fetchIfExists("output/query.graphql");
+    const queryTypeInfo = await importIfExists("output/query.ts");
+    const mutationSchema = fetchIfExists("output/mutation.graphql");
+    const mutationTypeInfo = await importIfExists("output/mutation.ts");
+    const schemaSchema = fetchIfExists("output/schema.graphql");
+    const schemaTypeInfo = await importIfExists("output/schema.ts");
 
     const resolveExternal = (uri: string): Promise<string> => {
       return Promise.resolve(fetchIfExists(`imports-ext/${uri}/schema.graphql`) || "");
@@ -58,7 +92,7 @@ export function fetchTestCases(): TestCases {
       return Promise.resolve(fetchIfExists(path, true) || "");
     };
 
-    cases.push({
+    return {
       name: dirent.name,
       input: {
         schemas: {
@@ -89,14 +123,30 @@ export function fetchTestCases(): TestCases {
         },
       },
       output: {
-        query: queryOutput,
-        mutation: mutationOutput,
-        combined: schemaOutput,
+        query: querySchema && queryTypeInfo ? {
+          schema: querySchema,
+          typeInfo: queryTypeInfo
+        } : undefined,
+        mutation: mutationSchema && mutationTypeInfo ? {
+          schema: mutationSchema,
+          typeInfo: mutationTypeInfo
+        } : undefined,
+        combined: schemaSchema && schemaTypeInfo ? {
+          schema: schemaSchema,
+          typeInfo: schemaTypeInfo
+        } : undefined
       },
-    });
+    };
   };
 
-  readdirSync(root, { withFileTypes: true }).forEach(importCase);
+  const testCases: TestCases = [];
 
-  return cases;
+  readdirSync(root, { withFileTypes: true }).forEach(
+    (value: Dirent) => testCases.push({
+      promise: importCase(value),
+      name: value.name
+    })
+  );
+
+  return testCases;
 }

--- a/packages/schema/compose/src/index.ts
+++ b/packages/schema/compose/src/index.ts
@@ -2,10 +2,7 @@ import { SchemaFile, SchemaResolvers } from "./types";
 import { resolveImportsAndParseSchemas } from "./resolve";
 import { renderSchema } from "./render";
 
-import {
-  TypeInfo,
-  combineTypeInfo,
-} from "@web3api/schema-parse";
+import { TypeInfo, combineTypeInfo } from "@web3api/schema-parse";
 
 export interface ComposerOptions {
   schemas: {
@@ -59,36 +56,33 @@ export async function composeSchema(
   if (results.query) {
     result.query = {
       schema: renderSchema(results.query, true),
-      typeInfo: results.query
+      typeInfo: results.query,
     };
   }
 
   if (results.mutation) {
     result.mutation = {
       schema: renderSchema(results.mutation, true),
-      typeInfo: results.mutation
+      typeInfo: results.mutation,
     };
   }
 
   if (results.query && results.mutation) {
-    const typeInfo = combineTypeInfo([
-      results.query,
-      results.mutation,
-    ]);
+    const typeInfo = combineTypeInfo([results.query, results.mutation]);
 
     result.combined = {
       schema: renderSchema(typeInfo, true),
-      typeInfo
+      typeInfo,
     };
   } else if (results.query) {
     result.combined = {
       schema: renderSchema(results.query, true),
-      typeInfo: results.query
+      typeInfo: results.query,
     };
   } else if (results.mutation) {
     result.combined = {
       schema: renderSchema(results.mutation, true),
-      typeInfo: results.mutation
+      typeInfo: results.mutation,
     };
   }
 

--- a/packages/schema/compose/src/index.ts
+++ b/packages/schema/compose/src/index.ts
@@ -15,10 +15,15 @@ export interface ComposerOptions {
   resolvers: SchemaResolvers;
 }
 
+export interface SchemaInfo {
+  schema: string;
+  typeInfo: TypeInfo;
+}
+
 export interface ComposerOutput {
-  query?: string;
-  mutation?: string;
-  combined?: string;
+  query?: SchemaInfo;
+  mutation?: SchemaInfo;
+  combined?: SchemaInfo;
 }
 
 export async function composeSchema(
@@ -52,11 +57,17 @@ export async function composeSchema(
   const result: ComposerOutput = {};
 
   if (results.query) {
-    result.query = renderSchema(results.query, true);
+    result.query = {
+      schema: renderSchema(results.query, true),
+      typeInfo: results.query
+    };
   }
 
   if (results.mutation) {
-    result.mutation = renderSchema(results.mutation, true);
+    result.mutation = {
+      schema: renderSchema(results.mutation, true),
+      typeInfo: results.mutation
+    };
   }
 
   if (results.query && results.mutation) {
@@ -65,11 +76,20 @@ export async function composeSchema(
       results.mutation,
     ]);
 
-    result.combined = renderSchema(typeInfo, true);
+    result.combined = {
+      schema: renderSchema(typeInfo, true),
+      typeInfo
+    };
   } else if (results.query) {
-    result.combined = renderSchema(results.query, true);
+    result.combined = {
+      schema: renderSchema(results.query, true),
+      typeInfo: results.query
+    };
   } else if (results.mutation) {
-    result.combined = renderSchema(results.mutation, true);
+    result.combined = {
+      schema: renderSchema(results.mutation, true),
+      typeInfo: results.mutation
+    };
   }
 
   return result;

--- a/packages/schema/compose/src/render.ts
+++ b/packages/schema/compose/src/render.ts
@@ -6,13 +6,13 @@ import {
   TypeInfo,
   addFirstLast,
   toGraphQLType,
-  performTransforms
+  performTransforms,
 } from "@web3api/schema-parse";
 
 // Remove mustache's built-in HTML escaping
 Mustache.escape = (value) => value;
 
-export function renderSchema(typeInfo: TypeInfo, header: boolean) {
+export function renderSchema(typeInfo: TypeInfo, header: boolean): string {
   // Prepare the TypeInfo for the renderer
   typeInfo = performTransforms(typeInfo, addFirstLast);
   typeInfo = performTransforms(typeInfo, toGraphQLType);

--- a/packages/schema/compose/src/render.ts
+++ b/packages/schema/compose/src/render.ts
@@ -1,0 +1,30 @@
+import { template as schemaTemplate } from "./templates/schema.mustache";
+import { addHeader } from "./templates/header.mustache";
+
+import Mustache from "mustache";
+import {
+  TypeInfo,
+  addFirstLast,
+  toGraphQLType,
+  performTransforms
+} from "@web3api/schema-parse";
+
+// Remove mustache's built-in HTML escaping
+Mustache.escape = (value) => value;
+
+export function renderSchema(typeInfo: TypeInfo, header: boolean) {
+  // Prepare the TypeInfo for the renderer
+  typeInfo = performTransforms(typeInfo, addFirstLast);
+  typeInfo = performTransforms(typeInfo, toGraphQLType);
+
+  let schema = Mustache.render(schemaTemplate, {
+    typeInfo,
+  });
+
+  if (header) {
+    schema = addHeader(schema);
+  }
+
+  // Remove needless whitespace
+  return schema.replace(/[\n]{2,}/gm, "\n\n");
+}

--- a/packages/schema/compose/src/resolve.ts
+++ b/packages/schema/compose/src/resolve.ts
@@ -34,7 +34,7 @@ import {
   visitImportedEnumDefinition,
   GenericDefinition,
   isKind,
-  header
+  header,
 } from "@web3api/schema-parse";
 
 export async function resolveImportsAndParseSchemas(
@@ -98,9 +98,7 @@ export async function resolveImportsAndParseSchemas(
   newSchema = addQueryImportsDirective(newSchema, externalImports, mutation);
 
   // Parse the newly formed schema, and combine it with the subTypeInfo
-  return parseSchema(
-    header + newSchema + renderSchema(subTypeInfo, false)
-  );
+  return parseSchema(header + newSchema + renderSchema(subTypeInfo, false));
 }
 
 interface Namespaced {

--- a/packages/schema/compose/src/templates/header.mustache.ts
+++ b/packages/schema/compose/src/templates/header.mustache.ts
@@ -1,8 +1,14 @@
 import { header } from "@web3api/schema-parse";
+import Mustache from "mustache";
 
-const template = `${header}
+// Remove mustache's built-in HTML escaping
+Mustache.escape = (value) => value;
+
+export const template = `${header}
 
 {{schema}}
 `;
 
-export { template };
+export function addHeader(schema: string): string {
+  return Mustache.render(template, { schema });
+}

--- a/packages/schema/compose/src/templates/schema.mustache.ts
+++ b/packages/schema/compose/src/templates/schema.mustache.ts
@@ -1,5 +1,26 @@
-const template = `{{schema}}
+const template = `
 {{#typeInfo}}
+{{#queryTypes}}
+type {{type}} {{#imports.length}}@imports(
+  types: [
+    {{#imports}}
+    "{{type}}"{{^last}},{{/last}}
+    {{/imports}}
+  ]
+) {{/imports.length}}{
+  {{#methods}}
+  {{name}}{{#arguments.length}}(
+    {{#arguments}}
+    {{name}}: {{toGraphQLType}}
+    {{/arguments}}
+  ){{/arguments.length}}: {{#return}}{{toGraphQLType}}{{/return}}
+  {{^last}}
+
+  {{/last}}
+  {{/methods}}
+}
+
+{{/queryTypes}}
 {{#objectTypes}}
 type {{type}} {
   {{#properties}}

--- a/packages/schema/parse/src/__tests__/index.ts
+++ b/packages/schema/parse/src/__tests__/index.ts
@@ -1,6 +1,5 @@
 import { TypeInfo } from "../typeInfo";
 
-import { create } from "ts-node";
 import path from "path";
 import { readdirSync, readFileSync, Dirent } from "fs";
 
@@ -21,7 +20,6 @@ export type TestCases = {
 
 export function fetchTestCases(): TestCases {
   const cases: TestCases = [];
-  const _compiler = create();
 
   const importCase = (dirent: Dirent) => {
     // The case must be a folder
@@ -38,7 +36,7 @@ export function fetchTestCases(): TestCases {
     );
 
     // Fetch the output TypeInfo
-    const outputTypeInfo = outputs[dirent.name];
+    const outputTypeInfo = (outputs as any)[dirent.name];
 
     if (!outputTypeInfo) {
       throw Error(

--- a/packages/schema/parse/src/__tests__/transforms.spec.ts
+++ b/packages/schema/parse/src/__tests__/transforms.spec.ts
@@ -81,6 +81,8 @@ describe("Web3API Schema TypeInfo Transformations", () => {
       transforms: [addFirstLast],
     });
     const expected: TypeInfo = {
+      enumTypes: [],
+      importedEnumTypes: [],
       objectTypes: [
         {
           ...createObjectDefinition({ type: "MyType" }),
@@ -336,6 +338,8 @@ describe("Web3API Schema TypeInfo Transformations", () => {
       ],
     });
     const expected: TypeInfo = {
+      enumTypes: [],
+      importedEnumTypes: [],
       objectTypes: [
         {
           ...createObjectDefinition({ type: "MyType" }),

--- a/packages/schema/parse/src/extract/imported-query-types.ts
+++ b/packages/schema/parse/src/extract/imported-query-types.ts
@@ -67,7 +67,7 @@ const visitorEnter = (
     const method = createMethodDefinition({
       type: importDef.nativeType,
       name: node.name.value,
-      return: returnType
+      return: returnType,
     });
     importDef.methods.push(method);
     state.currentMethod = method;

--- a/packages/schema/parse/src/extract/imported-query-types.ts
+++ b/packages/schema/parse/src/extract/imported-query-types.ts
@@ -3,6 +3,7 @@ import {
   ImportedQueryDefinition,
   createImportedQueryDefinition,
   createMethodDefinition,
+  createPropertyDefinition,
 } from "../typeInfo";
 import {
   extractInputValueDefinition,
@@ -58,12 +59,19 @@ const visitorEnter = (
       );
     }
 
+    const returnType = createPropertyDefinition({
+      type: "N/A",
+      name: node.name.value,
+    });
+
     const method = createMethodDefinition({
       type: importDef.nativeType,
       name: node.name.value,
+      return: returnType
     });
     importDef.methods.push(method);
     state.currentMethod = method;
+    state.currentReturn = returnType;
   },
   InputValueDefinition: (node: InputValueDefinitionNode) => {
     extractInputValueDefinition(node, state);

--- a/packages/schema/parse/src/extract/query-types-utils.ts
+++ b/packages/schema/parse/src/extract/query-types-utils.ts
@@ -54,14 +54,7 @@ export function extractNamedType(
     state.nonNullType = false;
   } else if (method) {
     // Return value
-    if (!method.return) {
-      method.return = createPropertyDefinition({
-        type: "N/A",
-        name: method.name,
-      });
-
-      state.currentReturn = method.return;
-    } else if (!state.currentReturn) {
+    if (!state.currentReturn) {
       state.currentReturn = method.return;
     }
 

--- a/packages/schema/parse/src/extract/query-types.ts
+++ b/packages/schema/parse/src/extract/query-types.ts
@@ -24,7 +24,7 @@ import {
   visit,
   DirectiveNode,
   ArgumentNode,
-  ValueNode
+  ValueNode,
 } from "graphql";
 
 const visitorEnter = (
@@ -90,7 +90,7 @@ const visitorEnter = (
 
     const query = createQueryDefinition({
       type: nodeName,
-      imports
+      imports,
     });
     queryTypes.push(query);
     state.currentQuery = query;
@@ -110,7 +110,7 @@ const visitorEnter = (
     const method = createMethodDefinition({
       type: query.type,
       name: node.name.value,
-      return: returnType
+      return: returnType,
     });
     query.methods.push(method);
     state.currentMethod = method;

--- a/packages/schema/parse/src/transform/addFirstLast.ts
+++ b/packages/schema/parse/src/transform/addFirstLast.ts
@@ -27,7 +27,7 @@ export const addFirstLast: TypeInfoTransforms = {
     QueryDefinition: (def: QueryDefinition) => ({
       ...def,
       methods: setFirstLast(def.methods),
-      imports: setFirstLast(def.imports)
+      imports: setFirstLast(def.imports),
     }),
     ImportedQueryDefinition: (def: ImportedQueryDefinition) => ({
       ...def,

--- a/packages/schema/parse/src/transform/addFirstLast.ts
+++ b/packages/schema/parse/src/transform/addFirstLast.ts
@@ -27,6 +27,7 @@ export const addFirstLast: TypeInfoTransforms = {
     QueryDefinition: (def: QueryDefinition) => ({
       ...def,
       methods: setFirstLast(def.methods),
+      imports: setFirstLast(def.imports)
     }),
     ImportedQueryDefinition: (def: ImportedQueryDefinition) => ({
       ...def,

--- a/packages/schema/parse/src/typeInfo/definitions.ts
+++ b/packages/schema/parse/src/typeInfo/definitions.ts
@@ -218,13 +218,13 @@ export function createObjectPropertyDefinition(args: {
 export interface MethodDefinition extends GenericDefinition {
   type: OperationType;
   arguments: PropertyDefinition[];
-  return: PropertyDefinition | null;
+  return: PropertyDefinition;
 }
 export function createMethodDefinition(args: {
   type: string;
   name: string;
   arguments?: PropertyDefinition[];
-  return?: PropertyDefinition;
+  return: PropertyDefinition;
 }): MethodDefinition {
   const lowercase = args.type.toLowerCase();
   if (!isOperationType(lowercase)) {
@@ -237,7 +237,7 @@ export function createMethodDefinition(args: {
     type: lowercase,
     required: true,
     arguments: args.arguments ? args.arguments : [],
-    return: args.return ? args.return : null,
+    return: args.return,
     kind: DefinitionKind.Method,
   };
 }
@@ -245,9 +245,11 @@ export function createMethodDefinition(args: {
 export interface QueryDefinition extends GenericDefinition {
   type: QueryType;
   methods: MethodDefinition[];
+  imports: { type: string }[];
 }
 export function createQueryDefinition(args: {
   type: string;
+  imports?: { type: string }[];
   required?: boolean;
 }): QueryDefinition {
   if (!isQueryType(args.type)) {
@@ -260,6 +262,7 @@ export function createQueryDefinition(args: {
     ...createGenericDefinition(args),
     type: args.type,
     methods: [],
+    imports: args.imports ? args.imports : [],
     kind: DefinitionKind.Query,
   };
 }

--- a/packages/test-cases/cases/compose/local-imports/output/mutation.ts
+++ b/packages/test-cases/cases/compose/local-imports/output/mutation.ts
@@ -1,0 +1,211 @@
+import {
+  createArrayPropertyDefinition,
+  createMethodDefinition,
+  createQueryDefinition,
+  createScalarDefinition,
+  createScalarPropertyDefinition,
+  createArrayDefinition,
+  createObjectPropertyDefinition,
+  createObjectDefinition,
+  createEnumDefinition,
+  TypeInfo,
+  createEnumPropertyDefinition
+} from "@web3api/schema-parse";
+
+export const typeInfo: TypeInfo = {
+  importedObjectTypes: [],
+  importedEnumTypes: [],
+  importedQueryTypes: [],
+  queryTypes: [
+    {
+      ...createQueryDefinition({ type: "Mutation" }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        }
+      ]
+    }
+  ],
+  objectTypes: [
+    {
+      ...createObjectDefinition({ type: "CustomMutationType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
+        createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
+        createScalarPropertyDefinition({ name: "u", type: "UInt", required: true }),
+        createScalarPropertyDefinition({ name: "optU", type: "UInt", required: false }),
+        createScalarPropertyDefinition({ name: "u8", type: "UInt8", required: true }),
+        createScalarPropertyDefinition({ name: "u64", type: "UInt64", required: true }),
+        createScalarPropertyDefinition({ name: "i", type: "Int", required: true }),
+        createScalarPropertyDefinition({ name: "i8", type: "Int8", required: true }),
+        createScalarPropertyDefinition({ name: "i64", type: "Int64", required: true }),
+        createScalarPropertyDefinition({ name: "bytes", type: "Bytes", required: true }),
+        createArrayPropertyDefinition({
+          name: "uArray",
+          type: "[UInt]",
+          required: true,
+          item: createScalarDefinition({ name: "uArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "uOptArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "optStrOptArray",
+          type: "[String]",
+          required: false,
+          item: createScalarDefinition({ name: "optStrOptArray", type: "String", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "crazyArray",
+          type: "[[[[UInt64]]]]",
+          required: false,
+          item: createArrayDefinition({
+            name: "crazyArray",
+            type: "[[[UInt64]]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "crazyArray",
+              type: "[[UInt64]]",
+              required: true,
+              item: createArrayDefinition({
+                name: "crazyArray",
+                type: "[UInt64]",
+                required: false,
+                item: createScalarDefinition({ name: "crazyArray", type: "UInt64", required: true })
+              })
+            })
+          })
+        }),
+        createObjectPropertyDefinition({
+          name: "commonType",
+          type: "CommonType",
+          required: true
+        }),
+      ],
+    },
+    {
+      ...createObjectDefinition({ type: "AnotherMutationType" }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String" })],
+    },
+    {
+      ...createObjectDefinition({ type: "CommonType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "UInt8", required: true }),
+        createObjectPropertyDefinition({ name: "nestedObject", type: "NestedType", required: true }),
+        createArrayPropertyDefinition({
+          name: "objectArray",
+          type: "[[ArrayObject]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "objectArray",
+            type: "[ArrayObject]",
+            required: false,
+            item: createObjectDefinition({
+              name: "objectArray",
+              type: "ArrayObject",
+              required: false
+            })
+          })
+        }),
+        createEnumPropertyDefinition({
+          name: "enum",
+          type: "CommonEnum",
+          required: true
+        })
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "NestedType"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "ArrayObject"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    }
+  ],
+  enumTypes: [
+    createEnumDefinition({
+      type: "CommonEnum",
+      constants: ["STRING", "BYTES"]
+    })
+  ]
+}

--- a/packages/test-cases/cases/compose/local-imports/output/query.ts
+++ b/packages/test-cases/cases/compose/local-imports/output/query.ts
@@ -1,0 +1,211 @@
+import {
+  createArrayPropertyDefinition,
+  createMethodDefinition,
+  createQueryDefinition,
+  createScalarDefinition,
+  createScalarPropertyDefinition,
+  createArrayDefinition,
+  createObjectPropertyDefinition,
+  createObjectDefinition,
+  createEnumDefinition,
+  TypeInfo,
+  createEnumPropertyDefinition
+} from "@web3api/schema-parse";
+
+export const typeInfo: TypeInfo = {
+  objectTypes: [
+    {
+      ...createObjectDefinition({ type: "CustomQueryType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
+        createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
+        createScalarPropertyDefinition({ name: "u", type: "UInt", required: true }),
+        createScalarPropertyDefinition({ name: "optU", type: "UInt", required: false }),
+        createScalarPropertyDefinition({ name: "u8", type: "UInt8", required: true }),
+        createScalarPropertyDefinition({ name: "u64", type: "UInt64", required: true }),
+        createScalarPropertyDefinition({ name: "i", type: "Int", required: true }),
+        createScalarPropertyDefinition({ name: "i8", type: "Int8", required: true }),
+        createScalarPropertyDefinition({ name: "i64", type: "Int64", required: true }),
+        createScalarPropertyDefinition({ name: "bytes", type: "Bytes", required: true }),
+        createArrayPropertyDefinition({
+          name: "uArray",
+          type: "[UInt]",
+          required: true,
+          item: createScalarDefinition({ name: "uArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "uOptArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "optStrOptArray",
+          type: "[String]",
+          required: false,
+          item: createScalarDefinition({ name: "optStrOptArray", type: "String", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "crazyArray",
+          type: "[[[[UInt64]]]]",
+          required: false,
+          item: createArrayDefinition({
+            name: "crazyArray",
+            type: "[[[UInt64]]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "crazyArray",
+              type: "[[UInt64]]",
+              required: true,
+              item: createArrayDefinition({
+                name: "crazyArray",
+                type: "[UInt64]",
+                required: false,
+                item: createScalarDefinition({ name: "crazyArray", type: "UInt64", required: true })
+              })
+            })
+          })
+        }),
+        createObjectPropertyDefinition({
+          name: "commonType",
+          type: "CommonType",
+          required: true
+        }),
+      ],
+    },
+    {
+      ...createObjectDefinition({ type: "AnotherQueryType" }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String" })],
+    },
+    {
+      ...createObjectDefinition({ type: "CommonType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "UInt8", required: true }),
+        createObjectPropertyDefinition({ name: "nestedObject", type: "NestedType", required: true }),
+        createArrayPropertyDefinition({
+          name: "objectArray",
+          type: "[[ArrayObject]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "objectArray",
+            type: "[ArrayObject]",
+            required: false,
+            item: createObjectDefinition({
+              name: "objectArray",
+              type: "ArrayObject",
+              required: false
+            })
+          })
+        }),
+        createEnumPropertyDefinition({
+          name: "enum",
+          type: "CommonEnum",
+          required: true
+        })
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "NestedType"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "ArrayObject"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    }
+  ],
+  queryTypes: [
+    {
+      ...createQueryDefinition({ type: "Query" }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        }
+      ]
+    }
+  ],
+  enumTypes: [
+    createEnumDefinition({
+      type: "CommonEnum",
+      constants: ["STRING", "BYTES"]
+    })
+  ],
+  importedObjectTypes: [],
+  importedQueryTypes: [],
+  importedEnumTypes: [],
+}

--- a/packages/test-cases/cases/compose/local-imports/output/schema.graphql
+++ b/packages/test-cases/cases/compose/local-imports/output/schema.graphql
@@ -35,6 +35,19 @@ type Query {
   ): [Int64!]!
 }
 
+type Mutation {
+  method1(
+    str: String!
+    optStr: String
+    u: UInt!
+    uArrayArray: [[UInt]]!
+  ): String!
+
+  method2(
+    arg: [String!]!
+  ): [Int64!]!
+}
+
 type CustomQueryType {
   str: String!
   optStr: String
@@ -57,17 +70,19 @@ type AnotherQueryType {
   prop: String
 }
 
-type Mutation {
-  method1(
-    str: String!
-    optStr: String
-    u: UInt!
-    uArrayArray: [[UInt]]!
-  ): String!
+type CommonType {
+  prop: UInt8!
+  nestedObject: NestedType!
+  objectArray: [[ArrayObject]]!
+  enum: CommonEnum!
+}
 
-  method2(
-    arg: [String!]!
-  ): [Int64!]!
+type NestedType {
+  prop: String!
+}
+
+type ArrayObject {
+  prop: String!
 }
 
 type CustomMutationType {
@@ -90,21 +105,6 @@ type CustomMutationType {
 
 type AnotherMutationType {
   prop: String
-}
-
-type CommonType {
-  prop: UInt8!
-  nestedObject: NestedType!
-  objectArray: [[ArrayObject]]!
-  enum: CommonEnum!
-}
-
-type NestedType {
-  prop: String!
-}
-
-type ArrayObject {
-  prop: String!
 }
 
 enum CommonEnum {

--- a/packages/test-cases/cases/compose/local-imports/output/schema.ts
+++ b/packages/test-cases/cases/compose/local-imports/output/schema.ts
@@ -1,0 +1,350 @@
+import {
+  createArrayPropertyDefinition,
+  createMethodDefinition,
+  createQueryDefinition,
+  createScalarDefinition,
+  createScalarPropertyDefinition,
+  createArrayDefinition,
+  createObjectPropertyDefinition,
+  createObjectDefinition,
+  createEnumDefinition,
+  TypeInfo,
+  createEnumPropertyDefinition
+} from "@web3api/schema-parse";
+
+export const typeInfo: TypeInfo = {
+  importedObjectTypes: [],
+  importedEnumTypes: [],
+  importedQueryTypes: [],
+  queryTypes: [
+    {
+      ...createQueryDefinition({ type: "Query" }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        }
+      ]
+    },
+    {
+      ...createQueryDefinition({ type: "Mutation" }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        }
+      ]
+    }
+  ],
+  objectTypes: [
+    {
+      ...createObjectDefinition({ type: "CustomQueryType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
+        createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
+        createScalarPropertyDefinition({ name: "u", type: "UInt", required: true }),
+        createScalarPropertyDefinition({ name: "optU", type: "UInt", required: false }),
+        createScalarPropertyDefinition({ name: "u8", type: "UInt8", required: true }),
+        createScalarPropertyDefinition({ name: "u64", type: "UInt64", required: true }),
+        createScalarPropertyDefinition({ name: "i", type: "Int", required: true }),
+        createScalarPropertyDefinition({ name: "i8", type: "Int8", required: true }),
+        createScalarPropertyDefinition({ name: "i64", type: "Int64", required: true }),
+        createScalarPropertyDefinition({ name: "bytes", type: "Bytes", required: true }),
+        createArrayPropertyDefinition({
+          name: "uArray",
+          type: "[UInt]",
+          required: true,
+          item: createScalarDefinition({ name: "uArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "uOptArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "optStrOptArray",
+          type: "[String]",
+          required: false,
+          item: createScalarDefinition({ name: "optStrOptArray", type: "String", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "crazyArray",
+          type: "[[[[UInt64]]]]",
+          required: false,
+          item: createArrayDefinition({
+            name: "crazyArray",
+            type: "[[[UInt64]]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "crazyArray",
+              type: "[[UInt64]]",
+              required: true,
+              item: createArrayDefinition({
+                name: "crazyArray",
+                type: "[UInt64]",
+                required: false,
+                item: createScalarDefinition({ name: "crazyArray", type: "UInt64", required: true })
+              })
+            })
+          })
+        }),
+        createObjectPropertyDefinition({
+          name: "commonType",
+          type: "CommonType",
+          required: true
+        }),
+      ],
+    },
+    {
+      ...createObjectDefinition({ type: "AnotherQueryType" }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String" })],
+    },
+    {
+      ...createObjectDefinition({ type: "CommonType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "UInt8", required: true }),
+        createObjectPropertyDefinition({ name: "nestedObject", type: "NestedType", required: true }),
+        createArrayPropertyDefinition({
+          name: "objectArray",
+          type: "[[ArrayObject]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "objectArray",
+            type: "[ArrayObject]",
+            required: false,
+            item: createObjectDefinition({
+              name: "objectArray",
+              type: "ArrayObject",
+              required: false
+            })
+          })
+        }),
+        createEnumPropertyDefinition({
+          name: "enum",
+          type: "CommonEnum",
+          required: true
+        })
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "NestedType"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "ArrayObject"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    },
+    {
+      ...createObjectDefinition({ type: "CustomMutationType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
+        createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
+        createScalarPropertyDefinition({ name: "u", type: "UInt", required: true }),
+        createScalarPropertyDefinition({ name: "optU", type: "UInt", required: false }),
+        createScalarPropertyDefinition({ name: "u8", type: "UInt8", required: true }),
+        createScalarPropertyDefinition({ name: "u64", type: "UInt64", required: true }),
+        createScalarPropertyDefinition({ name: "i", type: "Int", required: true }),
+        createScalarPropertyDefinition({ name: "i8", type: "Int8", required: true }),
+        createScalarPropertyDefinition({ name: "i64", type: "Int64", required: true }),
+        createScalarPropertyDefinition({ name: "bytes", type: "Bytes", required: true }),
+        createArrayPropertyDefinition({
+          name: "uArray",
+          type: "[UInt]",
+          required: true,
+          item: createScalarDefinition({ name: "uArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "uOptArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "optStrOptArray",
+          type: "[String]",
+          required: false,
+          item: createScalarDefinition({ name: "optStrOptArray", type: "String", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "crazyArray",
+          type: "[[[[UInt64]]]]",
+          required: false,
+          item: createArrayDefinition({
+            name: "crazyArray",
+            type: "[[[UInt64]]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "crazyArray",
+              type: "[[UInt64]]",
+              required: true,
+              item: createArrayDefinition({
+                name: "crazyArray",
+                type: "[UInt64]",
+                required: false,
+                item: createScalarDefinition({ name: "crazyArray", type: "UInt64", required: true })
+              })
+            })
+          })
+        }),
+        createObjectPropertyDefinition({
+          name: "commonType",
+          type: "CommonType",
+          required: true
+        }),
+      ],
+    },
+    {
+      ...createObjectDefinition({ type: "AnotherMutationType" }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String" })],
+    },
+  ],
+  enumTypes: [
+    createEnumDefinition({
+      type: "CommonEnum",
+      constants: ["STRING", "BYTES"]
+    })
+  ]
+}

--- a/packages/test-cases/cases/compose/sanity/output/mutation.ts
+++ b/packages/test-cases/cases/compose/sanity/output/mutation.ts
@@ -1,0 +1,721 @@
+import {
+  createArrayPropertyDefinition,
+  createMethodDefinition,
+  createQueryDefinition,
+  createScalarDefinition,
+  createScalarPropertyDefinition,
+  createArrayDefinition,
+  createObjectPropertyDefinition,
+  createObjectDefinition,
+  TypeInfo,
+  createEnumPropertyDefinition,
+  createImportedQueryDefinition,
+  createImportedObjectDefinition,
+  createImportedEnumDefinition
+} from "@web3api/schema-parse";
+
+export const typeInfo: TypeInfo = {
+  enumTypes: [],
+  queryTypes: [
+    {
+      ...createQueryDefinition({ type: "Mutation" }),
+      imports: [
+        { type: "Namespace_Query" },
+        { type: "Namespace_Mutation" },
+        { type: "Namespace_NestedObjectType" },
+        { type: "Namespace_ObjectType" },
+        { type: "Namespace_Imported_NestedObjectType" },
+        { type: "Namespace_Imported_ObjectType" },
+        { type: "Namespace_CustomType" },
+        { type: "Namespace_CustomEnum" },
+        { type: "Namespace_Imported_Enum" },
+        { type: "JustMutation_Mutation" },
+      ],
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        }
+      ]
+    }
+  ],
+  objectTypes: [
+    {
+      ...createObjectDefinition({ type: "CustomMutationType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
+        createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
+        createScalarPropertyDefinition({ name: "u", type: "UInt", required: true }),
+        createScalarPropertyDefinition({ name: "optU", type: "UInt", required: false }),
+        createScalarPropertyDefinition({ name: "u8", type: "UInt8", required: true }),
+        createScalarPropertyDefinition({ name: "u64", type: "UInt64", required: true }),
+        createScalarPropertyDefinition({ name: "i", type: "Int", required: true }),
+        createScalarPropertyDefinition({ name: "i8", type: "Int8", required: true }),
+        createScalarPropertyDefinition({ name: "i64", type: "Int64", required: true }),
+        createScalarPropertyDefinition({ name: "bytes", type: "Bytes", required: true }),
+        createArrayPropertyDefinition({
+          name: "uArray",
+          type: "[UInt]",
+          required: true,
+          item: createScalarDefinition({ name: "uArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "uOptArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "optStrOptArray",
+          type: "[String]",
+          required: false,
+          item: createScalarDefinition({ name: "optStrOptArray", type: "String", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "crazyArray",
+          type: "[[[[UInt64]]]]",
+          required: false,
+          item: createArrayDefinition({
+            name: "crazyArray",
+            type: "[[[UInt64]]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "crazyArray",
+              type: "[[UInt64]]",
+              required: true,
+              item: createArrayDefinition({
+                name: "crazyArray",
+                type: "[UInt64]",
+                required: false,
+                item: createScalarDefinition({ name: "crazyArray", type: "UInt64", required: true })
+              })
+            })
+          })
+        }),
+        createObjectPropertyDefinition({
+          name: "commonType",
+          type: "CommonType",
+          required: true
+        }),
+        createObjectPropertyDefinition({
+          name: "customType",
+          type: "Namespace_CustomType",
+          required: true,
+        })
+      ],
+    },
+    {
+      ...createObjectDefinition({ type: "AnotherMutationType" }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String" })],
+    },
+    {
+      ...createObjectDefinition({ type: "CommonType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "UInt8", required: true }),
+        createObjectPropertyDefinition({ name: "nestedObject", type: "NestedType", required: true }),
+        createArrayPropertyDefinition({
+          name: "objectArray",
+          type: "[[ArrayObject]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "objectArray",
+            type: "[ArrayObject]",
+            required: false,
+            item: createObjectDefinition({
+              name: "objectArray",
+              type: "ArrayObject",
+              required: false
+            })
+          })
+        })
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "NestedType"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "ArrayObject"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    }
+  ],
+  importedQueryTypes: [
+    {
+      ...createImportedQueryDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Query",
+        type: "Namespace_Query"
+      }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createScalarPropertyDefinition({
+              name: "optU",
+              required: false,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        }
+      ]
+    },
+    {
+      ...createImportedQueryDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Mutation",
+        type: "Namespace_Mutation"
+      }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createScalarPropertyDefinition({
+              name: "optU",
+              required: false,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "localObjects",
+            return: createObjectPropertyDefinition({
+              name: "localObjects",
+              type: "Namespace_NestedObjectType",
+              required: false
+            })
+          }),
+          arguments: [
+            createObjectPropertyDefinition({
+              name: "nestedLocalObject",
+              required: false,
+              type: "Namespace_NestedObjectType"
+            }),
+            createArrayPropertyDefinition({
+              name: "localObjectArray",
+              required: false,
+              type: "[Namespace_NestedObjectType]",
+              item: createObjectDefinition({
+                name: "localObjectArray",
+                required: true,
+                type: "Namespace_NestedObjectType"
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "importedObjects",
+            return: createObjectPropertyDefinition({
+              name: "importedObjects",
+              type: "Namespace_Imported_NestedObjectType",
+              required: false
+            })
+          }),
+          arguments: [
+            createObjectPropertyDefinition({
+              name: "nestedLocalObject",
+              required: false,
+              type: "Namespace_Imported_NestedObjectType"
+            }),
+            createArrayPropertyDefinition({
+              name: "localObjectArray",
+              required: false,
+              type: "[Namespace_Imported_NestedObjectType]",
+              item: createObjectDefinition({
+                name: "localObjectArray",
+                required: true,
+                type: "Namespace_Imported_NestedObjectType"
+              })
+            })
+          ]
+        },
+      ]
+    },
+    {
+      ...createImportedQueryDefinition({
+        uri: "just.mutation.eth",
+        namespace: "JustMutation",
+        nativeType: "Mutation",
+        type: "JustMutation_Mutation"
+      }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method",
+            return: createArrayPropertyDefinition({
+              name: "method",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method",
+                type: "Int64",
+                required: true
+              })
+            }),
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        },
+      ]
+    },
+  ],
+  importedObjectTypes: [
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "NestedObjectType",
+        type: "Namespace_NestedObjectType"
+      }),
+      properties: [createObjectPropertyDefinition({ name: "nestedObject", type: "Namespace_ObjectType", required: true })],
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "ObjectType",
+        type: "Namespace_ObjectType"
+      }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String", required: true })],
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Imported_NestedObjectType",
+        type: "Namespace_Imported_NestedObjectType"
+      }),
+      properties: [createObjectPropertyDefinition({ name: "nestedObject", type: "Namespace_Imported_ObjectType", required: true })],
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Imported_ObjectType",
+        type: "Namespace_Imported_ObjectType"
+      }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String", required: true })],
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "CustomType",
+        type: "Namespace_CustomType"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
+        createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
+        createScalarPropertyDefinition({ name: "u", type: "UInt", required: true }),
+        createScalarPropertyDefinition({ name: "optU", type: "UInt", required: false }),
+        createScalarPropertyDefinition({ name: "u8", type: "UInt8", required: true }),
+        createScalarPropertyDefinition({ name: "u16", type: "UInt16", required: true }),
+        createScalarPropertyDefinition({ name: "u32", type: "UInt32", required: true }),
+        createScalarPropertyDefinition({ name: "u64", type: "UInt64", required: true }),
+        createScalarPropertyDefinition({ name: "i", type: "Int", required: true }),
+        createScalarPropertyDefinition({ name: "i8", type: "Int8", required: true }),
+        createScalarPropertyDefinition({ name: "i16", type: "Int16", required: true }),
+        createScalarPropertyDefinition({ name: "i32", type: "Int32", required: true }),
+        createScalarPropertyDefinition({ name: "i64", type: "Int64", required: true }),
+        createScalarPropertyDefinition({ name: "bytes", type: "Bytes", required: true }),
+        createArrayPropertyDefinition({
+          name: "uArray",
+          type: "[UInt]",
+          required: true,
+          item: createScalarDefinition({ name: "uArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "uOptArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "optUOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "optUOptArray", type: "UInt", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "optStrOptArray",
+          type: "[String]",
+          required: false,
+          item: createScalarDefinition({ name: "optStrOptArray", type: "String", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "uArrayArray",
+          type: "[[UInt]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "uArrayArray",
+            type: "[UInt]",
+            required: true,
+            item: createScalarDefinition({ name: "uArrayArray", type: "UInt", required: true })
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArrayOptArray",
+          type: "[[UInt64]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "uOptArrayOptArray",
+            type: "[UInt64]",
+            required: false,
+            item: createScalarDefinition({ name: "uOptArrayOptArray", type: "UInt64", required: false })
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "uArrayOptArrayArray",
+          type: "[[[UInt64]]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "uArrayOptArrayArray",
+            type: "[[UInt64]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "uArrayOptArrayArray",
+              type: "[UInt64]",
+              required: true,
+              item: createScalarDefinition({ name: "uArrayOptArrayArray", type: "UInt64", required: true })
+            })
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "crazyArray",
+          type: "[[[[UInt64]]]]",
+          required: false,
+          item: createArrayDefinition({
+            name: "crazyArray",
+            type: "[[[UInt64]]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "crazyArray",
+              type: "[[UInt64]]",
+              required: true,
+              item: createArrayDefinition({
+                name: "crazyArray",
+                type: "[UInt64]",
+                required: false,
+                item: createScalarDefinition({ name: "crazyArray", type: "UInt64", required: true })
+              })
+            })
+          })
+        }),
+        createObjectPropertyDefinition({
+          name: "object",
+          type: "Namespace_ObjectType",
+          required: true
+        }),
+        createObjectPropertyDefinition({
+          name: "optObject",
+          type: "Namespace_ObjectType",
+          required: false
+        }),
+        createObjectPropertyDefinition({
+          name: "nestedObject",
+          type: "Namespace_NestedObjectType",
+          required: true
+        }),
+        createObjectPropertyDefinition({
+          name: "optNestedObject",
+          type: "Namespace_NestedObjectType",
+          required: false
+        }),
+        createArrayPropertyDefinition({
+          name: "optNestedObjectArray",
+          type: "[Namespace_NestedObjectType]",
+          required: true,
+          item: createObjectDefinition({
+            name: "optNestedObjectArray",
+            type: "Namespace_NestedObjectType",
+            required: false
+          }),
+        }),
+        createObjectPropertyDefinition({
+          name: "importedNestedObject",
+          type: "Namespace_Imported_NestedObjectType",
+          required: true
+        }),
+        createArrayPropertyDefinition({
+          name: "optImportedNestedObjectArray",
+          type: "[Namespace_Imported_NestedObjectType]",
+          required: true,
+          item: createObjectDefinition({
+            name: "optImportedNestedObjectArray",
+            type: "Namespace_Imported_NestedObjectType",
+            required: false
+          }),
+        }),
+        createEnumPropertyDefinition({
+          name: "enum",
+          type: "Namespace_CustomEnum",
+          required: true
+        }),
+        createEnumPropertyDefinition({
+          name: "optEnum",
+          type: "Namespace_CustomEnum",
+          required: false
+        }),
+        createEnumPropertyDefinition({
+          name: "importedEnum",
+          type: "Namespace_Imported_Enum",
+          required: true
+        }),
+        createEnumPropertyDefinition({
+          name: "optImportedEnum",
+          type: "Namespace_Imported_Enum",
+          required: false
+        }),
+      ]
+    },
+  ],
+  importedEnumTypes: [
+    {
+      ...createImportedEnumDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "CustomEnum",
+        type: "Namespace_CustomEnum",
+        constants: [
+          "STRING",
+          "BYTES"
+        ]
+      })
+    },
+    {
+      ...createImportedEnumDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Imported_Enum",
+        type: "Namespace_Imported_Enum",
+        constants: [
+          "STRING",
+          "BYTES"
+        ]
+      })
+    }
+  ],
+}

--- a/packages/test-cases/cases/compose/sanity/output/query.ts
+++ b/packages/test-cases/cases/compose/sanity/output/query.ts
@@ -1,0 +1,539 @@
+import {
+  createArrayPropertyDefinition,
+  createMethodDefinition,
+  createQueryDefinition,
+  createScalarDefinition,
+  createScalarPropertyDefinition,
+  createArrayDefinition,
+  createObjectPropertyDefinition,
+  createObjectDefinition,
+  TypeInfo,
+  createEnumPropertyDefinition,
+  createImportedQueryDefinition,
+  createImportedObjectDefinition,
+  createImportedEnumDefinition
+} from "@web3api/schema-parse";
+
+export const typeInfo: TypeInfo = {
+  objectTypes: [
+    {
+      ...createObjectDefinition({ type: "CustomQueryType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
+        createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
+        createScalarPropertyDefinition({ name: "u", type: "UInt", required: true }),
+        createScalarPropertyDefinition({ name: "optU", type: "UInt", required: false }),
+        createScalarPropertyDefinition({ name: "u8", type: "UInt8", required: true }),
+        createScalarPropertyDefinition({ name: "u64", type: "UInt64", required: true }),
+        createScalarPropertyDefinition({ name: "i", type: "Int", required: true }),
+        createScalarPropertyDefinition({ name: "i8", type: "Int8", required: true }),
+        createScalarPropertyDefinition({ name: "i64", type: "Int64", required: true }),
+        createScalarPropertyDefinition({ name: "bytes", type: "Bytes", required: true }),
+        createArrayPropertyDefinition({
+          name: "uArray",
+          type: "[UInt]",
+          required: true,
+          item: createScalarDefinition({ name: "uArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "uOptArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "optStrOptArray",
+          type: "[String]",
+          required: false,
+          item: createScalarDefinition({ name: "optStrOptArray", type: "String", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "crazyArray",
+          type: "[[[[UInt64]]]]",
+          required: false,
+          item: createArrayDefinition({
+            name: "crazyArray",
+            type: "[[[UInt64]]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "crazyArray",
+              type: "[[UInt64]]",
+              required: true,
+              item: createArrayDefinition({
+                name: "crazyArray",
+                type: "[UInt64]",
+                required: false,
+                item: createScalarDefinition({ name: "crazyArray", type: "UInt64", required: true })
+              })
+            })
+          })
+        }),
+        createObjectPropertyDefinition({
+          name: "commonType",
+          type: "CommonType",
+          required: true
+        }),
+        createObjectPropertyDefinition({
+          name: "customType",
+          type: "Namespace_CustomType",
+          required: true,
+        })
+      ],
+    },
+    {
+      ...createObjectDefinition({ type: "AnotherQueryType" }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String" })],
+    },
+    {
+      ...createObjectDefinition({ type: "CommonType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "UInt8", required: true }),
+        createObjectPropertyDefinition({ name: "nestedObject", type: "NestedType", required: true }),
+        createArrayPropertyDefinition({
+          name: "objectArray",
+          type: "[[ArrayObject]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "objectArray",
+            type: "[ArrayObject]",
+            required: false,
+            item: createObjectDefinition({
+              name: "objectArray",
+              type: "ArrayObject",
+              required: false
+            })
+          })
+        })
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "NestedType"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "ArrayObject"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    }
+  ],
+  queryTypes: [
+    {
+      ...createQueryDefinition({ type: "Query" }),
+      imports: [
+        { type: "Namespace_Query" },
+        { type: "Namespace_CustomType" },
+        { type: "Namespace_ObjectType" },
+        { type: "Namespace_NestedObjectType" },
+        { type: "Namespace_Imported_NestedObjectType" },
+        { type: "Namespace_Imported_ObjectType" },
+        { type: "Namespace_CustomEnum" },
+        { type: "Namespace_Imported_Enum" },
+      ],
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        }
+      ]
+    }
+  ],
+  enumTypes: [],
+  importedObjectTypes: [
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "CustomType",
+        type: "Namespace_CustomType"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
+        createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
+        createScalarPropertyDefinition({ name: "u", type: "UInt", required: true }),
+        createScalarPropertyDefinition({ name: "optU", type: "UInt", required: false }),
+        createScalarPropertyDefinition({ name: "u8", type: "UInt8", required: true }),
+        createScalarPropertyDefinition({ name: "u16", type: "UInt16", required: true }),
+        createScalarPropertyDefinition({ name: "u32", type: "UInt32", required: true }),
+        createScalarPropertyDefinition({ name: "u64", type: "UInt64", required: true }),
+        createScalarPropertyDefinition({ name: "i", type: "Int", required: true }),
+        createScalarPropertyDefinition({ name: "i8", type: "Int8", required: true }),
+        createScalarPropertyDefinition({ name: "i16", type: "Int16", required: true }),
+        createScalarPropertyDefinition({ name: "i32", type: "Int32", required: true }),
+        createScalarPropertyDefinition({ name: "i64", type: "Int64", required: true }),
+        createScalarPropertyDefinition({ name: "bytes", type: "Bytes", required: true }),
+        createArrayPropertyDefinition({
+          name: "uArray",
+          type: "[UInt]",
+          required: true,
+          item: createScalarDefinition({ name: "uArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "uOptArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "optUOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "optUOptArray", type: "UInt", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "optStrOptArray",
+          type: "[String]",
+          required: false,
+          item: createScalarDefinition({ name: "optStrOptArray", type: "String", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "uArrayArray",
+          type: "[[UInt]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "uArrayArray",
+            type: "[UInt]",
+            required: true,
+            item: createScalarDefinition({ name: "uArrayArray", type: "UInt", required: true })
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArrayOptArray",
+          type: "[[UInt64]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "uOptArrayOptArray",
+            type: "[UInt64]",
+            required: false,
+            item: createScalarDefinition({ name: "uOptArrayOptArray", type: "UInt64", required: false })
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "uArrayOptArrayArray",
+          type: "[[[UInt64]]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "uArrayOptArrayArray",
+            type: "[[UInt64]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "uArrayOptArrayArray",
+              type: "[UInt64]",
+              required: true,
+              item: createScalarDefinition({ name: "uArrayOptArrayArray", type: "UInt64", required: true })
+            })
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "crazyArray",
+          type: "[[[[UInt64]]]]",
+          required: false,
+          item: createArrayDefinition({
+            name: "crazyArray",
+            type: "[[[UInt64]]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "crazyArray",
+              type: "[[UInt64]]",
+              required: true,
+              item: createArrayDefinition({
+                name: "crazyArray",
+                type: "[UInt64]",
+                required: false,
+                item: createScalarDefinition({ name: "crazyArray", type: "UInt64", required: true })
+              })
+            })
+          })
+        }),
+        createObjectPropertyDefinition({
+          name: "object",
+          type: "Namespace_ObjectType",
+          required: true
+        }),
+        createObjectPropertyDefinition({
+          name: "optObject",
+          type: "Namespace_ObjectType",
+          required: false
+        }),
+        createObjectPropertyDefinition({
+          name: "nestedObject",
+          type: "Namespace_NestedObjectType",
+          required: true
+        }),
+        createObjectPropertyDefinition({
+          name: "optNestedObject",
+          type: "Namespace_NestedObjectType",
+          required: false
+        }),
+        createArrayPropertyDefinition({
+          name: "optNestedObjectArray",
+          type: "[Namespace_NestedObjectType]",
+          required: true,
+          item: createObjectDefinition({
+            name: "optNestedObjectArray",
+            type: "Namespace_NestedObjectType",
+            required: false
+          }),
+        }),
+        createObjectPropertyDefinition({
+          name: "importedNestedObject",
+          type: "Namespace_Imported_NestedObjectType",
+          required: true
+        }),
+        createArrayPropertyDefinition({
+          name: "optImportedNestedObjectArray",
+          type: "[Namespace_Imported_NestedObjectType]",
+          required: true,
+          item: createObjectDefinition({
+            name: "optImportedNestedObjectArray",
+            type: "Namespace_Imported_NestedObjectType",
+            required: false
+          }),
+        }),
+        createEnumPropertyDefinition({
+          name: "enum",
+          type: "Namespace_CustomEnum",
+          required: true
+        }),
+        createEnumPropertyDefinition({
+          name: "optEnum",
+          type: "Namespace_CustomEnum",
+          required: false
+        }),
+        createEnumPropertyDefinition({
+          name: "importedEnum",
+          type: "Namespace_Imported_Enum",
+          required: true
+        }),
+        createEnumPropertyDefinition({
+          name: "optImportedEnum",
+          type: "Namespace_Imported_Enum",
+          required: false
+        }),
+      ]
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "ObjectType",
+        type: "Namespace_ObjectType"
+      }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String", required: true })],
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "NestedObjectType",
+        type: "Namespace_NestedObjectType"
+      }),
+      properties: [createObjectPropertyDefinition({ name: "nestedObject", type: "Namespace_ObjectType", required: true })],
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Imported_NestedObjectType",
+        type: "Namespace_Imported_NestedObjectType"
+      }),
+      properties: [createObjectPropertyDefinition({ name: "nestedObject", type: "Namespace_Imported_ObjectType", required: true })],
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Imported_ObjectType",
+        type: "Namespace_Imported_ObjectType"
+      }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String", required: true })],
+    },
+  ],
+  importedQueryTypes: [
+    {
+      ...createImportedQueryDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Query",
+        type: "Namespace_Query"
+      }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createScalarPropertyDefinition({
+              name: "optU",
+              required: false,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        }
+      ]
+    }
+  ],
+  importedEnumTypes: [
+    {
+      ...createImportedEnumDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "CustomEnum",
+        type: "Namespace_CustomEnum",
+        constants: [
+          "STRING",
+          "BYTES"
+        ]
+      })
+    },
+    {
+      ...createImportedEnumDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Imported_Enum",
+        type: "Namespace_Imported_Enum",
+        constants: [
+          "STRING",
+          "BYTES"
+        ]
+      })
+    }
+  ],
+}

--- a/packages/test-cases/cases/compose/sanity/output/schema.graphql
+++ b/packages/test-cases/cases/compose/sanity/output/schema.graphql
@@ -46,29 +46,6 @@ type Query @imports(
   ): [Int64!]!
 }
 
-type CustomQueryType {
-  str: String!
-  optStr: String
-  u: UInt!
-  optU: UInt
-  u8: UInt8!
-  u64: UInt64!
-  i: Int!
-  i8: Int8!
-  i64: Int64!
-  bytes: Bytes!
-  uArray: [UInt!]!
-  uOptArray: [UInt!]
-  optStrOptArray: [String]
-  crazyArray: [[[[UInt64!]]!]]
-  commonType: CommonType!
-  customType: Namespace_CustomType!
-}
-
-type AnotherQueryType {
-  prop: String
-}
-
 type Mutation @imports(
   types: [
     "Namespace_Query",
@@ -95,6 +72,43 @@ type Mutation @imports(
   ): [Int64!]!
 }
 
+type CustomQueryType {
+  str: String!
+  optStr: String
+  u: UInt!
+  optU: UInt
+  u8: UInt8!
+  u64: UInt64!
+  i: Int!
+  i8: Int8!
+  i64: Int64!
+  bytes: Bytes!
+  uArray: [UInt!]!
+  uOptArray: [UInt!]
+  optStrOptArray: [String]
+  crazyArray: [[[[UInt64!]]!]]
+  commonType: CommonType!
+  customType: Namespace_CustomType!
+}
+
+type AnotherQueryType {
+  prop: String
+}
+
+type CommonType {
+  prop: UInt8!
+  nestedObject: NestedType!
+  objectArray: [[ArrayObject]]!
+}
+
+type NestedType {
+  prop: String!
+}
+
+type ArrayObject {
+  prop: String!
+}
+
 type CustomMutationType {
   str: String!
   optStr: String
@@ -116,20 +130,6 @@ type CustomMutationType {
 
 type AnotherMutationType {
   prop: String
-}
-
-type CommonType {
-  prop: UInt8!
-  nestedObject: NestedType!
-  objectArray: [[ArrayObject]]!
-}
-
-type NestedType {
-  prop: String!
-}
-
-type ArrayObject {
-  prop: String!
 }
 
 ### Imported Queries START ###

--- a/packages/test-cases/cases/compose/sanity/output/schema.ts
+++ b/packages/test-cases/cases/compose/sanity/output/schema.ts
@@ -1,0 +1,875 @@
+import {
+  createArrayPropertyDefinition,
+  createMethodDefinition,
+  createQueryDefinition,
+  createScalarDefinition,
+  createScalarPropertyDefinition,
+  createArrayDefinition,
+  createObjectPropertyDefinition,
+  createObjectDefinition,
+  TypeInfo,
+  createEnumPropertyDefinition,
+  createImportedQueryDefinition,
+  createImportedObjectDefinition,
+  createImportedEnumDefinition
+} from "@web3api/schema-parse";
+
+export const typeInfo: TypeInfo = {
+  enumTypes: [],
+  queryTypes: [
+    {
+      ...createQueryDefinition({ type: "Query" }),
+      imports: [
+        { type: "Namespace_Query" },
+        { type: "Namespace_CustomType" },
+        { type: "Namespace_ObjectType" },
+        { type: "Namespace_NestedObjectType" },
+        { type: "Namespace_Imported_NestedObjectType" },
+        { type: "Namespace_Imported_ObjectType" },
+        { type: "Namespace_CustomEnum" },
+        { type: "Namespace_Imported_Enum" },
+      ],
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        }
+      ]
+    },
+    {
+      ...createQueryDefinition({ type: "Mutation" }),
+      imports: [
+        { type: "Namespace_Query" },
+        { type: "Namespace_Mutation" },
+        { type: "Namespace_NestedObjectType" },
+        { type: "Namespace_ObjectType" },
+        { type: "Namespace_Imported_NestedObjectType" },
+        { type: "Namespace_Imported_ObjectType" },
+        { type: "Namespace_CustomType" },
+        { type: "Namespace_CustomEnum" },
+        { type: "Namespace_Imported_Enum" },
+        { type: "JustMutation_Mutation" },
+      ],
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        }
+      ]
+    }
+  ],
+  objectTypes: [
+    {
+      ...createObjectDefinition({ type: "CustomQueryType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
+        createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
+        createScalarPropertyDefinition({ name: "u", type: "UInt", required: true }),
+        createScalarPropertyDefinition({ name: "optU", type: "UInt", required: false }),
+        createScalarPropertyDefinition({ name: "u8", type: "UInt8", required: true }),
+        createScalarPropertyDefinition({ name: "u64", type: "UInt64", required: true }),
+        createScalarPropertyDefinition({ name: "i", type: "Int", required: true }),
+        createScalarPropertyDefinition({ name: "i8", type: "Int8", required: true }),
+        createScalarPropertyDefinition({ name: "i64", type: "Int64", required: true }),
+        createScalarPropertyDefinition({ name: "bytes", type: "Bytes", required: true }),
+        createArrayPropertyDefinition({
+          name: "uArray",
+          type: "[UInt]",
+          required: true,
+          item: createScalarDefinition({ name: "uArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "uOptArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "optStrOptArray",
+          type: "[String]",
+          required: false,
+          item: createScalarDefinition({ name: "optStrOptArray", type: "String", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "crazyArray",
+          type: "[[[[UInt64]]]]",
+          required: false,
+          item: createArrayDefinition({
+            name: "crazyArray",
+            type: "[[[UInt64]]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "crazyArray",
+              type: "[[UInt64]]",
+              required: true,
+              item: createArrayDefinition({
+                name: "crazyArray",
+                type: "[UInt64]",
+                required: false,
+                item: createScalarDefinition({ name: "crazyArray", type: "UInt64", required: true })
+              })
+            })
+          })
+        }),
+        createObjectPropertyDefinition({
+          name: "commonType",
+          type: "CommonType",
+          required: true
+        }),
+        createObjectPropertyDefinition({
+          name: "customType",
+          type: "Namespace_CustomType",
+          required: true,
+        })
+      ],
+    },
+    {
+      ...createObjectDefinition({ type: "AnotherQueryType" }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String" })],
+    },
+    {
+      ...createObjectDefinition({ type: "CommonType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "UInt8", required: true }),
+        createObjectPropertyDefinition({ name: "nestedObject", type: "NestedType", required: true }),
+        createArrayPropertyDefinition({
+          name: "objectArray",
+          type: "[[ArrayObject]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "objectArray",
+            type: "[ArrayObject]",
+            required: false,
+            item: createObjectDefinition({
+              name: "objectArray",
+              type: "ArrayObject",
+              required: false
+            })
+          })
+        })
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "NestedType"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "ArrayObject"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    },
+    {
+      ...createObjectDefinition({ type: "CustomMutationType" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
+        createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
+        createScalarPropertyDefinition({ name: "u", type: "UInt", required: true }),
+        createScalarPropertyDefinition({ name: "optU", type: "UInt", required: false }),
+        createScalarPropertyDefinition({ name: "u8", type: "UInt8", required: true }),
+        createScalarPropertyDefinition({ name: "u64", type: "UInt64", required: true }),
+        createScalarPropertyDefinition({ name: "i", type: "Int", required: true }),
+        createScalarPropertyDefinition({ name: "i8", type: "Int8", required: true }),
+        createScalarPropertyDefinition({ name: "i64", type: "Int64", required: true }),
+        createScalarPropertyDefinition({ name: "bytes", type: "Bytes", required: true }),
+        createArrayPropertyDefinition({
+          name: "uArray",
+          type: "[UInt]",
+          required: true,
+          item: createScalarDefinition({ name: "uArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "uOptArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "optStrOptArray",
+          type: "[String]",
+          required: false,
+          item: createScalarDefinition({ name: "optStrOptArray", type: "String", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "crazyArray",
+          type: "[[[[UInt64]]]]",
+          required: false,
+          item: createArrayDefinition({
+            name: "crazyArray",
+            type: "[[[UInt64]]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "crazyArray",
+              type: "[[UInt64]]",
+              required: true,
+              item: createArrayDefinition({
+                name: "crazyArray",
+                type: "[UInt64]",
+                required: false,
+                item: createScalarDefinition({ name: "crazyArray", type: "UInt64", required: true })
+              })
+            })
+          })
+        }),
+        createObjectPropertyDefinition({
+          name: "commonType",
+          type: "CommonType",
+          required: true
+        }),
+        createObjectPropertyDefinition({
+          name: "customType",
+          type: "Namespace_CustomType",
+          required: true,
+        })
+      ],
+    },
+    {
+      ...createObjectDefinition({ type: "AnotherMutationType" }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String" })],
+    },
+  ],
+  importedQueryTypes: [
+    {
+      ...createImportedQueryDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Query",
+        type: "Namespace_Query"
+      }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createScalarPropertyDefinition({
+              name: "optU",
+              required: false,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        }
+      ]
+    },
+    {
+      ...createImportedQueryDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Mutation",
+        type: "Namespace_Mutation"
+      }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method1",
+            return: createScalarPropertyDefinition({
+              name: "method1",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "optStr",
+              required: false,
+              type: "String"
+            }),
+            createScalarPropertyDefinition({
+              name: "u",
+              required: true,
+              type: "UInt"
+            }),
+            createScalarPropertyDefinition({
+              name: "optU",
+              required: false,
+              type: "UInt"
+            }),
+            createArrayPropertyDefinition({
+              name: "uArrayArray",
+              required: true,
+              type: "[[UInt]]",
+              item: createArrayDefinition({
+                name: "uArrayArray",
+                required: false,
+                type: "[UInt]",
+                item: createScalarDefinition({
+                  name: "uArrayArray",
+                  required: false,
+                  type: "UInt"
+                })
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method2",
+            return: createArrayPropertyDefinition({
+              name: "method2",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method2",
+                required: true,
+                type: "Int64"
+              })
+            })
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "localObjects",
+            return: createObjectPropertyDefinition({
+              name: "localObjects",
+              type: "Namespace_NestedObjectType",
+              required: false
+            })
+          }),
+          arguments: [
+            createObjectPropertyDefinition({
+              name: "nestedLocalObject",
+              required: false,
+              type: "Namespace_NestedObjectType"
+            }),
+            createArrayPropertyDefinition({
+              name: "localObjectArray",
+              required: false,
+              type: "[Namespace_NestedObjectType]",
+              item: createObjectDefinition({
+                name: "localObjectArray",
+                required: true,
+                type: "Namespace_NestedObjectType"
+              })
+            })
+          ]
+        },
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "importedObjects",
+            return: createObjectPropertyDefinition({
+              name: "importedObjects",
+              type: "Namespace_Imported_NestedObjectType",
+              required: false
+            })
+          }),
+          arguments: [
+            createObjectPropertyDefinition({
+              name: "nestedLocalObject",
+              required: false,
+              type: "Namespace_Imported_NestedObjectType"
+            }),
+            createArrayPropertyDefinition({
+              name: "localObjectArray",
+              required: false,
+              type: "[Namespace_Imported_NestedObjectType]",
+              item: createObjectDefinition({
+                name: "localObjectArray",
+                required: true,
+                type: "Namespace_Imported_NestedObjectType"
+              })
+            })
+          ]
+        },
+      ]
+    },
+    {
+      ...createImportedQueryDefinition({
+        uri: "just.mutation.eth",
+        namespace: "JustMutation",
+        nativeType: "Mutation",
+        type: "JustMutation_Mutation"
+      }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method",
+            return: createArrayPropertyDefinition({
+              name: "method",
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "method",
+                type: "Int64",
+                required: true
+              })
+            }),
+          }),
+          arguments: [
+            createArrayPropertyDefinition({
+              name: "arg",
+              required: true,
+              type: "[String]",
+              item: createScalarDefinition({
+                name: "arg",
+                required: true,
+                type: "String"
+              })
+            })
+          ]
+        },
+      ]
+    },
+  ],
+  importedObjectTypes: [
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "CustomType",
+        type: "Namespace_CustomType"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
+        createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
+        createScalarPropertyDefinition({ name: "u", type: "UInt", required: true }),
+        createScalarPropertyDefinition({ name: "optU", type: "UInt", required: false }),
+        createScalarPropertyDefinition({ name: "u8", type: "UInt8", required: true }),
+        createScalarPropertyDefinition({ name: "u16", type: "UInt16", required: true }),
+        createScalarPropertyDefinition({ name: "u32", type: "UInt32", required: true }),
+        createScalarPropertyDefinition({ name: "u64", type: "UInt64", required: true }),
+        createScalarPropertyDefinition({ name: "i", type: "Int", required: true }),
+        createScalarPropertyDefinition({ name: "i8", type: "Int8", required: true }),
+        createScalarPropertyDefinition({ name: "i16", type: "Int16", required: true }),
+        createScalarPropertyDefinition({ name: "i32", type: "Int32", required: true }),
+        createScalarPropertyDefinition({ name: "i64", type: "Int64", required: true }),
+        createScalarPropertyDefinition({ name: "bytes", type: "Bytes", required: true }),
+        createArrayPropertyDefinition({
+          name: "uArray",
+          type: "[UInt]",
+          required: true,
+          item: createScalarDefinition({ name: "uArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "uOptArray", type: "UInt", required: true })
+        }),
+        createArrayPropertyDefinition({
+          name: "optUOptArray",
+          type: "[UInt]",
+          required: false,
+          item: createScalarDefinition({ name: "optUOptArray", type: "UInt", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "optStrOptArray",
+          type: "[String]",
+          required: false,
+          item: createScalarDefinition({ name: "optStrOptArray", type: "String", required: false })
+        }),
+        createArrayPropertyDefinition({
+          name: "uArrayArray",
+          type: "[[UInt]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "uArrayArray",
+            type: "[UInt]",
+            required: true,
+            item: createScalarDefinition({ name: "uArrayArray", type: "UInt", required: true })
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "uOptArrayOptArray",
+          type: "[[UInt64]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "uOptArrayOptArray",
+            type: "[UInt64]",
+            required: false,
+            item: createScalarDefinition({ name: "uOptArrayOptArray", type: "UInt64", required: false })
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "uArrayOptArrayArray",
+          type: "[[[UInt64]]]",
+          required: true,
+          item: createArrayDefinition({
+            name: "uArrayOptArrayArray",
+            type: "[[UInt64]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "uArrayOptArrayArray",
+              type: "[UInt64]",
+              required: true,
+              item: createScalarDefinition({ name: "uArrayOptArrayArray", type: "UInt64", required: true })
+            })
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "crazyArray",
+          type: "[[[[UInt64]]]]",
+          required: false,
+          item: createArrayDefinition({
+            name: "crazyArray",
+            type: "[[[UInt64]]]",
+            required: false,
+            item: createArrayDefinition({
+              name: "crazyArray",
+              type: "[[UInt64]]",
+              required: true,
+              item: createArrayDefinition({
+                name: "crazyArray",
+                type: "[UInt64]",
+                required: false,
+                item: createScalarDefinition({ name: "crazyArray", type: "UInt64", required: true })
+              })
+            })
+          })
+        }),
+        createObjectPropertyDefinition({
+          name: "object",
+          type: "Namespace_ObjectType",
+          required: true
+        }),
+        createObjectPropertyDefinition({
+          name: "optObject",
+          type: "Namespace_ObjectType",
+          required: false
+        }),
+        createObjectPropertyDefinition({
+          name: "nestedObject",
+          type: "Namespace_NestedObjectType",
+          required: true
+        }),
+        createObjectPropertyDefinition({
+          name: "optNestedObject",
+          type: "Namespace_NestedObjectType",
+          required: false
+        }),
+        createArrayPropertyDefinition({
+          name: "optNestedObjectArray",
+          type: "[Namespace_NestedObjectType]",
+          required: true,
+          item: createObjectDefinition({
+            name: "optNestedObjectArray",
+            type: "Namespace_NestedObjectType",
+            required: false
+          }),
+        }),
+        createObjectPropertyDefinition({
+          name: "importedNestedObject",
+          type: "Namespace_Imported_NestedObjectType",
+          required: true
+        }),
+        createArrayPropertyDefinition({
+          name: "optImportedNestedObjectArray",
+          type: "[Namespace_Imported_NestedObjectType]",
+          required: true,
+          item: createObjectDefinition({
+            name: "optImportedNestedObjectArray",
+            type: "Namespace_Imported_NestedObjectType",
+            required: false
+          }),
+        }),
+        createEnumPropertyDefinition({
+          name: "enum",
+          type: "Namespace_CustomEnum",
+          required: true
+        }),
+        createEnumPropertyDefinition({
+          name: "optEnum",
+          type: "Namespace_CustomEnum",
+          required: false
+        }),
+        createEnumPropertyDefinition({
+          name: "importedEnum",
+          type: "Namespace_Imported_Enum",
+          required: true
+        }),
+        createEnumPropertyDefinition({
+          name: "optImportedEnum",
+          type: "Namespace_Imported_Enum",
+          required: false
+        }),
+      ]
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "ObjectType",
+        type: "Namespace_ObjectType"
+      }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String", required: true })],
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "NestedObjectType",
+        type: "Namespace_NestedObjectType"
+      }),
+      properties: [createObjectPropertyDefinition({ name: "nestedObject", type: "Namespace_ObjectType", required: true })],
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Imported_NestedObjectType",
+        type: "Namespace_Imported_NestedObjectType"
+      }),
+      properties: [createObjectPropertyDefinition({ name: "nestedObject", type: "Namespace_Imported_ObjectType", required: true })],
+    },
+    {
+      ...createImportedObjectDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Imported_ObjectType",
+        type: "Namespace_Imported_ObjectType"
+      }),
+      properties: [createScalarPropertyDefinition({ name: "prop", type: "String", required: true })],
+    },
+  ],
+  importedEnumTypes: [
+    {
+      ...createImportedEnumDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "CustomEnum",
+        type: "Namespace_CustomEnum",
+        constants: [
+          "STRING",
+          "BYTES"
+        ]
+      })
+    },
+    {
+      ...createImportedEnumDefinition({
+        uri: "test.eth",
+        namespace: "Namespace",
+        nativeType: "Imported_Enum",
+        type: "Namespace_Imported_Enum",
+        constants: [
+          "STRING",
+          "BYTES"
+        ]
+      })
+    }
+  ],
+}

--- a/packages/test-cases/cases/parse/sanity/input.graphql
+++ b/packages/test-cases/cases/parse/sanity/input.graphql
@@ -72,7 +72,7 @@ type Query @imports(
 ) {
   queryMethod(
     arg: String!
-  ): Int!
+  ): [Int]!
 
   userObjectMethod(
     userObject: UserObject
@@ -100,7 +100,7 @@ type TestImport_Query @imported(
 
   anotherMethod(
     arg: [String!]!
-  ): Int64!
+  ): [Int64]!
 
   importedObjectMethod(
     importedObject: TestImport_Object!

--- a/packages/test-cases/cases/parse/sanity/output.ts
+++ b/packages/test-cases/cases/parse/sanity/output.ts
@@ -203,15 +203,29 @@ export const output: TypeInfo = {
   ],
   queryTypes: [
     {
-      ...createQueryDefinition({ type: "Query" }),
+      ...createQueryDefinition({
+        type: "Query",
+        imports: [{ type: "TestImport_Query" }]
+      }),
       methods: [
         {
-          ...createMethodDefinition({ type: "query", name: "queryMethod" }),
+          ...createMethodDefinition({
+            type: "query",
+            name: "queryMethod",
+            return: createScalarPropertyDefinition({ name: "queryMethod", type: "Int", required: true }),
+          }),
           arguments: [createScalarPropertyDefinition({ name: "arg", type: "String", required: true })],
-          return: createScalarPropertyDefinition({ name: "queryMethod", type: "Int", required: true }),
         },
         {
-          ...createMethodDefinition({ type: "query", name: "userObjectMethod" }),
+          ...createMethodDefinition({
+            type: "query",
+            name: "userObjectMethod",
+            return: createObjectPropertyDefinition({
+              name: "userObjectMethod",
+              type: "UserObject",
+              required: true
+            }),
+          }),
           arguments: [
             createObjectPropertyDefinition({ name: "userObject", type: "UserObject" }),
             createArrayPropertyDefinition({ name: "arrayObject", type: "[UserObject]", required: true, item: createObjectDefinition({
@@ -220,14 +234,17 @@ export const output: TypeInfo = {
               required: true
             })}),
           ],
-          return: createObjectPropertyDefinition({
-            name: "userObjectMethod",
-            type: "UserObject",
-            required: true
-          }),
         },
         {
-          ...createMethodDefinition({ type: "query", name: "enumMethod" }),
+          ...createMethodDefinition({
+            type: "query",
+            name: "enumMethod",
+            return: createEnumPropertyDefinition({
+              name: "enumMethod",
+              type: "CustomEnum",
+              required: true
+            }),
+          }),
           arguments: [
             createEnumPropertyDefinition({ name: "enum", type: "CustomEnum" }),
             createArrayPropertyDefinition({ name: "arrayEnum", type: "[CustomEnum]", required: true, item: createEnumDefinition({
@@ -236,11 +253,6 @@ export const output: TypeInfo = {
               required: true
             })}),
           ],
-          return: createEnumPropertyDefinition({
-            name: "enumMethod",
-            type: "CustomEnum",
-            required: true
-          }),
         },
       ],
     },
@@ -294,7 +306,15 @@ export const output: TypeInfo = {
       }),
       methods: [
         {
-          ...createMethodDefinition({ type: "query", name: "importedMethod" }),
+          ...createMethodDefinition({
+            type: "query",
+            name: "importedMethod",
+            return: createScalarPropertyDefinition({
+              name: "importedMethod",
+              type: "String",
+              required: true
+            }),
+          }),
           arguments: [
             createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
             createScalarPropertyDefinition({ name: "optStr", type: "String", required: false }),
@@ -312,14 +332,17 @@ export const output: TypeInfo = {
               })
             }),
           ],
-          return: createScalarPropertyDefinition({
-            name: "importedMethod",
-            type: "String",
-            required: true
-          }),
         },
         {
-          ...createMethodDefinition({ type: "query", name: "anotherMethod" }),
+          ...createMethodDefinition({
+            type: "query",
+            name: "anotherMethod",
+            return: createScalarPropertyDefinition({
+              name: "anotherMethod",
+              type: "Int64",
+              required: true
+            }),
+          }),
           arguments: [
             createArrayPropertyDefinition({
               name: "arg",
@@ -328,14 +351,26 @@ export const output: TypeInfo = {
               item: createScalarDefinition({ name: "arg", type: "String", required: true })
             }),
           ],
-          return: createScalarPropertyDefinition({
-            name: "anotherMethod",
-            type: "Int64",
-            required: true
-          }),
         },
         {
-          ...createMethodDefinition({ type: "query", name: "importedObjectMethod" }),
+          ...createMethodDefinition({
+            type: "query",
+            name: "importedObjectMethod",
+            return: {
+              ...createObjectPropertyDefinition({
+                name: "importedObjectMethod",
+                type: "TestImport_Object",
+                required: true
+              }),
+              object: {
+                ...createObjectDefinition({
+                  name: "importedObjectMethod",
+                  type: "TestImport_Object",
+                  required: true
+                }),
+              }
+            },
+          }),
           arguments: [
             {
               ...createObjectPropertyDefinition({
@@ -352,23 +387,17 @@ export const output: TypeInfo = {
               }
             }
           ],
-          return: {
-            ...createObjectPropertyDefinition({
-              name: "importedObjectMethod",
-              type: "TestImport_Object",
-              required: true
-            }),
-            object: {
-              ...createObjectDefinition({
-                name: "importedObjectMethod",
-                type: "TestImport_Object",
-                required: true
-              }),
-            }
-          }
         },
         {
-          ...createMethodDefinition({ type: "query", name: "importedEnumMethod" }),
+          ...createMethodDefinition({
+            type: "query",
+            name: "importedEnumMethod",
+            return: createEnumPropertyDefinition({
+              name: "importedEnumMethod",
+              type: "TestImport_Enum",
+              required: true
+            }),
+          }),
           arguments: [
             {
               ...createEnumPropertyDefinition({
@@ -384,14 +413,7 @@ export const output: TypeInfo = {
                 required: false
               }),
             }
-          ],
-          return: {
-            ...createEnumPropertyDefinition({
-              name: "importedEnumMethod",
-              type: "TestImport_Enum",
-              required: true
-            }),
-          }
+          ]
         },
       ],
     },
@@ -404,13 +426,16 @@ export const output: TypeInfo = {
       }),
       methods: [
         {
-          ...createMethodDefinition({ type: "mutation", name: "importedMethod" }),
-          arguments: [createScalarPropertyDefinition({ name: "str", type: "String", required: true })],
-          return: createScalarPropertyDefinition({
+          ...createMethodDefinition({
+            type: "mutation",
             name: "importedMethod",
-            type: "String",
-            required: true
+            return: createScalarPropertyDefinition({
+              name: "importedMethod",
+              type: "String",
+              required: true
+            }),
           }),
+          arguments: [createScalarPropertyDefinition({ name: "str", type: "String", required: true })],
         },
       ],
     },

--- a/packages/test-cases/cases/parse/sanity/output.ts
+++ b/packages/test-cases/cases/parse/sanity/output.ts
@@ -212,7 +212,12 @@ export const output: TypeInfo = {
           ...createMethodDefinition({
             type: "query",
             name: "queryMethod",
-            return: createScalarPropertyDefinition({ name: "queryMethod", type: "Int", required: true }),
+            return: createArrayPropertyDefinition({
+              name: "queryMethod",
+              type: "[Int]",
+              required: true,
+              item: createScalarDefinition({ name: "queryMethod", type: "Int", required: false }),
+            })
           }),
           arguments: [createScalarPropertyDefinition({ name: "arg", type: "String", required: true })],
         },
@@ -337,10 +342,15 @@ export const output: TypeInfo = {
           ...createMethodDefinition({
             type: "query",
             name: "anotherMethod",
-            return: createScalarPropertyDefinition({
+            return: createArrayPropertyDefinition({
               name: "anotherMethod",
-              type: "Int64",
-              required: true
+              type: "[Int64]",
+              required: true,
+              item: createScalarDefinition({
+                name: "anotherMethod",
+                type: "Int64",
+                required: false
+              }),
             }),
           }),
           arguments: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,10 +92,10 @@
   dependencies:
     "@babel/highlight" "^7.12.13"
 
-"@babel/compat-data@^7.13.0", "@babel/compat-data@^7.13.12", "@babel/compat-data@^7.13.8", "@babel/compat-data@^7.9.0":
-  version "7.13.12"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.12.tgz#a8a5ccac19c200f9dd49624cac6e19d7be1236a1"
-  integrity sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ==
+"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.13.12", "@babel/compat-data@^7.13.15", "@babel/compat-data@^7.13.8", "@babel/compat-data@^7.9.0":
+  version "7.13.15"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.15.tgz#7e8eea42d0b64fda2b375b22d06c605222e848f4"
+  integrity sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==
 
 "@babel/core@7.4.4":
   version "7.4.4"
@@ -140,24 +140,23 @@
     source-map "^0.5.0"
 
 "@babel/core@^7.1.0", "@babel/core@^7.4.5", "@babel/core@^7.7.5":
-  version "7.13.13"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.13.tgz#bc44c4a2be2288ec4ddf56b66fc718019c76ac29"
-  integrity sha512-1xEs9jZAyKIouOoCmpsgk/I26PoKyvzQ2ixdRpRzfbcp1fL+ozw7TUgdDgwonbTovqRaTfRh50IXuw4QrWO0GA==
+  version "7.13.15"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.15.tgz#a6d40917df027487b54312202a06812c4f7792d0"
+  integrity sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==
   dependencies:
     "@babel/code-frame" "^7.12.13"
     "@babel/generator" "^7.13.9"
     "@babel/helper-compilation-targets" "^7.13.13"
-    "@babel/helper-module-transforms" "^7.13.12"
+    "@babel/helper-module-transforms" "^7.13.14"
     "@babel/helpers" "^7.13.10"
-    "@babel/parser" "^7.13.13"
+    "@babel/parser" "^7.13.15"
     "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.13.13"
-    "@babel/types" "^7.13.13"
+    "@babel/traverse" "^7.13.15"
+    "@babel/types" "^7.13.14"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
     json5 "^2.1.2"
-    lodash "^4.17.19"
     semver "^6.3.0"
     source-map "^0.5.0"
 
@@ -185,7 +184,7 @@
     "@babel/helper-explode-assignable-expression" "^7.12.13"
     "@babel/types" "^7.12.13"
 
-"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.13.10", "@babel/helper-compilation-targets@^7.13.13", "@babel/helper-compilation-targets@^7.13.8", "@babel/helper-compilation-targets@^7.8.7":
+"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.13.13", "@babel/helper-compilation-targets@^7.13.8", "@babel/helper-compilation-targets@^7.8.7":
   version "7.13.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz#2b2972a0926474853f41e4adbc69338f520600e5"
   integrity sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==
@@ -214,10 +213,10 @@
     "@babel/helper-annotate-as-pure" "^7.12.13"
     regexpu-core "^4.7.1"
 
-"@babel/helper-define-polyfill-provider@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz#3c2f91b7971b9fc11fe779c945c014065dea340e"
-  integrity sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==
+"@babel/helper-define-polyfill-provider@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.0.tgz#a640051772045fedaaecc6f0c6c69f02bdd34bf1"
+  integrity sha512-JT8tHuFjKBo8NnaUbblz7mIu1nnvUDiHVjXXkulZULyidvo/7P6TY7+YqpV37IfF+KUFxmlK04elKtGKXaiVgw==
   dependencies:
     "@babel/helper-compilation-targets" "^7.13.0"
     "@babel/helper-module-imports" "^7.12.13"
@@ -273,10 +272,10 @@
   dependencies:
     "@babel/types" "^7.13.12"
 
-"@babel/helper-module-transforms@^7.13.0", "@babel/helper-module-transforms@^7.13.12", "@babel/helper-module-transforms@^7.9.0":
-  version "7.13.12"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.13.12.tgz#600e58350490828d82282631a1422268e982ba96"
-  integrity sha512-7zVQqMO3V+K4JOOj40kxiCrMf6xlQAkewBB0eu2b03OO/Q21ZutOzjpfD79A5gtE/2OWi1nv625MrDlGlkbknQ==
+"@babel/helper-module-transforms@^7.13.0", "@babel/helper-module-transforms@^7.13.14", "@babel/helper-module-transforms@^7.9.0":
+  version "7.13.14"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz#e600652ba48ccb1641775413cb32cfa4e8b495ef"
+  integrity sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==
   dependencies:
     "@babel/helper-module-imports" "^7.13.12"
     "@babel/helper-replace-supers" "^7.13.12"
@@ -284,8 +283,8 @@
     "@babel/helper-split-export-declaration" "^7.12.13"
     "@babel/helper-validator-identifier" "^7.12.11"
     "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.13.0"
-    "@babel/types" "^7.13.12"
+    "@babel/traverse" "^7.13.13"
+    "@babel/types" "^7.13.14"
 
 "@babel/helper-optimise-call-expression@^7.12.13":
   version "7.12.13"
@@ -377,10 +376,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.13", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0":
-  version "7.13.13"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.13.tgz#42f03862f4aed50461e543270916b47dd501f0df"
-  integrity sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.15", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0":
+  version "7.13.15"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.15.tgz#8e66775fb523599acb6a289e12929fa5ab0954d8"
+  integrity sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
   version "7.13.12"
@@ -391,10 +390,10 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
     "@babel/plugin-proposal-optional-chaining" "^7.13.12"
 
-"@babel/plugin-proposal-async-generator-functions@^7.13.8", "@babel/plugin-proposal-async-generator-functions@^7.2.0", "@babel/plugin-proposal-async-generator-functions@^7.8.3":
-  version "7.13.8"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz#87aacb574b3bc4b5603f6fe41458d72a5a2ec4b1"
-  integrity sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==
+"@babel/plugin-proposal-async-generator-functions@^7.13.15", "@babel/plugin-proposal-async-generator-functions@^7.2.0", "@babel/plugin-proposal-async-generator-functions@^7.8.3":
+  version "7.13.15"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.15.tgz#80e549df273a3b3050431b148c892491df1bcc5b"
+  integrity sha512-VapibkWzFeoa6ubXy/NgV5U2U4MVnUlvnx6wo1XhlsaTrLYWE0UFpDQsVrmn22q5CzeloqJ8gEMHSKxuee6ZdA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/helper-remap-async-to-generator" "^7.13.0"
@@ -935,10 +934,10 @@
   dependencies:
     regenerator-transform "^0.13.4"
 
-"@babel/plugin-transform-regenerator@^7.12.13", "@babel/plugin-transform-regenerator@^7.4.4", "@babel/plugin-transform-regenerator@^7.8.7":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.13.tgz#b628bcc9c85260ac1aeb05b45bde25210194a2f5"
-  integrity sha512-lxb2ZAvSLyJ2PEe47hoGWPmW22v7CtSl9jW8mingV4H2sEX/JOcrAj2nPuGWi56ERUm2bUpjKzONAuT6HCn2EA==
+"@babel/plugin-transform-regenerator@^7.13.15", "@babel/plugin-transform-regenerator@^7.4.4", "@babel/plugin-transform-regenerator@^7.8.7":
+  version "7.13.15"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.13.15.tgz#e5eb28945bf8b6563e7f818945f966a8d2997f39"
+  integrity sha512-Bk9cOLSz8DiurcMETZ8E2YtIVJbFCPGW28DJWUakmyVWtQSm6Wsf0p4B4BfEr/eL2Nkhe/CICiUiMOCi1TPhuQ==
   dependencies:
     regenerator-transform "^0.14.2"
 
@@ -1165,16 +1164,16 @@
     semver "^5.5.0"
 
 "@babel/preset-env@^7.4.5":
-  version "7.13.12"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.13.12.tgz#6dff470478290582ac282fb77780eadf32480237"
-  integrity sha512-JzElc6jk3Ko6zuZgBtjOd01pf9yYDEIH8BcqVuYIuOkzOwDesoa/Nz4gIo4lBG6K861KTV9TvIgmFuT6ytOaAA==
+  version "7.13.15"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.13.15.tgz#c8a6eb584f96ecba183d3d414a83553a599f478f"
+  integrity sha512-D4JAPMXcxk69PKe81jRJ21/fP/uYdcTZ3hJDF5QX2HSI9bBxxYw/dumdR6dGumhjxlprHPE4XWoPaqzZUVy2MA==
   dependencies:
-    "@babel/compat-data" "^7.13.12"
-    "@babel/helper-compilation-targets" "^7.13.10"
+    "@babel/compat-data" "^7.13.15"
+    "@babel/helper-compilation-targets" "^7.13.13"
     "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/helper-validator-option" "^7.12.17"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.13.12"
-    "@babel/plugin-proposal-async-generator-functions" "^7.13.8"
+    "@babel/plugin-proposal-async-generator-functions" "^7.13.15"
     "@babel/plugin-proposal-class-properties" "^7.13.0"
     "@babel/plugin-proposal-dynamic-import" "^7.13.8"
     "@babel/plugin-proposal-export-namespace-from" "^7.12.13"
@@ -1222,7 +1221,7 @@
     "@babel/plugin-transform-object-super" "^7.12.13"
     "@babel/plugin-transform-parameters" "^7.13.0"
     "@babel/plugin-transform-property-literals" "^7.12.13"
-    "@babel/plugin-transform-regenerator" "^7.12.13"
+    "@babel/plugin-transform-regenerator" "^7.13.15"
     "@babel/plugin-transform-reserved-words" "^7.12.13"
     "@babel/plugin-transform-shorthand-properties" "^7.12.13"
     "@babel/plugin-transform-spread" "^7.13.0"
@@ -1232,10 +1231,10 @@
     "@babel/plugin-transform-unicode-escapes" "^7.12.13"
     "@babel/plugin-transform-unicode-regex" "^7.12.13"
     "@babel/preset-modules" "^0.1.4"
-    "@babel/types" "^7.13.12"
-    babel-plugin-polyfill-corejs2 "^0.1.4"
-    babel-plugin-polyfill-corejs3 "^0.1.3"
-    babel-plugin-polyfill-regenerator "^0.1.2"
+    "@babel/types" "^7.13.14"
+    babel-plugin-polyfill-corejs2 "^0.2.0"
+    babel-plugin-polyfill-corejs3 "^0.2.0"
+    babel-plugin-polyfill-regenerator "^0.2.0"
     core-js-compat "^3.9.0"
     semver "^6.3.0"
 
@@ -1320,24 +1319,24 @@
     "@babel/parser" "^7.12.13"
     "@babel/types" "^7.12.13"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.13.13", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.7.0", "@babel/traverse@^7.9.0":
-  version "7.13.13"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.13.tgz#39aa9c21aab69f74d948a486dd28a2dbdbf5114d"
-  integrity sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.13.13", "@babel/traverse@^7.13.15", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.7.0", "@babel/traverse@^7.9.0":
+  version "7.13.15"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.15.tgz#c38bf7679334ddd4028e8e1f7b3aa5019f0dada7"
+  integrity sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==
   dependencies:
     "@babel/code-frame" "^7.12.13"
     "@babel/generator" "^7.13.9"
     "@babel/helper-function-name" "^7.12.13"
     "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/parser" "^7.13.13"
-    "@babel/types" "^7.13.13"
+    "@babel/parser" "^7.13.15"
+    "@babel/types" "^7.13.14"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.13", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0":
-  version "7.13.13"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.13.tgz#dcd8b815b38f537a3697ce84c8e3cc62197df96f"
-  integrity sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==
+"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.14", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0":
+  version "7.13.14"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.14.tgz#c35a4abb15c7cd45a2746d78ab328e362cbace0d"
+  integrity sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
@@ -1444,35 +1443,22 @@
     "@ethersproject/properties" ">=5.0.0-beta.131"
     "@ethersproject/strings" ">=5.0.0-beta.130"
 
-"@ethersproject/abi@^5.0.0", "@ethersproject/abi@^5.0.10":
-  version "5.0.13"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.13.tgz#600a559c3730467716595658beaa2894b4352bcc"
-  integrity sha512-2coOH3D7ra1lwamKEH0HVc+Jbcsw5yfeCgmY8ekhCDualEiyyovD2qDcMBBcY3+kjoLHVTmo7ost6MNClxdOrg==
+"@ethersproject/abi@^5.0.0", "@ethersproject/abi@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.1.0.tgz#d582c9f6a8e8192778b5f2c991ce19d7b336b0c5"
+  integrity sha512-N/W9Sbn1/C6Kh2kuHRjf/hX6euMK4+9zdJRBB8sDWmihVntjUAfxbusGZKzDQD8i3szAHhTz8K7XADV5iFNfJw==
   dependencies:
-    "@ethersproject/address" "^5.0.9"
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/constants" "^5.0.8"
-    "@ethersproject/hash" "^5.0.10"
-    "@ethersproject/keccak256" "^5.0.7"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/properties" "^5.0.7"
-    "@ethersproject/strings" "^5.0.8"
+    "@ethersproject/address" "^5.1.0"
+    "@ethersproject/bignumber" "^5.1.0"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/constants" "^5.1.0"
+    "@ethersproject/hash" "^5.1.0"
+    "@ethersproject/keccak256" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    "@ethersproject/properties" "^5.1.0"
+    "@ethersproject/strings" "^5.1.0"
 
-"@ethersproject/abstract-provider@^5.0.0", "@ethersproject/abstract-provider@^5.0.8":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.0.10.tgz#a533aed39a5f27312745c8c4c40fa25fc884831c"
-  integrity sha512-OSReY5iz94iIaPlRvLiJP8YVIvQLx4aUvMMnHWSaA/vTU8QHZmgNlt4OBdYV1+aFY8Xl+VRYiWBHq72ZDKXXCQ==
-  dependencies:
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/networks" "^5.0.7"
-    "@ethersproject/properties" "^5.0.7"
-    "@ethersproject/transactions" "^5.0.9"
-    "@ethersproject/web" "^5.0.12"
-
-"@ethersproject/abstract-provider@^5.0.3", "@ethersproject/abstract-provider@^5.1.0":
+"@ethersproject/abstract-provider@^5.0.0", "@ethersproject/abstract-provider@^5.0.3", "@ethersproject/abstract-provider@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.1.0.tgz#1f24c56cda5524ef4ed3cfc562a01d6b6f8eeb0b"
   integrity sha512-8dJUnT8VNvPwWhYIau4dwp7qe1g+KgdRm4XTWvjkI9gAT2zZa90WF5ApdZ3vl1r6NDmnn6vUVvyphClRZRteTQ==
@@ -1485,18 +1471,7 @@
     "@ethersproject/transactions" "^5.1.0"
     "@ethersproject/web" "^5.1.0"
 
-"@ethersproject/abstract-signer@^5.0.0", "@ethersproject/abstract-signer@^5.0.10":
-  version "5.0.14"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.0.14.tgz#30ef912b0f86599d90fdffc65c110452e7b55cf1"
-  integrity sha512-JztBwVO7o5OHLh2vyjordlS4/1EjRyaECtc8vPdXTF1i4dXN+J0coeRoPN6ZFbBvi/YbaB6br2fvqhst1VQD/g==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.0.8"
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/properties" "^5.0.7"
-
-"@ethersproject/abstract-signer@^5.0.3", "@ethersproject/abstract-signer@^5.1.0":
+"@ethersproject/abstract-signer@^5.0.0", "@ethersproject/abstract-signer@^5.0.3", "@ethersproject/abstract-signer@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.1.0.tgz#744c7a2d0ebe3cc0bc38294d0f53d5ca3f4e49e3"
   integrity sha512-qQDMkjGZSSJSKl6AnfTgmz9FSnzq3iEoEbHTYwjDlEAv+LNP7zd4ixCcVWlWyk+2siud856M5CRhAmPdupeN9w==
@@ -1518,18 +1493,7 @@
     "@ethersproject/logger" "^5.0.5"
     "@ethersproject/rlp" "^5.0.3"
 
-"@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.0.0", "@ethersproject/address@^5.0.9":
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.0.11.tgz#12022e8c590c33939beb5ab18b401ecf585eac59"
-  integrity sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==
-  dependencies:
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/keccak256" "^5.0.7"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/rlp" "^5.0.7"
-
-"@ethersproject/address@^5.0.3", "@ethersproject/address@^5.1.0":
+"@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.0.0", "@ethersproject/address@^5.0.3", "@ethersproject/address@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.1.0.tgz#3854fd7ebcb6af7597de66f847c3345dae735b58"
   integrity sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==
@@ -1540,29 +1504,14 @@
     "@ethersproject/logger" "^5.1.0"
     "@ethersproject/rlp" "^5.1.0"
 
-"@ethersproject/base64@^5.0.0", "@ethersproject/base64@^5.0.7":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.0.9.tgz#bb1f35d3dba92082a574d5e2418f9202a0a1a7e6"
-  integrity sha512-37RBz5LEZ9SlTNGiWCYFttnIN9J7qVs9Xo2EbqGqDH5LfW9EIji66S+YDMpXVo1zWDax1FkEldAoatxHK2gfgA==
-  dependencies:
-    "@ethersproject/bytes" "^5.0.9"
-
-"@ethersproject/base64@^5.1.0":
+"@ethersproject/base64@^5.0.0", "@ethersproject/base64@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.1.0.tgz#27240c174d0a4e13f6eae87416fd876caf7f42b6"
   integrity sha512-npD1bLvK4Bcxz+m4EMkx+F8Rd7CnqS9DYnhNu0/GlQBXhWjvfoAZzk5HJ0f1qeyp8d+A86PTuzLOGOXf4/CN8g==
   dependencies:
     "@ethersproject/bytes" "^5.1.0"
 
-"@ethersproject/basex@^5.0.0", "@ethersproject/basex@^5.0.7":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.0.9.tgz#00d727a031bac563cb8bb900955206f1bf3cf1fc"
-  integrity sha512-FANswl1IN3PS0eltQxH2aM2+utPrkLUVG4XVFi6SafRG9EpAqXCgycxC8PU90mPGhigYTpg9cnTB5mCZ6ejQjw==
-  dependencies:
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/properties" "^5.0.7"
-
-"@ethersproject/basex@^5.0.3":
+"@ethersproject/basex@^5.0.0", "@ethersproject/basex@^5.0.3", "@ethersproject/basex@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.1.0.tgz#80da2e86f9da0cb5ccd446b337364d791f6a131c"
   integrity sha512-vBKr39bum7DDbOvkr1Sj19bRMEPA4FnST6Utt6xhDzI7o7L6QNkDn2yrCfP+hnvJGhZFKtLygWwqlTBZoBXYLg==
@@ -1570,16 +1519,7 @@
     "@ethersproject/bytes" "^5.1.0"
     "@ethersproject/properties" "^5.1.0"
 
-"@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.0.0", "@ethersproject/bignumber@^5.0.13":
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.0.15.tgz#b089b3f1e0381338d764ac1c10512f0c93b184ed"
-  integrity sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==
-  dependencies:
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/logger" "^5.0.8"
-    bn.js "^4.4.0"
-
-"@ethersproject/bignumber@^5.0.10", "@ethersproject/bignumber@^5.0.6", "@ethersproject/bignumber@^5.1.0":
+"@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.0.0", "@ethersproject/bignumber@^5.0.10", "@ethersproject/bignumber@^5.0.6", "@ethersproject/bignumber@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.1.0.tgz#966a013a5d871fc03fc67bf33cd8aadae627f0fd"
   integrity sha512-wUvQlhTjPjFXIdLPOuTrFeQmSa6Wvls1bGXQNQWvB/SEn1NsTCE8PmumIEZxmOPjSHl1eV2uyHP5jBm5Cgj92Q==
@@ -1588,28 +1528,14 @@
     "@ethersproject/logger" "^5.1.0"
     bn.js "^4.4.0"
 
-"@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.0.0", "@ethersproject/bytes@^5.0.9":
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.0.11.tgz#21118e75b1d00db068984c15530e316021101276"
-  integrity sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==
-  dependencies:
-    "@ethersproject/logger" "^5.0.8"
-
-"@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.1.0":
+"@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.0.0", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.1.0.tgz#55dfa9c4c21df1b1b538be3accb50fb76d5facfd"
   integrity sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==
   dependencies:
     "@ethersproject/logger" "^5.1.0"
 
-"@ethersproject/constants@>=5.0.0-beta.128", "@ethersproject/constants@^5.0.0", "@ethersproject/constants@^5.0.8":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.0.10.tgz#eb0c604fbc44c53ba9641eed31a1d0c9e1ebcadc"
-  integrity sha512-OSo8jxkHLDXieCy8bgOFR7lMfgPxEzKvSDdP+WAWHCDM8+orwch0B6wzkTmiQFgryAtIctrBt5glAdJikZ3hGw==
-  dependencies:
-    "@ethersproject/bignumber" "^5.0.13"
-
-"@ethersproject/constants@^5.0.3", "@ethersproject/constants@^5.1.0":
+"@ethersproject/constants@>=5.0.0-beta.128", "@ethersproject/constants@^5.0.0", "@ethersproject/constants@^5.0.3", "@ethersproject/constants@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.1.0.tgz#4e7da6367ea0e9be87585d8b09f3fccf384b1452"
   integrity sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==
@@ -1617,35 +1543,22 @@
     "@ethersproject/bignumber" "^5.1.0"
 
 "@ethersproject/contracts@^5.0.0":
-  version "5.0.12"
-  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.0.12.tgz#6d488db46221258399dfe80b89bf849b3afd7897"
-  integrity sha512-srijy31idjz8bE+gL1I6IRj2H4I9dUwfQ+QroLrIgNdGArqY8y2iFUKa3QTy+JBX26fJsdYiCQi1kKkaNpnMpQ==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.1.0.tgz#f7c3451f1af77e029005733ccab3419d07d23f6b"
+  integrity sha512-dvTMs/4XGSc57cYOW0KjgX1NdTujUu7mNb6PQdJWg08m9ULzPyGZuBkFJnijBcp6vTOCQ59RwjboWgNWw393og==
   dependencies:
-    "@ethersproject/abi" "^5.0.10"
-    "@ethersproject/abstract-provider" "^5.0.8"
-    "@ethersproject/abstract-signer" "^5.0.10"
-    "@ethersproject/address" "^5.0.9"
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/constants" "^5.0.8"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/properties" "^5.0.7"
+    "@ethersproject/abi" "^5.1.0"
+    "@ethersproject/abstract-provider" "^5.1.0"
+    "@ethersproject/abstract-signer" "^5.1.0"
+    "@ethersproject/address" "^5.1.0"
+    "@ethersproject/bignumber" "^5.1.0"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/constants" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    "@ethersproject/properties" "^5.1.0"
+    "@ethersproject/transactions" "^5.1.0"
 
-"@ethersproject/hash@>=5.0.0-beta.128", "@ethersproject/hash@^5.0.0", "@ethersproject/hash@^5.0.10":
-  version "5.0.12"
-  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.0.12.tgz#1074599f7509e2ca2bb7a3d4f4e39ab3a796da42"
-  integrity sha512-kn4QN+fhNFbUgX3XZTZUaQixi0oyfIEY+hfW+KtkHu+rq7dV76oAIvaLEEynu1/4npOL38E4X4YI42gGZk+C0Q==
-  dependencies:
-    "@ethersproject/abstract-signer" "^5.0.10"
-    "@ethersproject/address" "^5.0.9"
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/keccak256" "^5.0.7"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/properties" "^5.0.7"
-    "@ethersproject/strings" "^5.0.8"
-
-"@ethersproject/hash@^5.0.3":
+"@ethersproject/hash@>=5.0.0-beta.128", "@ethersproject/hash@^5.0.0", "@ethersproject/hash@^5.0.3", "@ethersproject/hash@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.1.0.tgz#40961d64837d57f580b7b055e0d74174876d891e"
   integrity sha512-fNwry20yLLPpnRRwm3fBL+2ksgO+KMadxM44WJmRIoTKzy4269+rbq9KFoe2LTqq2CXJM2CE70beGaNrpuqflQ==
@@ -1659,52 +1572,44 @@
     "@ethersproject/properties" "^5.1.0"
     "@ethersproject/strings" "^5.1.0"
 
-"@ethersproject/hdnode@^5.0.0", "@ethersproject/hdnode@^5.0.8":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.0.10.tgz#f7cdf154bf5d104c76dce2940745fc71d9e7eb1b"
-  integrity sha512-ZLwMtIcXK7xz2lSITDCl40W04CtRq4K9NwBxhCzdzPdaz6XnoJMwGz2YMVLg+8ksseq+RYtTwIIXtlK6vyvQyg==
+"@ethersproject/hdnode@^5.0.0", "@ethersproject/hdnode@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.1.0.tgz#2bf5c4048935136ce83e9242e1bd570afcc0bc83"
+  integrity sha512-obIWdlujloExPHWJGmhJO/sETOOo7SEb6qemV4f8kyFoXg+cJK+Ta9SvBrj7hsUK85n3LZeZJZRjjM7oez3Clg==
   dependencies:
-    "@ethersproject/abstract-signer" "^5.0.10"
-    "@ethersproject/basex" "^5.0.7"
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/pbkdf2" "^5.0.7"
-    "@ethersproject/properties" "^5.0.7"
-    "@ethersproject/sha2" "^5.0.7"
-    "@ethersproject/signing-key" "^5.0.8"
-    "@ethersproject/strings" "^5.0.8"
-    "@ethersproject/transactions" "^5.0.9"
-    "@ethersproject/wordlists" "^5.0.8"
+    "@ethersproject/abstract-signer" "^5.1.0"
+    "@ethersproject/basex" "^5.1.0"
+    "@ethersproject/bignumber" "^5.1.0"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    "@ethersproject/pbkdf2" "^5.1.0"
+    "@ethersproject/properties" "^5.1.0"
+    "@ethersproject/sha2" "^5.1.0"
+    "@ethersproject/signing-key" "^5.1.0"
+    "@ethersproject/strings" "^5.1.0"
+    "@ethersproject/transactions" "^5.1.0"
+    "@ethersproject/wordlists" "^5.1.0"
 
-"@ethersproject/json-wallets@^5.0.0", "@ethersproject/json-wallets@^5.0.10":
-  version "5.0.12"
-  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.0.12.tgz#8946a0fcce1634b636313a50330b7d30a24996e8"
-  integrity sha512-nac553zGZnOewpjlqbfy7WBl8m3y7qudzRsI2dCxrediYtPIVIs9f6Pbnou8vDmmp8X4/U4W788d+Ma88o+Gbg==
+"@ethersproject/json-wallets@^5.0.0", "@ethersproject/json-wallets@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.1.0.tgz#bba7af2e520e8aea4d3829d80520db5d2e4fb8d2"
+  integrity sha512-00n2iBy27w8zrGZSiU762UOVuzCQZxUZxopsZC47++js6xUFuI74DHcJ5K/2pddlF1YBskvmMuboEu1geK8mnA==
   dependencies:
-    "@ethersproject/abstract-signer" "^5.0.10"
-    "@ethersproject/address" "^5.0.9"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/hdnode" "^5.0.8"
-    "@ethersproject/keccak256" "^5.0.7"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/pbkdf2" "^5.0.7"
-    "@ethersproject/properties" "^5.0.7"
-    "@ethersproject/random" "^5.0.7"
-    "@ethersproject/strings" "^5.0.8"
-    "@ethersproject/transactions" "^5.0.9"
+    "@ethersproject/abstract-signer" "^5.1.0"
+    "@ethersproject/address" "^5.1.0"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/hdnode" "^5.1.0"
+    "@ethersproject/keccak256" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    "@ethersproject/pbkdf2" "^5.1.0"
+    "@ethersproject/properties" "^5.1.0"
+    "@ethersproject/random" "^5.1.0"
+    "@ethersproject/strings" "^5.1.0"
+    "@ethersproject/transactions" "^5.1.0"
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
-"@ethersproject/keccak256@>=5.0.0-beta.127", "@ethersproject/keccak256@^5.0.0", "@ethersproject/keccak256@^5.0.7":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.0.9.tgz#ca0d86e4af56c13b1ef25e533bde3e96d28f647d"
-  integrity sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==
-  dependencies:
-    "@ethersproject/bytes" "^5.0.9"
-    js-sha3 "0.5.7"
-
-"@ethersproject/keccak256@^5.0.3", "@ethersproject/keccak256@^5.1.0":
+"@ethersproject/keccak256@>=5.0.0-beta.127", "@ethersproject/keccak256@^5.0.0", "@ethersproject/keccak256@^5.0.3", "@ethersproject/keccak256@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.1.0.tgz#fdcd88fb13bfef4271b225cdd8dec4d315c8e60e"
   integrity sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==
@@ -1712,46 +1617,27 @@
     "@ethersproject/bytes" "^5.1.0"
     js-sha3 "0.5.7"
 
-"@ethersproject/logger@>=5.0.0-beta.129", "@ethersproject/logger@^5.0.0", "@ethersproject/logger@^5.0.8":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.0.10.tgz#fd884688b3143253e0356ef92d5f22d109d2e026"
-  integrity sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw==
-
-"@ethersproject/logger@^5.0.5", "@ethersproject/logger@^5.1.0":
+"@ethersproject/logger@>=5.0.0-beta.129", "@ethersproject/logger@^5.0.0", "@ethersproject/logger@^5.0.5", "@ethersproject/logger@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.1.0.tgz#4cdeeefac029373349d5818f39c31b82cc6d9bbf"
   integrity sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw==
 
-"@ethersproject/networks@^5.0.0", "@ethersproject/networks@^5.0.7":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.0.9.tgz#ec5da11e4d4bfd69bec4eaebc9ace33eb9569279"
-  integrity sha512-L8+VCQwArBLGkxZb/5Ns/OH/OxP38AcaveXIxhUTq+VWpXYjrObG3E7RDQIKkUx1S1IcQl/UWTz5w4DK0UitJg==
-  dependencies:
-    "@ethersproject/logger" "^5.0.8"
-
-"@ethersproject/networks@^5.0.3", "@ethersproject/networks@^5.1.0":
+"@ethersproject/networks@^5.0.0", "@ethersproject/networks@^5.0.3", "@ethersproject/networks@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.1.0.tgz#f537290cb05aa6dc5e81e910926c04cfd5814bca"
   integrity sha512-A/NIrIED/G/IgU1XUukOA3WcFRxn2I4O5GxsYGA5nFlIi+UZWdGojs85I1VXkR1gX9eFnDXzjE6OtbgZHjFhIA==
   dependencies:
     "@ethersproject/logger" "^5.1.0"
 
-"@ethersproject/pbkdf2@^5.0.0", "@ethersproject/pbkdf2@^5.0.7":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.0.9.tgz#be39c7f0a66c0d3cb1ad1dbb12a78e9bcdf9b5ae"
-  integrity sha512-ItE/wQ/WVw/ajEHPUVgfu0aEvksPgOQc+278bke8sGKnGO3ppjmqp0MHh17tHc1EBTzJbSms5aLIqc56qZ/oiA==
+"@ethersproject/pbkdf2@^5.0.0", "@ethersproject/pbkdf2@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.1.0.tgz#6b740a85dc780e879338af74856ca2c0d3b24d19"
+  integrity sha512-B8cUbHHTgs8OtgJIafrRcz/YPDobVd5Ru8gTnShOiM9EBuFpYHQpq3+8iQJ6pyczDu6HP/oc/njAsIBhwFZYew==
   dependencies:
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/sha2" "^5.0.7"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/sha2" "^5.1.0"
 
-"@ethersproject/properties@>=5.0.0-beta.131", "@ethersproject/properties@^5.0.0", "@ethersproject/properties@^5.0.7":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.0.9.tgz#d7aae634680760136ea522e25c3ef043ec15b5c2"
-  integrity sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==
-  dependencies:
-    "@ethersproject/logger" "^5.0.8"
-
-"@ethersproject/properties@^5.0.3", "@ethersproject/properties@^5.1.0":
+"@ethersproject/properties@>=5.0.0-beta.131", "@ethersproject/properties@^5.0.0", "@ethersproject/properties@^5.0.3", "@ethersproject/properties@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.1.0.tgz#9484bd6def16595fc6e4bdc26f29dff4d3f6ac42"
   integrity sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==
@@ -1784,39 +1670,31 @@
     ws "7.2.3"
 
 "@ethersproject/providers@^5.0.0":
-  version "5.0.24"
-  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.0.24.tgz#4c638a029482d052faa18364b5e0e2d3ddd9c0cb"
-  integrity sha512-M4Iw1r4gGJkt7ZUa++iREuviKL/DIpmIMsaUlVlXtV+ZrUXeN8xQ3zOTrbz7R4h9W9oljBZM7i4D3Kn1krJ30A==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.1.0.tgz#27695a02cfafa370428cde1c7a4abab13afb6a35"
+  integrity sha512-FjpZL2lSXrYpQDg2fMjugZ0HjQD9a+2fOOoRhhihh+Z+qi/xZ8vIlPoumrEP1DzIG4DBV6liUqLNqnX2C6FIAA==
   dependencies:
-    "@ethersproject/abstract-provider" "^5.0.8"
-    "@ethersproject/abstract-signer" "^5.0.10"
-    "@ethersproject/address" "^5.0.9"
-    "@ethersproject/basex" "^5.0.7"
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/constants" "^5.0.8"
-    "@ethersproject/hash" "^5.0.10"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/networks" "^5.0.7"
-    "@ethersproject/properties" "^5.0.7"
-    "@ethersproject/random" "^5.0.7"
-    "@ethersproject/rlp" "^5.0.7"
-    "@ethersproject/sha2" "^5.0.7"
-    "@ethersproject/strings" "^5.0.8"
-    "@ethersproject/transactions" "^5.0.9"
-    "@ethersproject/web" "^5.0.12"
+    "@ethersproject/abstract-provider" "^5.1.0"
+    "@ethersproject/abstract-signer" "^5.1.0"
+    "@ethersproject/address" "^5.1.0"
+    "@ethersproject/basex" "^5.1.0"
+    "@ethersproject/bignumber" "^5.1.0"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/constants" "^5.1.0"
+    "@ethersproject/hash" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    "@ethersproject/networks" "^5.1.0"
+    "@ethersproject/properties" "^5.1.0"
+    "@ethersproject/random" "^5.1.0"
+    "@ethersproject/rlp" "^5.1.0"
+    "@ethersproject/sha2" "^5.1.0"
+    "@ethersproject/strings" "^5.1.0"
+    "@ethersproject/transactions" "^5.1.0"
+    "@ethersproject/web" "^5.1.0"
     bech32 "1.1.4"
     ws "7.2.3"
 
-"@ethersproject/random@^5.0.0", "@ethersproject/random@^5.0.7":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.0.9.tgz#1903d4436ba66e4c8ac77968b16f756abea3a0d0"
-  integrity sha512-DANG8THsKqFbJOantrxumtG6gyETNE54VfbsWa+SQAT8WKpDo9W/X5Zhh73KuhClaey1UI32uVmISZeq/Zxn1A==
-  dependencies:
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/logger" "^5.0.8"
-
-"@ethersproject/random@^5.0.3":
+"@ethersproject/random@^5.0.0", "@ethersproject/random@^5.0.3", "@ethersproject/random@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.1.0.tgz#0bdff2554df03ebc5f75689614f2d58ea0d9a71f"
   integrity sha512-+uuczLQZ4+no9cP6TCoCktXx0u2YbNaRT7lRkSt12d8263e702f0u+4JnnRO8Qmv5nylWJebnqCHzyxP+6mLqw==
@@ -1824,15 +1702,7 @@
     "@ethersproject/bytes" "^5.1.0"
     "@ethersproject/logger" "^5.1.0"
 
-"@ethersproject/rlp@^5.0.0", "@ethersproject/rlp@^5.0.7":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.0.9.tgz#da205bf8a34d3c3409eb73ddd237130a4b376aff"
-  integrity sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==
-  dependencies:
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/logger" "^5.0.8"
-
-"@ethersproject/rlp@^5.0.3", "@ethersproject/rlp@^5.1.0":
+"@ethersproject/rlp@^5.0.0", "@ethersproject/rlp@^5.0.3", "@ethersproject/rlp@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.1.0.tgz#700f4f071c27fa298d3c1d637485fefe919dd084"
   integrity sha512-vDTyHIwNPrecy55gKGZ47eJZhBm8LLBxihzi5ou+zrSvYTpkSTWRcKUlXFDFQVwfWB+P5PGyERAdiDEI76clxw==
@@ -1840,16 +1710,7 @@
     "@ethersproject/bytes" "^5.1.0"
     "@ethersproject/logger" "^5.1.0"
 
-"@ethersproject/sha2@^5.0.0", "@ethersproject/sha2@^5.0.7":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.0.9.tgz#41275ee03e6e1660b3c997754005e089e936adc6"
-  integrity sha512-5FH4s47gM7N1fFAYQ1+m7aX0SbLg0Xr+6tvqndmNqc382/qBIbzXiGlUookrsjlPb6gLNurnTssCXjNM72J6lQ==
-  dependencies:
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/logger" "^5.0.8"
-    hash.js "1.1.3"
-
-"@ethersproject/sha2@^5.0.3":
+"@ethersproject/sha2@^5.0.0", "@ethersproject/sha2@^5.0.3", "@ethersproject/sha2@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.1.0.tgz#6ca42d1a26884b3e32ffa943fe6494af7211506c"
   integrity sha512-+fNSeZRstOpdRJpdGUkRONFCaiAqWkc91zXgg76Nlp5ndBQE25Kk5yK8gCPG1aGnCrbariiPr5j9DmrYH78JCA==
@@ -1858,17 +1719,7 @@
     "@ethersproject/logger" "^5.1.0"
     hash.js "1.1.3"
 
-"@ethersproject/signing-key@^5.0.0", "@ethersproject/signing-key@^5.0.8":
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.0.11.tgz#19fc5c4597e18ad0a5efc6417ba5b74069fdd2af"
-  integrity sha512-Jfcru/BGwdkXhLxT+8WCZtFy7LL0TPFZw05FAb5asxB/MyVsEfNdNxGDtjVE9zXfmRSPe/EusXYY4K7wcygOyQ==
-  dependencies:
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/properties" "^5.0.7"
-    elliptic "6.5.4"
-
-"@ethersproject/signing-key@^5.1.0":
+"@ethersproject/signing-key@^5.0.0", "@ethersproject/signing-key@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.1.0.tgz#6eddfbddb6826b597b9650e01acf817bf8991b9c"
   integrity sha512-tE5LFlbmdObG8bY04NpuwPWSRPgEswfxweAI1sH7TbP0ml1elNfqcq7ii/3AvIN05i5U0Pkm3Tf8bramt8MmLw==
@@ -1880,26 +1731,17 @@
     elliptic "6.5.4"
 
 "@ethersproject/solidity@^5.0.0":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.0.10.tgz#128c9289761cf83d81ff62a1195d6079a924a86c"
-  integrity sha512-8OG3HLqynWXDA6mVIHuHfF/ojTTwBahON7hc9GAKCqglzXCkVA3OpyxOJXPzjHClRIAUUiU7r9oy9Z/nsjtT/g==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.1.0.tgz#095a9c75244edccb26c452c155736d363399b954"
+  integrity sha512-kPodsGyo9zg1g9XSXp1lGhFaezBAUUsAUB1Vf6OkppE5Wksg4Et+x3kG4m7J/uShDMP2upkJtHNsIBK2XkVpKQ==
   dependencies:
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/keccak256" "^5.0.7"
-    "@ethersproject/sha2" "^5.0.7"
-    "@ethersproject/strings" "^5.0.8"
+    "@ethersproject/bignumber" "^5.1.0"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/keccak256" "^5.1.0"
+    "@ethersproject/sha2" "^5.1.0"
+    "@ethersproject/strings" "^5.1.0"
 
-"@ethersproject/strings@>=5.0.0-beta.130", "@ethersproject/strings@^5.0.0", "@ethersproject/strings@^5.0.8":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.0.10.tgz#ddce1e9724f4ac4f3f67e0cac0b48748e964bfdb"
-  integrity sha512-KAeoS1tZ9/5ECXiIZA6S6hywbD0so2VmuW+Wfyo5EDXeyZ6Na1nxTPhTnW7voQmjbeYJffCrOc0qLFJeylyg7w==
-  dependencies:
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/constants" "^5.0.8"
-    "@ethersproject/logger" "^5.0.8"
-
-"@ethersproject/strings@^5.0.3", "@ethersproject/strings@^5.1.0":
+"@ethersproject/strings@>=5.0.0-beta.130", "@ethersproject/strings@^5.0.0", "@ethersproject/strings@^5.0.3", "@ethersproject/strings@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.1.0.tgz#0f95a56c3c8c9d5510a06c241d818779750e2da5"
   integrity sha512-perBZy0RrmmL0ejiFGUOlBVjMsUceqLut3OBP3zP96LhiJWWbS8u1NqQVgN4/Gyrbziuda66DxiQocXhsvx+Sw==
@@ -1908,22 +1750,7 @@
     "@ethersproject/constants" "^5.1.0"
     "@ethersproject/logger" "^5.1.0"
 
-"@ethersproject/transactions@^5.0.0", "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.0.9":
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.0.11.tgz#b31df5292f47937136a45885d6ee6112477c13df"
-  integrity sha512-ftsRvR9+gQp7L63F6+XmstvsZ4w8GtWvQB08e/zB+oB86Fnhq8+i/tkgpJplSHC8I/qgiCisva+M3u2GVhDFPA==
-  dependencies:
-    "@ethersproject/address" "^5.0.9"
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/constants" "^5.0.8"
-    "@ethersproject/keccak256" "^5.0.7"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/properties" "^5.0.7"
-    "@ethersproject/rlp" "^5.0.7"
-    "@ethersproject/signing-key" "^5.0.8"
-
-"@ethersproject/transactions@^5.0.3", "@ethersproject/transactions@^5.1.0":
+"@ethersproject/transactions@^5.0.0", "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.0.3", "@ethersproject/transactions@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.1.0.tgz#da7fcd7e77e23dcfcca317a945f60bc228c61b36"
   integrity sha512-s10crRLZEA0Bgv6FGEl/AKkTw9f+RVUrlWDX1rHnD4ZncPFeiV2AJr4nT7QSUhxJdFPvjyKRDb3nEH27dIqcPQ==
@@ -1939,47 +1766,36 @@
     "@ethersproject/signing-key" "^5.1.0"
 
 "@ethersproject/units@^5.0.0":
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.0.11.tgz#f82f6e353ac0d6fa43b17337790f1f9aa72cb4c8"
-  integrity sha512-nOSPmcCWyB/dwoBRhhTtPGCsTbiXqmc7Q0Adwvafc432AC7hy3Fj3IFZtnSXsbtJ/GdHCIUIoA8gtvxSsFuBJg==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.1.0.tgz#b6ab3430ebc22adc3cb4839516496f167bee3ad5"
+  integrity sha512-isvJrx6qG0nKWfxsGORNjmOq/nh175fStfvRTA2xEKrGqx8JNJY83fswu4GkILowfriEM/eYpretfJnfzi7YhA==
   dependencies:
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/constants" "^5.0.8"
-    "@ethersproject/logger" "^5.0.8"
+    "@ethersproject/bignumber" "^5.1.0"
+    "@ethersproject/constants" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
 
 "@ethersproject/wallet@^5.0.0":
-  version "5.0.12"
-  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.0.12.tgz#bfb96f95e066b4b1b4591c4615207b87afedda8b"
-  integrity sha512-rboJebGf47/KPZrKZQdYg9BAYuXbc/OwcUyML1K1f2jnJeo1ObWV11U1PAWTjTbhhSy6/Fg+34GO2yMb5Dt1Rw==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.1.0.tgz#134c5816eaeaa586beae9f9ff67891104a2c9a15"
+  integrity sha512-ULmUtiYQLTUS+y3DgkLzRhFEK10zMwmjOthnjiZxee3Q/MVwr3rnmuAnXIUZrPjna6hvUPnyRIdW5XuF0Ld0YQ==
   dependencies:
-    "@ethersproject/abstract-provider" "^5.0.8"
-    "@ethersproject/abstract-signer" "^5.0.10"
-    "@ethersproject/address" "^5.0.9"
-    "@ethersproject/bignumber" "^5.0.13"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/hash" "^5.0.10"
-    "@ethersproject/hdnode" "^5.0.8"
-    "@ethersproject/json-wallets" "^5.0.10"
-    "@ethersproject/keccak256" "^5.0.7"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/properties" "^5.0.7"
-    "@ethersproject/random" "^5.0.7"
-    "@ethersproject/signing-key" "^5.0.8"
-    "@ethersproject/transactions" "^5.0.9"
-    "@ethersproject/wordlists" "^5.0.8"
+    "@ethersproject/abstract-provider" "^5.1.0"
+    "@ethersproject/abstract-signer" "^5.1.0"
+    "@ethersproject/address" "^5.1.0"
+    "@ethersproject/bignumber" "^5.1.0"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/hash" "^5.1.0"
+    "@ethersproject/hdnode" "^5.1.0"
+    "@ethersproject/json-wallets" "^5.1.0"
+    "@ethersproject/keccak256" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    "@ethersproject/properties" "^5.1.0"
+    "@ethersproject/random" "^5.1.0"
+    "@ethersproject/signing-key" "^5.1.0"
+    "@ethersproject/transactions" "^5.1.0"
+    "@ethersproject/wordlists" "^5.1.0"
 
-"@ethersproject/web@^5.0.0", "@ethersproject/web@^5.0.12":
-  version "5.0.14"
-  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.0.14.tgz#6e7bebdd9fb967cb25ee60f44d9218dc0803bac4"
-  integrity sha512-QpTgplslwZ0Sp9oKNLoRuS6TKxnkwfaEk3gr7zd7XLF8XBsYejsrQO/03fNfnMx/TAT/RR6WEw/mbOwpRSeVRA==
-  dependencies:
-    "@ethersproject/base64" "^5.0.7"
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/properties" "^5.0.7"
-    "@ethersproject/strings" "^5.0.8"
-
-"@ethersproject/web@^5.0.4", "@ethersproject/web@^5.1.0":
+"@ethersproject/web@^5.0.0", "@ethersproject/web@^5.0.4", "@ethersproject/web@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.1.0.tgz#ed56bbe4e3d9a8ffe3b2ed882da5c62d3551381b"
   integrity sha512-LTeluWgTq04+RNqAkVhpydPcRZK/kKxD2Vy7PYGrAD27ABO9kTqTBKwiOuzTyAHKUQHfnvZbXmxBXJAGViSDcA==
@@ -1990,16 +1806,16 @@
     "@ethersproject/properties" "^5.1.0"
     "@ethersproject/strings" "^5.1.0"
 
-"@ethersproject/wordlists@^5.0.0", "@ethersproject/wordlists@^5.0.8":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.0.10.tgz#177b9a0b4d72b9c4f304d08b36612d6c60e9b896"
-  integrity sha512-jWsEm1iJzpg9SCXnNfFz+tcp4Ofzv0TJb6mj+soCNcar9GcT0yGz62ZsHC3pLQWaF4LkCzGwRJHJTXKjHQfG1A==
+"@ethersproject/wordlists@^5.0.0", "@ethersproject/wordlists@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.1.0.tgz#54eb9ef3a00babbff90ffe124e19c89e07e6aace"
+  integrity sha512-NsUCi/TpBb+oTFvMSccUkJGtp5o/84eOyqp5q5aBeiNBSLkYyw21znRn9mAmxZgySpxgruVgKbaapnYPgvctPQ==
   dependencies:
-    "@ethersproject/bytes" "^5.0.9"
-    "@ethersproject/hash" "^5.0.10"
-    "@ethersproject/logger" "^5.0.8"
-    "@ethersproject/properties" "^5.0.7"
-    "@ethersproject/strings" "^5.0.8"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/hash" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    "@ethersproject/properties" "^5.1.0"
+    "@ethersproject/strings" "^5.1.0"
 
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
@@ -3314,17 +3130,15 @@
     once "^1.4.0"
 
 "@octokit/request@^5.2.0":
-  version "5.4.14"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.14.tgz#ec5f96f78333bb2af390afa5ff66f114b063bc96"
-  integrity sha512-VkmtacOIQp9daSnBmDI92xNIeLuSRDOIuplp/CJomkvzt7M18NXgG044Cx/LFKLgjKt9T2tZR6AtJayba9GTSA==
+  version "5.4.15"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.15.tgz#829da413dc7dd3aa5e2cdbb1c7d0ebe1f146a128"
+  integrity sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==
   dependencies:
     "@octokit/endpoint" "^6.0.1"
     "@octokit/request-error" "^2.0.0"
     "@octokit/types" "^6.7.1"
-    deprecation "^2.0.0"
     is-plain-object "^5.0.0"
     node-fetch "^2.6.1"
-    once "^1.4.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^16.28.4":
@@ -3374,9 +3188,9 @@
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
 "@sinonjs/commons@^1.7.0":
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.2.tgz#858f5c4b48d80778fde4b9d541f27edc0d56488b"
-  integrity sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
+  integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
   dependencies:
     type-detect "4.0.8"
 
@@ -3498,9 +3312,9 @@
     defer-to-connect "^1.0.1"
 
 "@testing-library/dom@*", "@testing-library/dom@^7.28.1":
-  version "7.30.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.30.1.tgz#07b6f3ccd7f1f1e34ab0406932073e2971817f3d"
-  integrity sha512-RQUvqqq2lxTCOffhSNxpX/9fCoR+nwuQPmG5uhuuEH5KBAzNf2bK3OzBoWjm5zKM78SLjnGRAKt8hRjQA4E46A==
+  version "7.30.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.30.3.tgz#779ea9bbb92d63302461800a388a5a890ac22519"
+  integrity sha512-7JhIg2MW6WPwyikH2iL3o7z+FTVgSOd2jqCwTAHqK7Qal2gRRYiUQyURAxtbK9VXm/UTyG9bRihv8C5Tznr2zw==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
@@ -3525,9 +3339,9 @@
     wait-for-expect "^3.0.2"
 
 "@testing-library/react-hooks@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.1.0.tgz#6014b7536d0e9427a1e73ce1d073c49a6af5fb3b"
-  integrity sha512-ChRyyA14e0CeVkWGp24v8q/IiWUqH+B8daRx4lGZme4dsudmMNWz+Qo2Q2NzbD2O5rAVXh2hSbS/KTKeqHYhkw==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.1.1.tgz#1fbaae8a4e8a4a7f97b176c23e1e890c41bbbfa5"
+  integrity sha512-52D2XnpelFDefnWpy/V6z2qGNj8JLIvW5DjYtelMvFXdEyWiykSaI7IXHwFy4ICoqXJDmmwHAiFRiFboub/U5g==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/react" ">=16.9.0"
@@ -3537,9 +3351,9 @@
     react-error-boundary "^3.1.0"
 
 "@testing-library/react@^11.2.5":
-  version "11.2.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.5.tgz#ae1c36a66c7790ddb6662c416c27863d87818eb9"
-  integrity sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==
+  version "11.2.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.6.tgz#586a23adc63615985d85be0c903f374dab19200b"
+  integrity sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
@@ -3630,9 +3444,9 @@
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
 "@types/eslint@^7.2.0":
-  version "7.2.7"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.7.tgz#f7ef1cf0dceab0ae6f9a976a0a9af14ab1baca26"
-  integrity sha512-EHXbc1z2GoQRqHaAT7+grxlTJ3WE2YNeD6jlpPoRc83cCoThRY+NUWjCUZaYmk51OICkPXn2hhphcWcWXgNW0Q==
+  version "7.2.10"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.10.tgz#4b7a9368d46c0f8cd5408c23288a59aa2394d917"
+  integrity sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -3735,9 +3549,9 @@
   integrity sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw==
 
 "@types/node@*", "@types/node@>= 8":
-  version "14.14.37"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
-  integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
+  version "14.14.41"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
+  integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
 
 "@types/node@12.6.9":
   version "12.6.9"
@@ -3745,9 +3559,9 @@
   integrity sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==
 
 "@types/node@^12.0.0", "@types/node@^12.12.6":
-  version "12.20.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.7.tgz#1cb61fd0c85cb87e728c43107b5fd82b69bc9ef8"
-  integrity sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==
+  version "12.20.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.10.tgz#4dcb8a85a8f1211acafb88d72fafc7e3d2685583"
+  integrity sha512-TxCmnSSppKBBOzYzPR2BR25YlX5Oay8z2XGwFBInuA/Co0V9xJhLlW4kjbxKtgeNo3NOMbQP1A5Rc03y+XecPw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -3833,9 +3647,9 @@
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/secp256k1@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/secp256k1/-/secp256k1-4.0.1.tgz#fb3aa61a1848ad97d7425ff9dcba784549fca5a4"
-  integrity sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/secp256k1/-/secp256k1-4.0.2.tgz#20c29a87149d980f64464e56539bf4810fdb5d1d"
+  integrity sha512-QMg+9v0bbNJ2peLuHRWxzmy0HRJIG6gFZNhaRSp7S3ggSbCCxiqQB2/ybvhXyhHOCequpNkrx7OavNhrWOsW0A==
   dependencies:
     "@types/node" "*"
 
@@ -4327,21 +4141,21 @@
     "@xtuc/long" "4.2.2"
 
 "@webpack-cli/configtest@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.0.1.tgz#241aecfbdc715eee96bed447ed402e12ec171935"
-  integrity sha512-B+4uBUYhpzDXmwuo3V9yBH6cISwxEI4J+NO5ggDaGEEHb0osY/R7MzeKc0bHURXQuZjMM4qD+bSJCKIuI3eNBQ==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.0.2.tgz#2a20812bfb3a2ebb0b27ee26a52eeb3e3f000836"
+  integrity sha512-3OBzV2fBGZ5TBfdW50cha1lHDVf9vlvRXnjpVbJBa20pSZQaSkMJZiwA8V2vD9ogyeXn8nU5s5A6mHyf5jhMzA==
 
 "@webpack-cli/info@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.2.2.tgz#ef3c0cd947a1fa083e174a59cb74e0b6195c236c"
-  integrity sha512-5U9kUJHnwU+FhKH4PWGZuBC1hTEPYyxGSL5jjoBI96Gx8qcYJGOikpiIpFoTq8mmgX3im2zAo2wanv/alD74KQ==
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.2.3.tgz#ef819d10ace2976b6d134c7c823a3e79ee31a92c"
+  integrity sha512-lLek3/T7u40lTqzCGpC6CAbY6+vXhdhmwFRxZLMnRm6/sIF/7qMpT8MocXCRQfz0JAh63wpbXLMnsQ5162WS7Q==
   dependencies:
     envinfo "^7.7.3"
 
 "@webpack-cli/serve@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.3.0.tgz#2730c770f5f1f132767c63dcaaa4ec28f8c56a6c"
-  integrity sha512-k2p2VrONcYVX1wRRrf0f3X2VGltLWcv+JzXRBDmvCxGlCeESx4OXw91TsWeKOkp784uNoVQo313vxJFHXPPwfw==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.3.1.tgz#911d1b3ff4a843304b9c3bacf67bb34672418441"
+  integrity sha512-0qXvpeYO6vaNoRBI52/UsbcaBydJCggoBBnIo/ovQQdn6fug0BgwsjorV1hVS7fMqGVTZGcVxv8334gjmbj5hw==
 
 "@wry/equality@^0.1.2":
   version "0.1.11"
@@ -4465,10 +4279,10 @@ acorn@^7.1.1, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.0.5:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.1.0.tgz#52311fd7037ae119cbb134309e901aa46295b3fe"
-  integrity sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==
+acorn@^8.1.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.1.1.tgz#fb0026885b9ac9f48bac1e185e4af472971149ff"
+  integrity sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==
 
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
@@ -4540,10 +4354,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^7.0.2:
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.2.4.tgz#8e239d4d56cf884bccca8cca362f508446dc160f"
-  integrity sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==
+ajv@^8.0.1:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.1.0.tgz#45d5d3d36c7cdd808930cc3e603cf6200dbeb736"
+  integrity sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -4652,9 +4466,9 @@ anymatch@^2.0.0:
     normalize-path "^2.1.1"
 
 anymatch@^3.0.3, anymatch@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
-  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
@@ -4790,6 +4604,11 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
+
+array-filter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-1.0.0.tgz#baf79e62e6ef4c2a4c0b831232daffec251f9d83"
+  integrity sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=
 
 array-find-index@^1.0.1:
   version "1.0.2"
@@ -4990,6 +4809,13 @@ autoprefixer@^9.6.1:
     num2fraction "^1.2.2"
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
+
+available-typed-arrays@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz#6b098ca9d8039079ee3f77f7b783c4480ba513f5"
+  integrity sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==
+  dependencies:
+    array-filter "^1.0.0"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -5271,29 +5097,29 @@ babel-plugin-named-asset-import@^0.3.6:
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz#156cd55d3f1228a5765774340937afc8398067dd"
   integrity sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==
 
-babel-plugin-polyfill-corejs2@^0.1.4:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.10.tgz#a2c5c245f56c0cac3dbddbf0726a46b24f0f81d1"
-  integrity sha512-DO95wD4g0A8KRaHKi0D51NdGXzvpqVLnLu5BTvDlpqUEpTmeEtypgC1xqesORaWmiUOQI14UHKlzNd9iZ2G3ZA==
+babel-plugin-polyfill-corejs2@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.0.tgz#686775bf9a5aa757e10520903675e3889caeedc4"
+  integrity sha512-9bNwiR0dS881c5SHnzCmmGlMkJLl0OUZvxrxHo9w/iNoRuqaPjqlvBf4HrovXtQs/au5yKkpcdgfT1cC5PAZwg==
   dependencies:
-    "@babel/compat-data" "^7.13.0"
-    "@babel/helper-define-polyfill-provider" "^0.1.5"
+    "@babel/compat-data" "^7.13.11"
+    "@babel/helper-define-polyfill-provider" "^0.2.0"
     semver "^6.1.1"
 
-babel-plugin-polyfill-corejs3@^0.1.3:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz#80449d9d6f2274912e05d9e182b54816904befd0"
-  integrity sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==
+babel-plugin-polyfill-corejs3@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.0.tgz#f4b4bb7b19329827df36ff56f6e6d367026cb7a2"
+  integrity sha512-zZyi7p3BCUyzNxLx8KV61zTINkkV65zVkDAFNZmrTCRVhjo1jAS+YLvDJ9Jgd/w2tsAviCwFHReYfxO3Iql8Yg==
   dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.1.5"
-    core-js-compat "^3.8.1"
+    "@babel/helper-define-polyfill-provider" "^0.2.0"
+    core-js-compat "^3.9.1"
 
-babel-plugin-polyfill-regenerator@^0.1.2:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.6.tgz#0fe06a026fe0faa628ccc8ba3302da0a6ce02f3f"
-  integrity sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==
+babel-plugin-polyfill-regenerator@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.0.tgz#853f5f5716f4691d98c84f8069c7636ea8da7ab8"
+  integrity sha512-J7vKbCuD2Xi/eEHxquHN14bXAW9CXtecwuLrOIDJtcZzTaPzV1VdEfoUf9AzcRBMolKUQKM9/GVojeh0hFiqMg==
   dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.1.5"
+    "@babel/helper-define-polyfill-provider" "^0.2.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -5701,9 +5527,9 @@ babylon@^6.18.0:
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 base-x@^3.0.2, base-x@^3.0.8:
   version "3.0.8"
@@ -5748,9 +5574,9 @@ bech32@1.1.4:
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
 before-after-hook@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.0.tgz#09c40d92e936c64777aa385c4e9b904f8147eaf0"
-  integrity sha512-jH6rKQIfroBbhEXVmI7XmXe3ix5S/PgJqpzdDPnR8JGLHWNYLsYZ6tK5iWOF/Ra3oqEX0NobXGlzbiylIzVphQ==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.1.tgz#73540563558687586b52ed217dad6a802ab1549c"
+  integrity sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -6004,15 +5830,15 @@ browserslist@^3.2.6:
     electron-to-chromium "^1.3.47"
 
 browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.3, browserslist@^4.5.2, browserslist@^4.6.2, browserslist@^4.6.4, browserslist@^4.9.1:
-  version "4.16.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.3.tgz#340aa46940d7db878748567c5dea24a48ddf3717"
-  integrity sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==
+  version "4.16.4"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.4.tgz#7ebf913487f40caf4637b892b268069951c35d58"
+  integrity sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==
   dependencies:
-    caniuse-lite "^1.0.30001181"
-    colorette "^1.2.1"
-    electron-to-chromium "^1.3.649"
+    caniuse-lite "^1.0.30001208"
+    colorette "^1.2.2"
+    electron-to-chromium "^1.3.712"
     escalade "^3.1.1"
-    node-releases "^1.1.70"
+    node-releases "^1.1.71"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -6325,10 +6151,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001181:
-  version "1.0.30001204"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz#256c85709a348ec4d175e847a3b515c66e79f2aa"
-  integrity sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001208:
+  version "1.0.30001209"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001209.tgz#1bb4be0bd118e98e21cfb7ef617b1ef2164622f4"
+  integrity sha512-2Ktt4OeRM7EM/JaOZjuLzPYAIqmbwQMNnYbgooT+icoRGrKOyAxA1xhlnotBD1KArRSPsuJp3TdYcZYrL7qNxA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -6441,11 +6267,9 @@ chownr@^1.1.1, chownr@^1.1.2:
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 chrome-trace-event@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
-  integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
-  dependencies:
-    tslib "^1.9.0"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
+  integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -6738,7 +6562,7 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.4"
 
-colorette@^1.2.1:
+colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
@@ -7062,18 +6886,18 @@ copyfiles@2.4.1:
     untildify "^4.0.0"
     yargs "^16.1.0"
 
-core-js-compat@^3.0.0, core-js-compat@^3.6.2, core-js-compat@^3.8.1, core-js-compat@^3.9.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.9.1.tgz#4e572acfe90aff69d76d8c37759d21a5c59bb455"
-  integrity sha512-jXAirMQxrkbiiLsCx9bQPJFA6llDadKMpYrBJQJ3/c4/vsPP/fAf29h24tviRlvwUL6AmY5CHLu2GvjuYviQqA==
+core-js-compat@^3.0.0, core-js-compat@^3.6.2, core-js-compat@^3.9.0, core-js-compat@^3.9.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.10.1.tgz#62183a3a77ceeffcc420d907a3e6fc67d9b27f1c"
+  integrity sha512-ZHQTdTPkqvw2CeHiZC970NNJcnwzT6YIueDMASKt+p3WbZsLXOcoD392SkcWhkC0wBBHhlfhqGKKsNCQUozYtg==
   dependencies:
     browserslist "^4.16.3"
     semver "7.0.0"
 
 core-js-pure@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.9.1.tgz#677b322267172bd490e4464696f790cbc355bec5"
-  integrity sha512-laz3Zx0avrw9a4QEIdmIblnVuJz8W51leY9iLThatCsFawWxC3sE4guASC78JbCin+DkwMpCdp1AVAuzL/GN7A==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.10.1.tgz#28642697dfcf02e0fd9f4d9891bd03a22df28ecf"
+  integrity sha512-PeyJH2SE0KuxY5eCGNWA+W+CeDpB6M1PN3S7Am7jSv/Ttuxz2SnWbIiVQOn/TDaGaGtxo8CRWHkXwJscbUHtVw==
 
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
   version "2.6.12"
@@ -7081,9 +6905,9 @@ core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.5.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.9.1.tgz#cec8de593db8eb2a85ffb0dbdeb312cb6e5460ae"
-  integrity sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.1.tgz#e683963978b6806dcc6c0a4a8bd4ab0bdaf3f21a"
+  integrity sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -7289,9 +7113,9 @@ css-tree@1.0.0-alpha.37:
     source-map "^0.6.1"
 
 css-tree@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.2.tgz#9ae393b5dafd7dae8a622475caec78d3d8fbd7b5"
-  integrity sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
   dependencies:
     mdn-data "2.0.14"
     source-map "^0.6.1"
@@ -7326,10 +7150,10 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-cssnano-preset-default@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz#51ec662ccfca0f88b396dcd9679cdb931be17f76"
-  integrity sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==
+cssnano-preset-default@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-4.0.8.tgz#920622b1fc1e95a34e8838203f1397a504f2d3ff"
+  integrity sha512-LdAyHuq+VRyeVREFmuxUZR1TXjQm8QQU/ktoo/x7bz+SdOge1YKc5eMN6pRW7YWBmyq59CqYba1dJ5cUukEjLQ==
   dependencies:
     css-declaration-sorter "^4.0.1"
     cssnano-util-raw-cache "^4.0.1"
@@ -7359,7 +7183,7 @@ cssnano-preset-default@^4.0.7:
     postcss-ordered-values "^4.1.2"
     postcss-reduce-initial "^4.0.3"
     postcss-reduce-transforms "^4.0.2"
-    postcss-svgo "^4.0.2"
+    postcss-svgo "^4.0.3"
     postcss-unique-selectors "^4.0.1"
 
 cssnano-util-get-arguments@^4.0.0:
@@ -7385,12 +7209,12 @@ cssnano-util-same-parent@^4.0.0:
   integrity sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==
 
 cssnano@^4.1.10:
-  version "4.1.10"
-  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-4.1.10.tgz#0ac41f0b13d13d465487e111b778d42da631b8b2"
-  integrity sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-4.1.11.tgz#c7b5f5b81da269cb1fd982cb960c1200910c9a99"
+  integrity sha512-6gZm2htn7xIPJOHY824ERgj8cNPgPxyCSnkXc4v7YvNW+TdVfzgngHcEhy/8D11kUWRUMbke+tC+AUcUsnMz2g==
   dependencies:
     cosmiconfig "^5.0.0"
-    cssnano-preset-default "^4.0.7"
+    cssnano-preset-default "^4.0.8"
     is-resolvable "^1.0.0"
     postcss "^7.0.0"
 
@@ -7871,9 +7695,9 @@ domelementtype@1, domelementtype@^1.3.1:
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
 domelementtype@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e"
-  integrity sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -7981,10 +7805,10 @@ electron-fetch@^1.7.2:
   dependencies:
     encoding "^0.1.13"
 
-electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.649:
-  version "1.3.701"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.701.tgz#5e796ed7ce88cd77bc7bf831cf311ef6b067c389"
-  integrity sha512-Zd9ofdIMYHYhG1gvnejQDvC/kqSeXQvtXF0yRURGxgwGqDZm9F9Fm3dYFnm5gyuA7xpXfBlzVLN1sz0FjxpKfw==
+electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.712:
+  version "1.3.717"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz#78d4c857070755fb58ab64bcc173db1d51cbc25f"
+  integrity sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==
 
 elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3:
   version "6.5.4"
@@ -8097,9 +7921,9 @@ env-paths@^2.2.0:
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 envinfo@^7.3.1, envinfo@^7.7.3:
-  version "7.7.4"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.7.4.tgz#c6311cdd38a0e86808c1c9343f667e4267c4a320"
-  integrity sha512-TQXTYFVVwwluWSFis6K2XKxgrD22jEv0FTuLCQI+OjH7rn93+iY0fSSFM5lrSxFY+H1+B0/cvvlamr3UsBivdQ==
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"
+  integrity sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -9374,6 +9198,11 @@ for-own@^0.1.3:
   dependencies:
     for-in "^1.0.1"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -9681,9 +9510,9 @@ get-stream@^5.0.0, get-stream@^5.1.0:
     pump "^3.0.0"
 
 get-stream@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
-  integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -10039,9 +9868,9 @@ hard-rejection@^2.1.0:
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
 harmony-reflect@^1.4.6:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.1.tgz#c108d4f2bb451efef7a37861fdbdae72c9bdefa9"
-  integrity sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
+  integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -10175,9 +10004,9 @@ hmac-drbg@^1.0.1:
     minimalistic-crypto-utils "^1.0.1"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
-  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 hosted-git-info@^4.0.1:
   version "4.0.2"
@@ -10205,11 +10034,6 @@ hsla-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
-
-html-comment-regex@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
-  integrity sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==
 
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
@@ -11016,9 +10840,9 @@ is-directory@^0.3.1:
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
 is-docker@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
-  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-electron@^2.2.0:
   version "2.2.0"
@@ -11073,6 +10897,11 @@ is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
+is-generator-function@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.8.tgz#dfb5c2b120e02b0a8d9d2c6806cd5621aa922f7b"
+  integrity sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ==
 
 is-glob@^3.1.0:
   version "3.1.0"
@@ -11202,9 +11031,9 @@ is-plain-object@^5.0.0:
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-potential-custom-element-name@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
-  integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
 
 is-promise@^2.2.2:
   version "2.2.2"
@@ -11268,13 +11097,6 @@ is-string@^1.0.5:
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
 
-is-svg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-3.0.0.tgz#9321dbd29c212e5ca99c4fa9794c714bcafa2f75"
-  integrity sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==
-  dependencies:
-    html-comment-regex "^1.1.0"
-
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
@@ -11288,6 +11110,17 @@ is-text-path@^1.0.1:
   integrity sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=
   dependencies:
     text-extensions "^1.0.0"
+
+is-typed-array@^1.1.3:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.5.tgz#f32e6e096455e329eb7b423862456aa213f0eb4e"
+  integrity sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==
+  dependencies:
+    available-typed-arrays "^1.0.2"
+    call-bind "^1.0.2"
+    es-abstract "^1.18.0-next.2"
+    foreach "^2.0.5"
+    has-symbols "^1.0.1"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -12418,12 +12251,12 @@ jsdom@^14.1.0:
     xml-name-validator "^3.0.0"
 
 jsdom@^16.4.0:
-  version "16.5.1"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.5.1.tgz#4ced6bbd7b77d67fb980e64d9e3e6fb900f97dd6"
-  integrity sha512-pF73EOsJgwZekbDHEY5VO/yKXUkab/DuvrQB/ANVizbr6UAHJsDdHXuotZYwkJSGQl1JM+ivXaqY+XBDDL4TiA==
+  version "16.5.3"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.5.3.tgz#13a755b3950eb938b4482c407238ddf16f0d2136"
+  integrity sha512-Qj1H+PEvUsOtdPJ056ewXM4UJPCi4hhLA8wpiz9F2YvsRBhuFsXxtrIFAgGBDynQA9isAMGE91PfUYbdMPXuTA==
   dependencies:
     abab "^2.0.5"
-    acorn "^8.0.5"
+    acorn "^8.1.0"
     acorn-globals "^6.0.0"
     cssom "^0.4.4"
     cssstyle "^2.3.0"
@@ -12445,7 +12278,7 @@ jsdom@^16.4.0:
     webidl-conversions "^6.1.0"
     whatwg-encoding "^1.0.5"
     whatwg-mimetype "^2.3.0"
-    whatwg-url "^8.0.0"
+    whatwg-url "^8.5.0"
     ws "^7.4.4"
     xml-name-validator "^3.0.0"
 
@@ -12920,6 +12753,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -13019,6 +12857,11 @@ lodash.trimstart@^4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/lodash.trimstart/-/lodash.trimstart-4.5.1.tgz#8ff4dec532d82486af59573c39445914e944a7f1"
   integrity sha1-j/TexTLYJIavWVc8OURZFOlEp/E=
+
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -13224,9 +13067,9 @@ map-obj@^2.0.0:
   integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
 
 map-obj@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.2.0.tgz#0e8bc823e2aaca8a0942567d12ed14f389eec153"
-  integrity sha512-NAq0fCmZYGz9UFEQyndp7sisrow4GroyGeKluyKC/chuITZsPyOyC1UJZPJlVFImhXdROIP5xqouRLThT3BbpQ==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.2.1.tgz#e4ea399dbc979ae735c83c863dd31bdf364277b7"
+  integrity sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -13428,12 +13271,12 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     to-regex "^3.0.2"
 
 micromatch@^4.0.0, micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
   dependencies:
     braces "^3.0.1"
-    picomatch "^2.0.5"
+    picomatch "^2.2.3"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -13443,17 +13286,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.46.0, "mime-db@>= 1.43.0 < 2":
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee"
-  integrity sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
+mime-db@1.47.0, "mime-db@>= 1.43.0 < 2":
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.47.0.tgz#8cb313e59965d3c05cfbf898915a267af46a335c"
+  integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
 
 mime-types@^2.1.12, mime-types@^2.1.16, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
-  version "2.1.29"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.29.tgz#1d4ab77da64b91f5f72489df29236563754bb1b2"
-  integrity sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==
+  version "2.1.30"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.30.tgz#6e7be8b4c479825f85ed6326695db73f9305d62d"
+  integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
   dependencies:
-    mime-db "1.46.0"
+    mime-db "1.47.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -13740,12 +13583,11 @@ multibase@^3.0.0, multibase@^3.1.0:
     web-encoding "^1.0.6"
 
 multibase@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/multibase/-/multibase-4.0.2.tgz#8250a0f50d0ed49765146bf0e3431e3df9b249ac"
-  integrity sha512-l0XMK4O5I9cCfxC0/UMDX/UxlIlrqkjEZQNG+ZUUrsGhnXWgFXgatYOQSONiR/lQGfBO463UyZkh3SiQBpjRIQ==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/multibase/-/multibase-4.0.4.tgz#55ef53e6acce223c5a09341a8a3a3d973871a577"
+  integrity sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==
   dependencies:
     "@multiformats/base-x" "^4.0.1"
-    web-encoding "^1.1.0"
 
 multibase@~0.6.0:
   version "0.6.1"
@@ -14124,7 +13966,7 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-releases@^1.1.52, node-releases@^1.1.70:
+node-releases@^1.1.52, node-releases@^1.1.71:
   version "1.1.71"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
@@ -14335,9 +14177,9 @@ object-hash@^2.0.1:
   integrity sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==
 
 object-inspect@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
-  integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.1.tgz#b69d9494d35a56387bbaebbae61c55510d877a1a"
+  integrity sha512-WQUIkCSDPWm5ing/PTUkLr2KaOXX2uV/vz1hLGW2XbZ/RDUmtgcsOyEqA1ox0rkyNx9mJX4kxX+YWceje3pmag==
 
 object-is@^1.0.1:
   version "1.1.5"
@@ -15001,9 +14843,9 @@ path-type@^4.0.0:
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 pbkdf2@^3.0.17, pbkdf2@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
-  integrity sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
+  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -15016,10 +14858,10 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
-  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
+  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -15325,11 +15167,10 @@ postcss-image-set-function@^3.0.1:
     postcss-values-parser "^2.0.0"
 
 postcss-initial@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-3.0.2.tgz#f018563694b3c16ae8eaabe3c585ac6319637b2d"
-  integrity sha512-ugA2wKonC0xeNHgirR4D3VWHs2JcU08WAi1KFLVcnb7IN89phID6Qtg2RIctWbnvp1TM2BOmDtX8GGLCKdR8YA==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-3.0.4.tgz#9d32069a10531fe2ecafa0b6ac750ee0bc7efc53"
+  integrity sha512-3RLn6DIpMsK1l5UUy9jxQvoDeUN4gP939tDcKUHD/kM8SGSKbFAnvkpFpj3Bhtz3HGk1jWY5ZNWX6mPta5M9fg==
   dependencies:
-    lodash.template "^4.5.0"
     postcss "^7.0.2"
 
 postcss-lab-function@^2.0.1:
@@ -15727,12 +15568,11 @@ postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
     uniq "^1.0.1"
     util-deprecate "^1.0.2"
 
-postcss-svgo@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-4.0.2.tgz#17b997bc711b333bab143aaed3b8d3d6e3d38258"
-  integrity sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==
+postcss-svgo@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-4.0.3.tgz#343a2cdbac9505d416243d496f724f38894c941e"
+  integrity sha512-NoRbrcMWTtUghzuKSoIm6XV+sJdvZ7GZSc3wdBN0W19FTtp2ko8NqLsgoh/m9CzNhU3KLPvQmjIwtaNFkaFTvw==
   dependencies:
-    is-svg "^3.0.0"
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
     svgo "^1.0.0"
@@ -15904,9 +15744,9 @@ promise@^8.0.3:
     asap "~2.0.6"
 
 prompts@^2.0.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.0.tgz#4aa5de0723a231d1ee9121c40fdf663df73f61d7"
-  integrity sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.1.tgz#befd3b1195ba052f9fd2fde8a486c4e82ee77f61"
+  integrity sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
@@ -15955,13 +15795,13 @@ protoduck@^5.0.1:
     genfun "^5.0.0"
 
 protons@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/protons/-/protons-2.0.0.tgz#a6910161f0ed0f3a9007c1503acda7a402023cd8"
-  integrity sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/protons/-/protons-2.0.1.tgz#bfee5123c100001dcf56ab8f71b1b36f2e8289f1"
+  integrity sha512-FlmPorLEeCEDPu+uIn0Qardgiy5XqVA4IyNTz9wb9c0e2U7BEXdRcIbx64r09o4Abtf+4B7mkTtMbsIXMxZzKw==
   dependencies:
     protocol-buffers-schema "^3.3.1"
     signed-varint "^2.0.1"
-    uint8arrays "^1.0.0"
+    uint8arrays "^2.1.3"
     varint "^5.0.0"
 
 proxy-addr@~2.0.5:
@@ -16740,9 +16580,9 @@ renderkid@^2.0.4:
     strip-ansi "^3.0.0"
 
 repeat-element@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
-  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.4.tgz#be681520847ab58c7568ac75fbfad28ed42d39e9"
+  integrity sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==
 
 repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
@@ -17049,9 +16889,9 @@ run@^1.4.0:
     minimatch "*"
 
 rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.6.0:
-  version "6.6.6"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.6.tgz#14d8417aa5a07c5e633995b525e1e3c0dec03b70"
-  integrity sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -17718,9 +17558,9 @@ sshpk@^1.7.0:
     tweetnacl "~0.14.0"
 
 ssri@^6.0.0, ssri@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
-  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
+  integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
   dependencies:
     figgy-pudding "^3.5.1"
 
@@ -17738,9 +17578,9 @@ stable@^0.1.8:
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
 stack-utils@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.4.tgz#4b600971dcfc6aed0cbdf2a8268177cc916c87c8"
-  integrity sha512-IPDJfugEGbfizBwBZRZ3xpccMdRyP5lqsBWXGQWimVjua/ccLCeMOAVjlc1R7LxFjo5sEDhyNIXd8mo/AiDS9w==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.5.tgz#a19b0b01947e0029c8e451d5d61a498f5bb1471b"
+  integrity sha512-KZiTzuV3CnSnSvgMRrARVCj+Ht7rMbauGDK0LdVFRGyenwdylpajAp4Q0i6SX8rEmbTpMMf6ryq2gb8pPq2WgQ==
   dependencies:
     escape-string-regexp "^2.0.0"
 
@@ -17814,9 +17654,9 @@ stream-shift@^1.0.0:
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
 stream-to-it@^0.2.0, stream-to-it@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/stream-to-it/-/stream-to-it-0.2.2.tgz#fb3de7917424c354a987c7bc2aab2d0facbd7d94"
-  integrity sha512-waULBmQpVdr6TkDzci6t1P7dIaSZ0bHC1TaPXDUeJC5PpSK7U3T0H0Zeo/LWUnd6mnhXOmGGDKAkjUCHw5IOng==
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/stream-to-it/-/stream-to-it-0.2.3.tgz#b9320ceb26a51b313de81036d4354d9b657f4d2d"
+  integrity sha512-xaK9EjPtLox5rrC7YLSBXSanTtUJN/lzJlMFvy9VaROmnyvy0U/X6m2uMhXPJRn3g3M9uOSIzTszW7BPiWSg9w==
   dependencies:
     get-iterator "^1.0.2"
 
@@ -18100,9 +17940,9 @@ supports-color@^7.0.0, supports-color@^7.1.0:
     has-flag "^4.0.0"
 
 supports-hyperlinks@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz#f663df252af5f37c5d49bbd7eeefa9e0b9e59e47"
-  integrity sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"
+  integrity sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
@@ -18164,12 +18004,17 @@ table@^5.2.3:
     string-width "^3.0.0"
 
 table@^6.0.4:
-  version "6.0.7"
-  resolved "https://registry.yarnpkg.com/table/-/table-6.0.7.tgz#e45897ffbcc1bcf9e8a87bf420f2c9e5a7a52a34"
-  integrity sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.1.0.tgz#676a0cfb206008b59e783fcd94ef8ba7d67d966c"
+  integrity sha512-T4G5KMmqIk6X87gLKWyU5exPpTjLjY5KyrFWaIjv3SvgaIUGXV7UEzGEnZJdTA38/yUS6f9PlKezQ0bYXG3iIQ==
   dependencies:
-    ajv "^7.0.2"
-    lodash "^4.17.20"
+    ajv "^8.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    lodash.clonedeep "^4.5.0"
+    lodash.flatten "^4.4.0"
+    lodash.truncate "^4.4.2"
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
 
@@ -18584,9 +18429,9 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.3, tslib@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tsutils@^3.17.1:
   version "3.21.0"
@@ -18692,9 +18537,9 @@ typescript@4.0.7:
   integrity sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==
 
 typescript@^4.0:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 uglify-js@^2.8.29:
   version "2.8.29"
@@ -18707,9 +18552,9 @@ uglify-js@^2.8.29:
     uglify-to-browserify "~1.0.0"
 
 uglify-js@^3.1.4:
-  version "3.13.2"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.2.tgz#fe10319861bccc8682bfe2e8151fbdd8aa921c44"
-  integrity sha512-SbMu4D2Vo95LMC/MetNaso1194M1htEA+JrqE9Hk+G2DhI+itfS9TRu9ZKeCahLDNa/J3n4MqUJ/fOHMzQpRWw==
+  version "3.13.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.4.tgz#592588bb9f47ae03b24916e2471218d914955574"
+  integrity sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
@@ -18739,12 +18584,11 @@ uint8arrays@1.1.0, uint8arrays@^1.0.0, uint8arrays@^1.1.0:
     web-encoding "^1.0.2"
 
 uint8arrays@^2.0.5, uint8arrays@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-2.1.3.tgz#6e09ed40687042ed7b0047b498c0e876efe5a49a"
-  integrity sha512-2h2Z2OIqzrhHmZTv9ViJVyZZreFkHRHeihh7SxLVY/nLUVJhU4ey/u74tWsgMR6hhMSO2g5rhKmdLQIg3lKiUQ==
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-2.1.5.tgz#9e6e6377a9463d5eba4620a3f0450f7eb389a351"
+  integrity sha512-CSR7AO+4AHUeSOnZ/NBNCElDeWfRh9bXtOck27083kc7SznmmHIhNEkEOCQOn0wvrIMjS3IH0TNLR16vuc46mA==
   dependencies:
     multibase "^4.0.1"
-    web-encoding "^1.1.0"
 
 ultron@~1.1.0:
   version "1.1.1"
@@ -19021,6 +18865,18 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
+util@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.3.tgz#971bb0292d2cc0c892dab7c6a5d37c2bec707888"
+  integrity sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    safe-buffer "^5.1.2"
+    which-typed-array "^1.1.2"
+
 utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
@@ -19052,9 +18908,9 @@ v8-compile-cache@^2.0.3, v8-compile-cache@^2.2.0:
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 v8-to-istanbul@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz#5b95cef45c0f83217ec79f8fc7ee1c8b486aee07"
-  integrity sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-7.1.1.tgz#04bfd1026ba4577de5472df4f5e89af49de5edda"
+  integrity sha512-p0BB09E5FRjx0ELN6RgusIPsSPhtgexSRcKETybEs6IGOTXJSZqfwxp7r//55nnu0f1AxltY5VvdVqy2vZf9AA==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
@@ -19176,10 +19032,12 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-encoding@^1.0.2, web-encoding@^1.0.6, web-encoding@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.0.tgz#b8ed50f0e23ba239542ba11ebe885b75a0b95bea"
-  integrity sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==
+web-encoding@^1.0.2, web-encoding@^1.0.6:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.4.tgz#fe15f7be090e64c3b640e8e9f3846403fe6fef9e"
+  integrity sha512-EJn3rQ/blHgaOTG8XvxGsZXTCyw9p1RAaDI/L0W3jjJRvW25F8uRshacU4h49wc9Fj0JlKU+oyOKm40HDAj75w==
+  dependencies:
+    util "^0.12.3"
   optionalDependencies:
     "@zxing/text-encoding" "0.9.0"
 
@@ -19415,9 +19273,9 @@ web3-utils@1.2.11:
     utf8 "3.0.0"
 
 web3-utils@^1.0.0-beta.31:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.3.4.tgz#9b1aa30d7549f860b573e7bb7e690999e7192198"
-  integrity sha512-/vC2v0MaZNpWooJfpRw63u0Y3ag2gNjAWiLtMSL6QQLmCqCy4SQIndMt/vRyx0uMoeGt1YTwSXEcHjUzOhLg0A==
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.3.5.tgz#14ee2ff1a7a226867698d6eaffd21aa97aed422e"
+  integrity sha512-5apMRm8ElYjI/92GHqijmaLC+s+d5lgjpjHft+rJSs/dsnX8I8tQreqev0dmU+wzU+2EEe4Sx9a/OwGWHhQv3A==
   dependencies:
     bn.js "^4.11.9"
     eth-lib "0.2.8"
@@ -19661,9 +19519,9 @@ websocket-extensions@>=0.1.1:
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
 websocket@^1.0.31:
-  version "1.0.33"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.33.tgz#407f763fc58e74a3fa41ca3ae5d78d3f5e3b82a5"
-  integrity sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
+  integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
   dependencies:
     bufferutil "^4.0.1"
     debug "^2.2.0"
@@ -19707,7 +19565,7 @@ whatwg-url@^7.0.0:
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
-whatwg-url@^8.0.0:
+whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.5.0.tgz#7752b8464fc0903fec89aa9846fc9efe07351fd3"
   integrity sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==
@@ -19736,6 +19594,19 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+which-typed-array@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.4.tgz#8fcb7d3ee5adf2d771066fba7cf37e32fe8711ff"
+  integrity sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==
+  dependencies:
+    available-typed-arrays "^1.0.2"
+    call-bind "^1.0.0"
+    es-abstract "^1.18.0-next.1"
+    foreach "^2.0.5"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.1"
+    is-typed-array "^1.1.3"
 
 which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
@@ -20161,14 +20032,14 @@ y18n@^3.2.1:
   integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
 
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
-  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
 y18n@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
-  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yaeti@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
The schema composer project now:
- Properly handles shared types
- Outputs a full TypeInfo structure for each schema (query, mutation, combined)
- Has an option for outputting the schema string, the typeinfo, or both.