### PR TITLE
Update api > as template to include as-bigint pkg

### DIFF
--- a/packages/templates/api/assemblyscript/package.json
+++ b/packages/templates/api/assemblyscript/package.json
@@ -18,7 +18,6 @@
     "@web3api/cli": "0.0.1-prealpha.23",
     "@web3api/ethereum-plugin-js": "0.0.1-prealpha.23",
     "@web3api/wasm-as": "0.0.1-prealpha.23",
-    "as-bigint": "^0.2.4",
     "ethers": "5.0.8",
     "js-yaml": "3.14.0",
     "solc": "0.8.3"

--- a/packages/templates/api/assemblyscript/package.json
+++ b/packages/templates/api/assemblyscript/package.json
@@ -18,6 +18,7 @@
     "@web3api/cli": "0.0.1-prealpha.23",
     "@web3api/ethereum-plugin-js": "0.0.1-prealpha.23",
     "@web3api/wasm-as": "0.0.1-prealpha.23",
+    "as-bigint": "^0.2.4",
     "ethers": "5.0.8",
     "js-yaml": "3.14.0",
     "solc": "0.8.3"

--- a/packages/wasm/as/package.json
+++ b/packages/wasm/as/package.json
@@ -20,9 +20,11 @@
     "test": "asp --verbose",
     "test:ci": "asp --summary"
   },
+  "dependencies": {
+    "as-bigint": "0.2.4"
+  },
   "devDependencies": {
     "@as-pect/cli": "5.0.1",
-    "as-bigint": "0.2.4",
     "assemblyscript": "0.17.14"
   },
   "gitHead": "7346adaf5adb7e6bbb70d9247583e995650d390a",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,13 +3251,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cross-spawn@6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.2.tgz#168309de311cd30a2b8ae720de6475c2fbf33ac7"
-  integrity sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/deep-equal@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/deep-equal/-/deep-equal-1.0.1.tgz#71cfabb247c22bcc16d536111f50c0ed12476b03"


### PR DESCRIPTION
closes https://github.com/Web3-API/monorepo/issues/347

### Issue

- `packages/templates/api/assemblyscript/package.json` did not include the `as-bigint` package as a dependency
- This caused `yarn build` to fail when going through the Web3API "Creating a Web3API" guide.

### Fix
- Added `"as-bigint": "^0.2.4"` to the template.