### PR TITLE
Improve messagepack read errors

### DIFF
--- a/packages/test-cases/cases/apis/invalid-types/query/index.ts
+++ b/packages/test-cases/cases/apis/invalid-types/query/index.ts
@@ -1,0 +1,27 @@
+import {
+  Input_boolMethod,
+  Input_bytesMethod,
+  Input_arrayMethod,
+  Input_intMethod,
+  Input_uIntMethod
+} from "./w3";
+
+export function boolMethod(input: Input_boolMethod): bool {
+  return input.arg;
+}
+
+export function intMethod(input: Input_intMethod): i64 {
+  return input.arg;
+}
+
+export function uIntMethod(input: Input_uIntMethod): u64 {
+  return input.arg;
+}
+
+export function bytesMethod(input: Input_bytesMethod): ArrayBuffer {
+  return input.arg;
+}
+
+export function arrayMethod(input: Input_arrayMethod): string[] {
+  return input.arg;
+}

--- a/packages/test-cases/cases/apis/invalid-types/query/schema.graphql
+++ b/packages/test-cases/cases/apis/invalid-types/query/schema.graphql
@@ -1,0 +1,21 @@
+type Query {
+  boolMethod(
+    arg: Boolean!
+  ): Boolean!
+
+  intMethod(
+    arg: Int64!
+  ): Int64!
+
+  uIntMethod(
+    arg: UInt64!
+  ): UInt64!
+
+  bytesMethod(
+    arg: Bytes!
+  ): Bytes!
+
+  arrayMethod(
+    arg: [String!]!
+  ): [String!]
+}

--- a/packages/test-cases/cases/apis/invalid-types/web3api.yaml
+++ b/packages/test-cases/cases/apis/invalid-types/web3api.yaml
@@ -1,0 +1,7 @@
+format: 0.0.1-prealpha.1
+query:
+  schema:
+    file: ./query/schema.graphql
+  module:
+    language: wasm/assemblyscript
+    file: ./query/index.ts

--- a/packages/wasm/as/assembly/msgpack/ReadDecoder.ts
+++ b/packages/wasm/as/assembly/msgpack/ReadDecoder.ts
@@ -541,15 +541,15 @@ export class ReadDecoder extends Read {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   private getErrorMessage(leadByte: u8): string {
     if (isNegativeFixedInt(leadByte)) {
-      return "Found 'NegativeFixedInt'.";
+      return "Found 'int'.";
     } else if (isFixedInt(leadByte)) {
-      return "Found 'FixedInt'.";
+      return "Found 'int'.";
     } else if (isFixedString(leadByte)) {
-      return "Found 'FixedString'.";
+      return "Found 'string'.";
     } else if (isFixedArray(leadByte)) {
-      return "Found 'FixedArray'.";
+      return "Found 'array'.";
     } else if (isFixedMap(leadByte)) {
-      return "Found 'FixedMap'.";
+      return "Found 'map'.";
     } else {
       switch (leadByte) {
         case Format.NIL:

--- a/packages/wasm/as/assembly/msgpack/ReadDecoder.ts
+++ b/packages/wasm/as/assembly/msgpack/ReadDecoder.ts
@@ -538,6 +538,7 @@ export class ReadDecoder extends Read {
     return objectsToDiscard;
   }
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   private getErrorMessage(leadByte: u8): string {
     if (isNegativeFixedInt(leadByte)) {
       return "Found 'NegativeFixedInt'.";


### PR DESCRIPTION
@dOrgJelli 
Couple of issues. In the issue it states that the message should be 'Property 'foo' should be type of 'string'. Found 'uint8' of value 8.' If we want those improvements that we can for property name pass property name into read methods and for value of found type we would need to switch all read methods to peek prefix instead of fetching it and then get prefix only if the format is a valid one. The question is are the changes worth it in your opinion to further improve error message?

This pr improves the message a bit in the sense that is says now: 'Property must be of type 'bool'. Found 'int''.

 Related: #206 