### PR TITLE
Parse and compose environment schema

### DIFF
--- a/packages/schema/compose/src/__tests__/resolve.spec.ts
+++ b/packages/schema/compose/src/__tests__/resolve.spec.ts
@@ -2,7 +2,7 @@ import { createObjectDefinition, createPropertyDefinition } from "@web3api/schem
 import { checkDuplicateEnvProperties } from "../resolve";
 
 describe("Check duplicate environment properties", () => {
-  it("should throws error if duplicate property found", () => {
+  it("should throw error if duplicate property found", () => {
     try {
       checkDuplicateEnvProperties(
         createObjectDefinition({

--- a/packages/schema/compose/src/__tests__/resolve.spec.ts
+++ b/packages/schema/compose/src/__tests__/resolve.spec.ts
@@ -1,0 +1,52 @@
+import { createObjectDefinition, createPropertyDefinition } from "@web3api/schema-parse";
+import { checkDuplicateEnvProperties } from "../resolve";
+
+describe("Check duplicate environment properties", () => {
+  it("should throws error if duplicate property found", () => {
+    try {
+      checkDuplicateEnvProperties(
+        createObjectDefinition({
+          type: "QueryEnv",
+          properties: [
+            createPropertyDefinition({
+              type: "String",
+              name: "prop"
+            })
+          ]
+        }),
+        [
+          createPropertyDefinition({
+            type: "Int",
+            name: "prop"
+          })
+        ]
+      );
+
+      fail("Error not thrown");
+    } catch (error) {
+      expect(error.message).toEqual(
+        "Type 'QueryEnv' contains duplicate property 'prop' of type 'Env'"
+      )
+    }
+  });
+
+  it("should do nothing if no duplicate properties found", () => {
+    checkDuplicateEnvProperties(
+      createObjectDefinition({
+        type: "QueryEnv",
+        properties: [
+          createPropertyDefinition({
+            type: "String",
+            name: "prop"
+          })
+        ]
+      }),
+      [
+        createPropertyDefinition({
+          type: "Int",
+          name: "prop2"
+        })
+      ]
+    );
+  });
+});

--- a/packages/schema/compose/src/index.ts
+++ b/packages/schema/compose/src/index.ts
@@ -1,8 +1,15 @@
 import { SchemaFile, SchemaResolvers } from "./types";
-import { resolveImportsAndParseSchemas } from "./resolve";
+import {
+  resolveEnviromentTypes,
+  resolveImportsAndParseSchemas,
+} from "./resolve";
 import { renderSchema } from "./render";
 
-import { TypeInfo, combineTypeInfo } from "@web3api/schema-parse";
+import {
+  TypeInfo,
+  combineTypeInfo,
+  EnvironmentType,
+} from "@web3api/schema-parse";
 
 export * from "./types";
 
@@ -49,6 +56,11 @@ export async function composeSchema(
       false,
       resolvers
     );
+    resolveEnviromentTypes(
+      typeInfos.query,
+      EnvironmentType.QueryEnvType,
+      typeInfos.query.environment.query.sanitized
+    );
   }
 
   if (mutation && mutation.schema) {
@@ -57,6 +69,11 @@ export async function composeSchema(
       mutation.absolutePath,
       true,
       resolvers
+    );
+    resolveEnviromentTypes(
+      typeInfos.mutation,
+      EnvironmentType.MutationEnvType,
+      typeInfos.mutation.environment.mutation.sanitized
     );
   }
 

--- a/packages/schema/compose/src/resolve.ts
+++ b/packages/schema/compose/src/resolve.ts
@@ -622,14 +622,14 @@ export function resolveEnviromentTypes(
     return;
   }
 
-  typeInfo.objectTypes = typeInfo.objectTypes.filter((type) => {
-    return type.type !== genericEnvType.type;
-  });
-
   if (!specificEnvType) {
     genericEnvType.type = envTypeName;
     return;
   }
+
+  typeInfo.objectTypes = typeInfo.objectTypes.filter((type) => {
+    return type.type !== genericEnvType.type;
+  });
 
   checkDuplicateEnvProperties(specificEnvType, genericEnvType.properties);
 

--- a/packages/schema/compose/src/resolve.ts
+++ b/packages/schema/compose/src/resolve.ts
@@ -637,7 +637,7 @@ export function resolveEnviromentTypes(
   typeInfo.objectTypes.push(specificEnvType);
 }
 
-function checkDuplicateEnvProperties(
+export function checkDuplicateEnvProperties(
   envType: ObjectDefinition,
   genericEnvProperties: AnyDefinition[]
 ): void {
@@ -648,7 +648,7 @@ function checkDuplicateEnvProperties(
       )
     ) {
       throw new Error(
-        `Type '${envType.type}' contains duplicate property ${specificProperty.name} of type 'Env'`
+        `Type '${envType.type}' contains duplicate property '${specificProperty.name}' of type 'Env'`
       );
     }
   }

--- a/packages/schema/compose/src/resolve.ts
+++ b/packages/schema/compose/src/resolve.ts
@@ -76,7 +76,7 @@ export async function resolveImportsAndParseSchemas(
     importedEnumTypes: [],
     importedObjectTypes: [],
     importedQueryTypes: [],
-    enviroment: {
+    environment: {
       mutation: {},
       query: {},
     },

--- a/packages/schema/compose/src/resolve.ts
+++ b/packages/schema/compose/src/resolve.ts
@@ -76,6 +76,10 @@ export async function resolveImportsAndParseSchemas(
     importedEnumTypes: [],
     importedObjectTypes: [],
     importedQueryTypes: [],
+    enviroment: {
+      mutation: {},
+      query: {},
+    },
   };
 
   const externalImports = await resolveExternalImports(

--- a/packages/schema/parse/src/__tests__/transforms.spec.ts
+++ b/packages/schema/parse/src/__tests__/transforms.spec.ts
@@ -81,6 +81,10 @@ describe("Web3API Schema TypeInfo Transformations", () => {
       transforms: [addFirstLast],
     });
     const expected: TypeInfo = {
+      environment: {
+        query: {},
+        mutation: {},
+      },
       enumTypes: [],
       importedEnumTypes: [],
       objectTypes: [
@@ -338,6 +342,10 @@ describe("Web3API Schema TypeInfo Transformations", () => {
       ],
     });
     const expected: TypeInfo = {
+      environment: {
+        query: {},
+        mutation: {},
+      },
       enumTypes: [],
       importedEnumTypes: [],
       objectTypes: [

--- a/packages/schema/parse/src/__tests__/validate-environment.spec.ts
+++ b/packages/schema/parse/src/__tests__/validate-environment.spec.ts
@@ -1,0 +1,167 @@
+import { parseSchema } from "..";
+
+const missingSanitizedQueryEnv = `
+type QueryClientEnv {
+  prop: String
+}
+`
+
+const missingSanitizedMutationEnv = `
+type MutationClientEnv {
+  prop: String
+}
+`
+const missingQuery = `
+type QueryClientEnv {
+  prop: String
+}
+
+type QueryEnv {
+  prop: String
+}
+`
+
+const missingQuerySanitizeEnvironment = `
+type QueryClientEnv {
+  prop: String
+}
+
+type QueryEnv {
+  prop: String
+}
+
+type Query {
+  method(prop: String): String
+}
+`
+
+const invalidQuerySanitizeEnvironmentArguments = `
+type QueryClientEnv {
+  prop: String
+}
+
+type QueryEnv {
+  prop: String
+}
+
+type Query {
+  sanitizeQueryEnv(prop: String): String
+}
+`
+
+const invalidQuerySanitizeEnvironmentReturnType = `
+type QueryClientEnv {
+  prop: String
+}
+
+type QueryEnv {
+  prop: String
+}
+
+type Query {
+  sanitizeQueryEnv(env: QueryClientEnv): String
+}
+`
+
+const missingMutation = `
+type MutationClientEnv {
+  prop: String
+}
+
+type MutationEnv {
+  prop: String
+}
+`
+
+const missingMutationSanitizeEnvironment = `
+type MutationClientEnv {
+  prop: String
+}
+
+type MutationEnv {
+  prop: String
+}
+
+type Mutation {
+  method(prop: String): String
+}
+`
+
+const invalidMutationSanitizeEnviromentArguments = `
+type MutationClientEnv {
+  prop: String
+}
+
+type MutationEnv {
+  prop: String
+}
+
+type Mutation {
+  sanitizeMutationEnv(prop: String): String
+}
+`
+
+const invalidMutationSanitizeEnvironmentReturnType = `
+type MutationClientEnv {
+  prop: String
+}
+
+type MutationEnv {
+  prop: String
+}
+
+type Mutation {
+  sanitizeMutationEnv(env: MutationClientEnv): String
+}
+`
+
+const exec = (schema: string) => () => parseSchema(
+  schema, {
+  validators: []
+});
+
+describe("Web3API Schema Environment Validation", () => {
+  it("throws error if query client env exists and sanitized env not defined", () => {
+    expect(exec(missingSanitizedQueryEnv)).toThrow(
+      /Client environment type 'QueryClientEnv' should have matching sanitized environment type 'QueryEnv'/gm
+    );
+
+    expect(exec(missingSanitizedMutationEnv)).toThrow(
+      /Client environment type 'MutationClientEnv' should have matching sanitized environment type 'MutationEnv'/gm
+    );
+  });
+
+  it("throws error if sanitize environment method invalid", () => {
+    expect(exec(missingQuery)).toThrow(
+      /Must have 'sanitizeQueryEnv' method inside Query methods when using 'QueryClientEnv'/gm
+    );
+
+    expect(exec(missingMutation)).toThrow(
+      /Must have 'sanitizeMutationEnv' method inside Mutation methods when using 'MutationClientEnv'/gm
+    );
+
+    expect(exec(missingQuerySanitizeEnvironment)).toThrow(
+      /Must have 'sanitizeQueryEnv' method inside Query methods when using 'QueryClientEnv'/gm
+    );
+
+    expect(exec(missingMutationSanitizeEnvironment)).toThrow(
+      /Must have 'sanitizeMutationEnv' method inside Mutation methods when using 'MutationClientEnv'/gm
+    );
+
+    expect(exec(invalidQuerySanitizeEnvironmentArguments)).toThrow(
+      /'sanitizeQueryEnv' query method should have single argument 'env: QueryClientEnv'/gm
+    );
+
+    expect(exec(invalidMutationSanitizeEnviromentArguments)).toThrow(
+      /'sanitizeMutationEnv' mutation method should have single argument 'env: MutationClientEnv'/gm
+    );
+
+    expect(exec(invalidQuerySanitizeEnvironmentReturnType)).toThrow(
+      /'sanitizeQueryEnv' query method should have required return type 'QueryEnv'/gm
+    );
+
+    expect(exec(invalidMutationSanitizeEnvironmentReturnType)).toThrow(
+      /'sanitizeMutationEnv' mutation method should have required return type 'MutationEnv'/gm
+    );
+  });
+});

--- a/packages/schema/parse/src/extract/enviroment-types.ts
+++ b/packages/schema/parse/src/extract/enviroment-types.ts
@@ -1,0 +1,88 @@
+import { TypeInfo, createObjectDefinition, Environment } from "../typeInfo";
+import {
+  extractFieldDefinition,
+  extractListType,
+  extractNamedType,
+  State,
+} from "./object-types-utils";
+import { Blackboard } from "./Blackboard";
+
+import {
+  DocumentNode,
+  ObjectTypeDefinitionNode,
+  NonNullTypeNode,
+  NamedTypeNode,
+  ListTypeNode,
+  FieldDefinitionNode,
+  visit,
+} from "graphql";
+
+const visitorEnter = (
+  enviroment: Environment,
+  state: State,
+  blackboard: Blackboard
+) => ({
+  ObjectTypeDefinition: (node: ObjectTypeDefinitionNode) => {
+    if (
+      node.name.value === "QueryClientEnv" ||
+      node.name.value === "QueryEnv" ||
+      node.name.value === "MutationEnv" ||
+      node.name.value === "MutationClientEnv"
+    ) {
+      const type = createObjectDefinition({ type: node.name.value });
+
+      if (node.name.value.startsWith("Query")) {
+        if (node.name.value.includes("Client")) {
+          enviroment.query.client = type;
+        } else {
+          enviroment.query.sanitized = type;
+        }
+      } else {
+        if (node.name.value.includes("Client")) {
+          enviroment.mutation.client = type;
+        } else {
+          enviroment.mutation.sanitized = type;
+        }
+      }
+
+      state.currentType = type;
+    }
+  },
+  NonNullType: (_node: NonNullTypeNode) => {
+    state.nonNullType = true;
+  },
+  NamedType: (node: NamedTypeNode) => {
+    extractNamedType(node, state, blackboard);
+  },
+  ListType: (_node: ListTypeNode) => {
+    extractListType(state);
+  },
+  FieldDefinition: (node: FieldDefinitionNode) => {
+    extractFieldDefinition(node, state);
+  },
+});
+
+const visitorLeave = (state: State) => ({
+  ObjectTypeDefinition: (_node: ObjectTypeDefinitionNode) => {
+    state.currentType = undefined;
+  },
+  FieldDefinition: (_node: FieldDefinitionNode) => {
+    state.currentProperty = undefined;
+  },
+  NonNullType: (_node: NonNullTypeNode) => {
+    state.nonNullType = false;
+  },
+});
+
+export function extractEnviromentTypes(
+  astNode: DocumentNode,
+  typeInfo: TypeInfo,
+  blackboard: Blackboard
+): void {
+  const state: State = {};
+
+  visit(astNode, {
+    enter: visitorEnter(typeInfo.enviroment, state, blackboard),
+    leave: visitorLeave(state),
+  });
+}

--- a/packages/schema/parse/src/extract/environment-types.ts
+++ b/packages/schema/parse/src/extract/environment-types.ts
@@ -1,8 +1,14 @@
-import { TypeInfo, createObjectDefinition, Environment } from "../typeInfo";
+import {
+  TypeInfo,
+  createObjectDefinition,
+  Environment,
+  EnvironmentType,
+} from "../typeInfo";
 import {
   extractFieldDefinition,
   extractListType,
   extractNamedType,
+  isEnviromentType,
   State,
 } from "./object-types-utils";
 import { Blackboard } from "./Blackboard";
@@ -23,26 +29,19 @@ const visitorEnter = (
   blackboard: Blackboard
 ) => ({
   ObjectTypeDefinition: (node: ObjectTypeDefinitionNode) => {
-    if (
-      node.name.value === "QueryClientEnv" ||
-      node.name.value === "QueryEnv" ||
-      node.name.value === "MutationEnv" ||
-      node.name.value === "MutationClientEnv"
-    ) {
+    if (isEnviromentType(node.name.value)) {
       const type = createObjectDefinition({ type: node.name.value });
 
-      if (node.name.value.startsWith("Query")) {
-        if (node.name.value.includes("Client")) {
-          environment.query.client = type;
-        } else {
-          environment.query.sanitized = type;
-        }
+      if (node.name.value.includes(EnvironmentType.QueryClientEnvType)) {
+        environment.query.client = type;
+      } else if (node.name.value.includes(EnvironmentType.QueryEnvType)) {
+        environment.query.sanitized = type;
+      } else if (
+        node.name.value.includes(EnvironmentType.MutationClientEnvType)
+      ) {
+        environment.mutation.client = type;
       } else {
-        if (node.name.value.includes("Client")) {
-          environment.mutation.client = type;
-        } else {
-          environment.mutation.sanitized = type;
-        }
+        environment.mutation.sanitized = type;
       }
 
       state.currentType = type;

--- a/packages/schema/parse/src/extract/environment-types.ts
+++ b/packages/schema/parse/src/extract/environment-types.ts
@@ -18,7 +18,7 @@ import {
 } from "graphql";
 
 const visitorEnter = (
-  enviroment: Environment,
+  environment: Environment,
   state: State,
   blackboard: Blackboard
 ) => ({
@@ -33,15 +33,15 @@ const visitorEnter = (
 
       if (node.name.value.startsWith("Query")) {
         if (node.name.value.includes("Client")) {
-          enviroment.query.client = type;
+          environment.query.client = type;
         } else {
-          enviroment.query.sanitized = type;
+          environment.query.sanitized = type;
         }
       } else {
         if (node.name.value.includes("Client")) {
-          enviroment.mutation.client = type;
+          environment.mutation.client = type;
         } else {
-          enviroment.mutation.sanitized = type;
+          environment.mutation.sanitized = type;
         }
       }
 
@@ -74,7 +74,7 @@ const visitorLeave = (state: State) => ({
   },
 });
 
-export function extractEnviromentTypes(
+export function extractenvironmentTypes(
   astNode: DocumentNode,
   typeInfo: TypeInfo,
   blackboard: Blackboard
@@ -82,7 +82,7 @@ export function extractEnviromentTypes(
   const state: State = {};
 
   visit(astNode, {
-    enter: visitorEnter(typeInfo.enviroment, state, blackboard),
+    enter: visitorEnter(typeInfo.environment, state, blackboard),
     leave: visitorLeave(state),
   });
 }

--- a/packages/schema/parse/src/extract/index.ts
+++ b/packages/schema/parse/src/extract/index.ts
@@ -6,7 +6,7 @@ import { extractImportedObjectTypes } from "./imported-object-types";
 import { extractImportedQueryTypes } from "./imported-query-types";
 import { extractImportedEnumTypes } from "./imported-enum-types";
 import { Blackboard } from "./Blackboard";
-import { extractEnviromentTypes } from "./enviroment-types";
+import { extractenvironmentTypes } from "./environment-types";
 
 import { DocumentNode } from "graphql";
 
@@ -23,5 +23,5 @@ export const extractors: SchemaExtractor[] = [
   extractImportedObjectTypes,
   extractQueryTypes,
   extractImportedQueryTypes,
-  extractEnviromentTypes,
+  extractenvironmentTypes,
 ];

--- a/packages/schema/parse/src/extract/index.ts
+++ b/packages/schema/parse/src/extract/index.ts
@@ -6,6 +6,7 @@ import { extractImportedObjectTypes } from "./imported-object-types";
 import { extractImportedQueryTypes } from "./imported-query-types";
 import { extractImportedEnumTypes } from "./imported-enum-types";
 import { Blackboard } from "./Blackboard";
+import { extractEnviromentTypes } from "./enviroment-types";
 
 import { DocumentNode } from "graphql";
 
@@ -22,4 +23,5 @@ export const extractors: SchemaExtractor[] = [
   extractImportedObjectTypes,
   extractQueryTypes,
   extractImportedQueryTypes,
+  extractEnviromentTypes,
 ];

--- a/packages/schema/parse/src/extract/object-types-utils.ts
+++ b/packages/schema/parse/src/extract/object-types-utils.ts
@@ -1,6 +1,7 @@
 import {
   createArrayDefinition,
   createPropertyDefinition,
+  EnvironmentType,
   ObjectDefinition,
   PropertyDefinition,
 } from "../typeInfo";
@@ -8,6 +9,19 @@ import { setPropertyType } from "./property-utils";
 import { Blackboard } from "./Blackboard";
 
 import { FieldDefinitionNode, NamedTypeNode } from "graphql";
+
+export function isEnviromentType(type: string): boolean {
+  if (
+    type === EnvironmentType.QueryClientEnvType ||
+    type === EnvironmentType.QueryEnvType ||
+    type === EnvironmentType.MutationEnvType ||
+    type === EnvironmentType.MutationClientEnvType
+  ) {
+    return true;
+  }
+
+  return false;
+}
 
 export interface State {
   currentType?: ObjectDefinition;

--- a/packages/schema/parse/src/extract/object-types.ts
+++ b/packages/schema/parse/src/extract/object-types.ts
@@ -7,6 +7,7 @@ import {
   extractFieldDefinition,
   extractListType,
   extractNamedType,
+  isEnviromentType,
   State,
 } from "./object-types-utils";
 import { Blackboard } from "./Blackboard";
@@ -34,12 +35,7 @@ const visitorEnter = (
     }
 
     // Skip env types
-    if (
-      node.name.value === "QueryClientEnv" ||
-      node.name.value === "QueryEnv" ||
-      node.name.value === "MutationEnv" ||
-      node.name.value === "MutationClientEnv"
-    ) {
+    if (isEnviromentType(node.name.value)) {
       return;
     }
 

--- a/packages/schema/parse/src/extract/object-types.ts
+++ b/packages/schema/parse/src/extract/object-types.ts
@@ -33,6 +33,16 @@ const visitorEnter = (
       return;
     }
 
+    // Skip env types
+    if (
+      node.name.value === "QueryClientEnv" ||
+      node.name.value === "QueryEnv" ||
+      node.name.value === "MutationEnv" ||
+      node.name.value === "MutationClientEnv"
+    ) {
+      return;
+    }
+
     // Skip imported types
     if (
       node.directives &&

--- a/packages/schema/parse/src/index.ts
+++ b/packages/schema/parse/src/index.ts
@@ -4,6 +4,7 @@ import { TypeInfoTransforms, transformTypeInfo } from "./transform";
 import { finalizePropertyDef } from "./transform/finalizePropertyDef";
 import { validators, SchemaValidator } from "./validate";
 import { Blackboard } from "./extract/Blackboard";
+import { validateEnvironment } from "./validate/environment";
 
 import { parse } from "graphql";
 
@@ -61,6 +62,8 @@ export function parseSchema(
       info = transformTypeInfo(info, transform);
     }
   }
+
+  validateEnvironment(info);
 
   return info;
 }

--- a/packages/schema/parse/src/transform/index.ts
+++ b/packages/schema/parse/src/transform/index.ts
@@ -99,30 +99,30 @@ export function transformTypeInfo(
     );
   }
 
-  if (result.enviroment.query.client) {
-    result.enviroment.query.client = visitObjectDefinition(
-      result.enviroment.query.client,
+  if (result.environment.query.client) {
+    result.environment.query.client = visitObjectDefinition(
+      result.environment.query.client,
       transforms
     );
   }
 
-  if (result.enviroment.query.sanitized) {
-    result.enviroment.query.sanitized = visitObjectDefinition(
-      result.enviroment.query.sanitized,
+  if (result.environment.query.sanitized) {
+    result.environment.query.sanitized = visitObjectDefinition(
+      result.environment.query.sanitized,
       transforms
     );
   }
 
-  if (result.enviroment.mutation.client) {
-    result.enviroment.mutation.client = visitObjectDefinition(
-      result.enviroment.mutation.client,
+  if (result.environment.mutation.client) {
+    result.environment.mutation.client = visitObjectDefinition(
+      result.environment.mutation.client,
       transforms
     );
   }
 
-  if (result.enviroment.mutation.sanitized) {
-    result.enviroment.mutation.sanitized = visitObjectDefinition(
-      result.enviroment.mutation.sanitized,
+  if (result.environment.mutation.sanitized) {
+    result.environment.mutation.sanitized = visitObjectDefinition(
+      result.environment.mutation.sanitized,
       transforms
     );
   }

--- a/packages/schema/parse/src/transform/index.ts
+++ b/packages/schema/parse/src/transform/index.ts
@@ -99,6 +99,34 @@ export function transformTypeInfo(
     );
   }
 
+  if (result.enviroment.query.client) {
+    result.enviroment.query.client = visitObjectDefinition(
+      result.enviroment.query.client,
+      transforms
+    );
+  }
+
+  if (result.enviroment.query.sanitized) {
+    result.enviroment.query.sanitized = visitObjectDefinition(
+      result.enviroment.query.sanitized,
+      transforms
+    );
+  }
+
+  if (result.enviroment.mutation.client) {
+    result.enviroment.mutation.client = visitObjectDefinition(
+      result.enviroment.mutation.client,
+      transforms
+    );
+  }
+
+  if (result.enviroment.mutation.sanitized) {
+    result.enviroment.mutation.sanitized = visitObjectDefinition(
+      result.enviroment.mutation.sanitized,
+      transforms
+    );
+  }
+
   if (transforms.leave && transforms.leave.TypeInfo) {
     result = transforms.leave.TypeInfo(result);
   }

--- a/packages/schema/parse/src/typeInfo/index.ts
+++ b/packages/schema/parse/src/typeInfo/index.ts
@@ -13,6 +13,17 @@ export * from "./scalar";
 export * from "./operation";
 export * from "./query";
 
+export interface Environment {
+  mutation: {
+    sanitized?: ObjectDefinition;
+    client?: ObjectDefinition;
+  };
+  query: {
+    sanitized?: ObjectDefinition;
+    client?: ObjectDefinition;
+  };
+}
+
 export interface TypeInfo {
   objectTypes: ObjectDefinition[];
   queryTypes: QueryDefinition[];
@@ -20,16 +31,7 @@ export interface TypeInfo {
   importedObjectTypes: ImportedObjectDefinition[];
   importedQueryTypes: ImportedQueryDefinition[];
   importedEnumTypes: ImportedEnumDefinition[];
-  enviroment: {
-    mutation: {
-      sanitized?: ObjectDefinition;
-      client?: ObjectDefinition;
-    };
-    query: {
-      sanitized?: ObjectDefinition;
-      client?: ObjectDefinition;
-    };
-  };
+  enviroment: Environment;
 }
 
 export function createTypeInfo(): TypeInfo {

--- a/packages/schema/parse/src/typeInfo/index.ts
+++ b/packages/schema/parse/src/typeInfo/index.ts
@@ -13,6 +13,13 @@ export * from "./scalar";
 export * from "./operation";
 export * from "./query";
 
+export enum EnvironmentType {
+  QueryClientEnvType = "QueryClientEnv",
+  QueryEnvType = "QueryEnv",
+  MutationClientEnvType = "MutationClientEnv",
+  MutationEnvType = "MutationEnv",
+}
+
 export interface Environment {
   mutation: {
     sanitized?: ObjectDefinition;

--- a/packages/schema/parse/src/typeInfo/index.ts
+++ b/packages/schema/parse/src/typeInfo/index.ts
@@ -31,7 +31,7 @@ export interface TypeInfo {
   importedObjectTypes: ImportedObjectDefinition[];
   importedQueryTypes: ImportedQueryDefinition[];
   importedEnumTypes: ImportedEnumDefinition[];
-  enviroment: Environment;
+  environment: Environment;
 }
 
 export function createTypeInfo(): TypeInfo {
@@ -42,7 +42,7 @@ export function createTypeInfo(): TypeInfo {
     importedObjectTypes: [],
     importedQueryTypes: [],
     importedEnumTypes: [],
-    enviroment: {
+    environment: {
       mutation: {},
       query: {},
     },
@@ -59,7 +59,7 @@ export function combineTypeInfo(typeInfos: TypeInfo[]): TypeInfo {
     importedObjectTypes: [],
     importedQueryTypes: [],
     importedEnumTypes: [],
-    enviroment: {
+    environment: {
       mutation: {},
       query: {},
     },

--- a/packages/schema/parse/src/typeInfo/index.ts
+++ b/packages/schema/parse/src/typeInfo/index.ts
@@ -20,7 +20,18 @@ export interface TypeInfo {
   importedObjectTypes: ImportedObjectDefinition[];
   importedQueryTypes: ImportedQueryDefinition[];
   importedEnumTypes: ImportedEnumDefinition[];
+  enviroment: {
+    mutation: {
+      sanitized?: ObjectDefinition;
+      client?: ObjectDefinition;
+    };
+    query: {
+      sanitized?: ObjectDefinition;
+      client?: ObjectDefinition;
+    };
+  };
 }
+
 export function createTypeInfo(): TypeInfo {
   return {
     objectTypes: [],
@@ -29,6 +40,10 @@ export function createTypeInfo(): TypeInfo {
     importedObjectTypes: [],
     importedQueryTypes: [],
     importedEnumTypes: [],
+    enviroment: {
+      mutation: {},
+      query: {},
+    },
   };
 }
 
@@ -42,6 +57,10 @@ export function combineTypeInfo(typeInfos: TypeInfo[]): TypeInfo {
     importedObjectTypes: [],
     importedQueryTypes: [],
     importedEnumTypes: [],
+    enviroment: {
+      mutation: {},
+      query: {},
+    },
   };
 
   const compareImportedType = (

--- a/packages/schema/parse/src/validate/environment.ts
+++ b/packages/schema/parse/src/validate/environment.ts
@@ -1,0 +1,105 @@
+import { EnvironmentType, TypeInfo } from "../typeInfo";
+
+export function validateEnvironment(info: TypeInfo): void {
+  if (info.environment.query.client) {
+    validateQueryEnvironment(info);
+  }
+
+  if (info.environment.mutation.client) {
+    validateMutationEnvironment(info);
+  }
+}
+
+export function validateQueryEnvironment(info: TypeInfo): void {
+  if (!info.environment.query.sanitized) {
+    throw new Error(
+      `Client enviroment type '${EnvironmentType.MutationClientEnvType}' should have matching sanitized enviroment type '${EnvironmentType.QueryEnvType}'`
+    );
+  }
+
+  const query = info.queryTypes.find((type) => type.type === "Query");
+  if (!query) {
+    throw new Error(
+      `Must have 'sanitizeQueryEnv' method inside Query methods when using '${EnvironmentType.QueryClientEnvType}'`
+    );
+  }
+
+  const sanitizeEnvMethod = query.methods.find(
+    (method) => method.name === "sanitizeQueryEnv"
+  );
+  if (!sanitizeEnvMethod) {
+    throw new Error(
+      `Must have 'sanitizeQueryEnv' method inside Query methods when using '${EnvironmentType.QueryClientEnvType}'`
+    );
+  }
+
+  if (
+    sanitizeEnvMethod.arguments.length === 0 ||
+    sanitizeEnvMethod.arguments.length > 1 ||
+    sanitizeEnvMethod.arguments[0].name !== "env" ||
+    sanitizeEnvMethod.arguments[0].type !==
+      EnvironmentType.QueryClientEnvType ||
+    sanitizeEnvMethod.arguments[0].required === false
+  ) {
+    throw new Error(
+      `'sanitizeQueryEnv' query method should have single argument 'env: ${EnvironmentType.QueryClientEnvType}'`
+    );
+  }
+
+  if (
+    !sanitizeEnvMethod.return ||
+    sanitizeEnvMethod.return.type !== EnvironmentType.QueryEnvType ||
+    sanitizeEnvMethod.return.required === false
+  ) {
+    throw new Error(
+      `'sanitizeQueryEnv' query method should have required return type '${EnvironmentType.QueryEnvType}'`
+    );
+  }
+}
+
+export function validateMutationEnvironment(info: TypeInfo): void {
+  if (!info.environment.mutation.sanitized) {
+    throw new Error(
+      `Client enviroment type '${EnvironmentType.MutationClientEnvType}' should have matching sanitized enviroment type '${EnvironmentType.MutationEnvType}'`
+    );
+  }
+
+  const mutation = info.queryTypes.find((type) => type.type === "Mutation");
+  if (!mutation) {
+    throw new Error(
+      `Must have 'sanitizeMutationEnv' method inside Mutation methods when using '${EnvironmentType.MutationClientEnvType}'`
+    );
+  }
+
+  const sanitizeEnvMethod = mutation.methods.find(
+    (method) => method.name === "sanitizeMutationEnv"
+  );
+  if (!sanitizeEnvMethod) {
+    throw new Error(
+      `Must have 'sanitizeMutationEnv' method inside Mutation methods when using '${EnvironmentType.MutationClientEnvType}'`
+    );
+  }
+
+  if (
+    sanitizeEnvMethod.arguments.length === 0 ||
+    sanitizeEnvMethod.arguments.length > 1 ||
+    sanitizeEnvMethod.arguments[0].name !== "env" ||
+    sanitizeEnvMethod.arguments[0].type !==
+      EnvironmentType.MutationClientEnvType ||
+    sanitizeEnvMethod.arguments[0].required === false
+  ) {
+    throw new Error(
+      `'sanitizeMutationEnv' mutation method should have single argument 'env: ${EnvironmentType.MutationClientEnvType}'`
+    );
+  }
+
+  if (
+    !sanitizeEnvMethod.return ||
+    sanitizeEnvMethod.return.type !== EnvironmentType.MutationEnvType ||
+    sanitizeEnvMethod.return.required === false
+  ) {
+    throw new Error(
+      `'sanitizeMutationEnv' mutation method should return type '${EnvironmentType.MutationEnvType}'`
+    );
+  }
+}

--- a/packages/schema/parse/src/validate/environment.ts
+++ b/packages/schema/parse/src/validate/environment.ts
@@ -13,7 +13,7 @@ export function validateEnvironment(info: TypeInfo): void {
 export function validateQueryEnvironment(info: TypeInfo): void {
   if (!info.environment.query.sanitized) {
     throw new Error(
-      `Client enviroment type '${EnvironmentType.MutationClientEnvType}' should have matching sanitized enviroment type '${EnvironmentType.QueryEnvType}'`
+      `Client environment type '${EnvironmentType.QueryClientEnvType}' should have matching sanitized environment type '${EnvironmentType.QueryEnvType}'`
     );
   }
 
@@ -60,7 +60,7 @@ export function validateQueryEnvironment(info: TypeInfo): void {
 export function validateMutationEnvironment(info: TypeInfo): void {
   if (!info.environment.mutation.sanitized) {
     throw new Error(
-      `Client enviroment type '${EnvironmentType.MutationClientEnvType}' should have matching sanitized enviroment type '${EnvironmentType.MutationEnvType}'`
+      `Client environment type '${EnvironmentType.MutationClientEnvType}' should have matching sanitized environment type '${EnvironmentType.MutationEnvType}'`
     );
   }
 
@@ -99,7 +99,7 @@ export function validateMutationEnvironment(info: TypeInfo): void {
     sanitizeEnvMethod.return.required === false
   ) {
     throw new Error(
-      `'sanitizeMutationEnv' mutation method should return type '${EnvironmentType.MutationEnvType}'`
+      `'sanitizeMutationEnv' mutation method should have required return type '${EnvironmentType.MutationEnvType}'`
     );
   }
 }

--- a/packages/schema/parse/src/validate/types.ts
+++ b/packages/schema/parse/src/validate/types.ts
@@ -4,6 +4,7 @@ import {
   isQueryType,
   queryTypeNames,
 } from "../typeInfo";
+import { isEnviromentType } from "../extract/object-types-utils";
 
 import { DocumentNode, StringValueNode, visit } from "graphql";
 import { getSchemaCycles } from "graphql-schema-cycles";
@@ -81,12 +82,7 @@ export function propertyTypes(astNode: DocumentNode): void {
     enter: {
       ObjectTypeDefinition: (node) => {
         // Skip env types
-        if (
-          node.name.value === "QueryClientEnv" ||
-          node.name.value === "QueryEnv" ||
-          node.name.value === "MutationEnv" ||
-          node.name.value === "MutationClientEnv"
-        ) {
+        if (isEnviromentType(node.name.value)) {
           return;
         }
 

--- a/packages/schema/parse/src/validate/types.ts
+++ b/packages/schema/parse/src/validate/types.ts
@@ -107,6 +107,13 @@ export function propertyTypes(astNode: DocumentNode): void {
         }
       },
       FieldDefinition: (node) => {
+        if (
+          node.name.value === "sanitizeMutationEnv" ||
+          node.name.value === "sanitizeQueryEnv"
+        ) {
+          return;
+        }
+
         currentField = node.name.value;
       },
       NamedType: (node) => {

--- a/packages/schema/parse/src/validate/types.ts
+++ b/packages/schema/parse/src/validate/types.ts
@@ -80,6 +80,16 @@ export function propertyTypes(astNode: DocumentNode): void {
   visit(astNode, {
     enter: {
       ObjectTypeDefinition: (node) => {
+        // Skip env types
+        if (
+          node.name.value === "QueryClientEnv" ||
+          node.name.value === "QueryEnv" ||
+          node.name.value === "MutationEnv" ||
+          node.name.value === "MutationClientEnv"
+        ) {
+          return;
+        }
+
         currentObject = node.name.value;
         objectTypes[node.name.value] = true;
       },

--- a/packages/test-cases/cases/compose/local-imports/output/mutation.ts
+++ b/packages/test-cases/cases/compose/local-imports/output/mutation.ts
@@ -13,6 +13,10 @@ import {
 } from "@web3api/schema-parse";
 
 export const typeInfo: TypeInfo = {
+  environment: {
+    query: {},
+    mutation: {},
+  },
   importedObjectTypes: [],
   importedEnumTypes: [],
   importedQueryTypes: [],

--- a/packages/test-cases/cases/compose/local-imports/output/query.ts
+++ b/packages/test-cases/cases/compose/local-imports/output/query.ts
@@ -13,6 +13,10 @@ import {
 } from "@web3api/schema-parse";
 
 export const typeInfo: TypeInfo = {
+  environment: {
+    query: {},
+    mutation: {},
+  },
   objectTypes: [
     {
       ...createObjectDefinition({ type: "CustomQueryType" }),

--- a/packages/test-cases/cases/compose/local-imports/output/schema.ts
+++ b/packages/test-cases/cases/compose/local-imports/output/schema.ts
@@ -13,6 +13,10 @@ import {
 } from "@web3api/schema-parse";
 
 export const typeInfo: TypeInfo = {
+  environment: {
+    query: {},
+    mutation: {},
+  },
   importedObjectTypes: [],
   importedEnumTypes: [],
   importedQueryTypes: [],

--- a/packages/test-cases/cases/compose/sanity/imports-local/common.graphql
+++ b/packages/test-cases/cases/compose/sanity/imports-local/common.graphql
@@ -11,3 +11,7 @@ type NestedType {
 type ArrayObject {
   prop: String!
 }
+
+type Env {
+  foo: String!
+}

--- a/packages/test-cases/cases/compose/sanity/input/mutation.graphql
+++ b/packages/test-cases/cases/compose/sanity/input/mutation.graphql
@@ -1,6 +1,7 @@
 #import { Query, Mutation, CustomType } into Namespace from "test.eth"
 #import { Mutation } into JustMutation from "just.mutation.eth"
 #import { CommonType } from "../imports-local/common.graphql"
+#import { Env } from "../imports-local/common.graphql"
 
 type Mutation {
   method1(
@@ -13,6 +14,10 @@ type Mutation {
   method2(
     arg: [String!]!
   ): [Int64!]!
+}
+
+type MutationEnv {
+  bar: Int
 }
 
 type CustomMutationType {

--- a/packages/test-cases/cases/compose/sanity/input/query.graphql
+++ b/packages/test-cases/cases/compose/sanity/input/query.graphql
@@ -1,5 +1,6 @@
 #import { Query, CustomType } into Namespace from "test.eth"
 #import { CommonType } from "../imports-local/common.graphql"
+#import { Env } from "../imports-local/common.graphql"
 
 type Query {
   method1(
@@ -35,4 +36,8 @@ type CustomQueryType {
 
 type AnotherQueryType {
   prop: String
+}
+
+type QueryEnv {
+  bar: Bytes
 }

--- a/packages/test-cases/cases/compose/sanity/output/mutation.graphql
+++ b/packages/test-cases/cases/compose/sanity/output/mutation.graphql
@@ -86,6 +86,11 @@ type ArrayObject {
   prop: String!
 }
 
+type MutationEnv {
+  bar: Int
+  foo: String!
+}
+
 ### Imported Queries START ###
 
 type Namespace_Query @imported(

--- a/packages/test-cases/cases/compose/sanity/output/mutation.ts
+++ b/packages/test-cases/cases/compose/sanity/output/mutation.ts
@@ -11,13 +11,30 @@ import {
   createEnumPropertyDefinition,
   createImportedQueryDefinition,
   createImportedObjectDefinition,
-  createImportedEnumDefinition
+  createImportedEnumDefinition,
+  AnyDefinition
 } from "@web3api/schema-parse";
 
 export const typeInfo: TypeInfo = {
   environment: {
     query: {},
-    mutation: {},
+    mutation: {
+      sanitized: {
+        ...createObjectDefinition({ type: "MutationEnv" }),
+        properties: [
+          {
+            ...createScalarPropertyDefinition({ name: "bar", type: "Int", required: false }),
+            first: true,
+            last: null
+          } as AnyDefinition,
+          {
+            ...createScalarPropertyDefinition({ name: "foo", type: "String", required: true }),
+            first: null,
+            last: true,
+          } as AnyDefinition
+        ],
+      }
+    },
   },
   enumTypes: [],
   queryTypes: [
@@ -216,6 +233,13 @@ export const typeInfo: TypeInfo = {
       properties: [
         createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
       ],
+    },
+    {
+      ...createObjectDefinition({ type: "MutationEnv" }),
+      properties: [
+        { ...createScalarPropertyDefinition({ name: "bar", type: "Int", required: false }) },
+        createScalarPropertyDefinition({ name: "foo", type: "String", required: true }),
+      ]
     }
   ],
   importedQueryTypes: [

--- a/packages/test-cases/cases/compose/sanity/output/mutation.ts
+++ b/packages/test-cases/cases/compose/sanity/output/mutation.ts
@@ -15,6 +15,10 @@ import {
 } from "@web3api/schema-parse";
 
 export const typeInfo: TypeInfo = {
+  environment: {
+    query: {},
+    mutation: {},
+  },
   enumTypes: [],
   queryTypes: [
     {

--- a/packages/test-cases/cases/compose/sanity/output/query.graphql
+++ b/packages/test-cases/cases/compose/sanity/output/query.graphql
@@ -84,6 +84,11 @@ type ArrayObject {
   prop: String!
 }
 
+type QueryEnv {
+  bar: Bytes
+  foo: String!
+}
+
 ### Imported Queries START ###
 
 type Namespace_Query @imported(

--- a/packages/test-cases/cases/compose/sanity/output/query.ts
+++ b/packages/test-cases/cases/compose/sanity/output/query.ts
@@ -16,7 +16,15 @@ import {
 
 export const typeInfo: TypeInfo = {
   environment: {
-    query: {},
+    query: {
+      sanitized: {
+        ...createObjectDefinition({ type: "QueryEnv" }),
+        properties: [
+          createScalarPropertyDefinition({ name: "bar", type: "Bytes", required: false }),
+          createScalarPropertyDefinition({ name: "foo", type: "String", required: true }),
+        ],
+      }
+    },
     mutation: {},
   },
   objectTypes: [
@@ -124,6 +132,13 @@ export const typeInfo: TypeInfo = {
       }),
       properties: [
         createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    },
+    {
+      ...createObjectDefinition({ type: "QueryEnv" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "bar", type: "Bytes", required: false }),
+        createScalarPropertyDefinition({ name: "foo", type: "String", required: true }),
       ],
     }
   ],

--- a/packages/test-cases/cases/compose/sanity/output/query.ts
+++ b/packages/test-cases/cases/compose/sanity/output/query.ts
@@ -15,6 +15,10 @@ import {
 } from "@web3api/schema-parse";
 
 export const typeInfo: TypeInfo = {
+  environment: {
+    query: {},
+    mutation: {},
+  },
   objectTypes: [
     {
       ...createObjectDefinition({ type: "CustomQueryType" }),

--- a/packages/test-cases/cases/compose/sanity/output/schema.graphql
+++ b/packages/test-cases/cases/compose/sanity/output/schema.graphql
@@ -110,6 +110,11 @@ type ArrayObject {
   prop: String!
 }
 
+type QueryEnv {
+  bar: Bytes
+  foo: String!
+}
+
 type CustomMutationType {
   str: String!
   optStr: String
@@ -131,6 +136,11 @@ type CustomMutationType {
 
 type AnotherMutationType {
   prop: String
+}
+
+type MutationEnv {
+  bar: Int
+  foo: String!
 }
 
 ### Imported Queries START ###

--- a/packages/test-cases/cases/compose/sanity/output/schema.ts
+++ b/packages/test-cases/cases/compose/sanity/output/schema.ts
@@ -15,6 +15,10 @@ import {
 } from "@web3api/schema-parse";
 
 export const typeInfo: TypeInfo = {
+  environment: {
+    query: {},
+    mutation: {},
+  },
   enumTypes: [],
   queryTypes: [
     {

--- a/packages/test-cases/cases/compose/sanity/output/schema.ts
+++ b/packages/test-cases/cases/compose/sanity/output/schema.ts
@@ -304,6 +304,13 @@ export const typeInfo: TypeInfo = {
       ],
     },
     {
+      ...createObjectDefinition({ type: "QueryEnv" }),
+      properties: [
+        createScalarPropertyDefinition({ name: "bar", type: "Bytes", required: false }),
+        createScalarPropertyDefinition({ name: "foo", type: "String", required: true }),
+      ],
+    },
+    {
       ...createObjectDefinition({ type: "CustomMutationType" }),
       properties: [
         createScalarPropertyDefinition({ name: "str", type: "String", required: true }),
@@ -371,6 +378,13 @@ export const typeInfo: TypeInfo = {
       ...createObjectDefinition({ type: "AnotherMutationType" }),
       properties: [createScalarPropertyDefinition({ name: "prop", type: "String" })],
     },
+    {
+      ...createObjectDefinition({ type: "MutationEnv" }),
+      properties: [
+        { ...createScalarPropertyDefinition({ name: "bar", type: "Int", required: false }) },
+        createScalarPropertyDefinition({ name: "foo", type: "String", required: true }),
+      ]
+    }
   ],
   importedQueryTypes: [
     {

--- a/packages/test-cases/cases/compose/shared-environment/imports-local/common.graphql
+++ b/packages/test-cases/cases/compose/shared-environment/imports-local/common.graphql
@@ -1,0 +1,3 @@
+type Env {
+  prop: String!
+}

--- a/packages/test-cases/cases/compose/shared-environment/input/mutation.graphql
+++ b/packages/test-cases/cases/compose/shared-environment/input/mutation.graphql
@@ -1,0 +1,7 @@
+#import { Env } from "../imports-local/common.graphql"
+
+type Mutation {
+  method(
+    str: String!
+  ): String!
+}

--- a/packages/test-cases/cases/compose/shared-environment/input/query.graphql
+++ b/packages/test-cases/cases/compose/shared-environment/input/query.graphql
@@ -1,0 +1,7 @@
+#import { Env } from "../imports-local/common.graphql"
+
+type Query {
+  method(
+    str: String!
+  ): String!
+}

--- a/packages/test-cases/cases/compose/shared-environment/output/mutation.graphql
+++ b/packages/test-cases/cases/compose/shared-environment/output/mutation.graphql
@@ -1,0 +1,42 @@
+### Web3API Header START ###
+scalar UInt
+scalar UInt8
+scalar UInt16
+scalar UInt32
+scalar UInt64
+scalar Int
+scalar Int8
+scalar Int16
+scalar Int32
+scalar Int64
+scalar Bytes
+scalar BigInt
+
+directive @imported(
+  uri: String!
+  namespace: String!
+  nativeType: String!
+) on OBJECT | ENUM
+
+directive @imports(
+  types: [String!]!
+) on OBJECT
+### Web3API Header END ###
+
+type Mutation {
+  method(
+    str: String!
+  ): String!
+}
+
+type MutationEnv {
+  prop: String!
+}
+
+### Imported Queries START ###
+
+### Imported Queries END ###
+
+### Imported Objects START ###
+
+### Imported Objects END ###

--- a/packages/test-cases/cases/compose/shared-environment/output/mutation.ts
+++ b/packages/test-cases/cases/compose/shared-environment/output/mutation.ts
@@ -1,0 +1,53 @@
+import {
+  createMethodDefinition,
+  createQueryDefinition,
+  createScalarPropertyDefinition,
+  createObjectDefinition,
+  TypeInfo,
+} from "@web3api/schema-parse";
+
+export const typeInfo: TypeInfo = {
+  environment: {
+    query: {},
+    mutation: {},
+  },
+  importedObjectTypes: [],
+  importedEnumTypes: [],
+  importedQueryTypes: [],
+  queryTypes: [
+    {
+      ...createQueryDefinition({ type: "Mutation" }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method",
+            return: createScalarPropertyDefinition({
+              name: "method",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+          ]
+        }
+      ]
+    }
+  ],
+  objectTypes: [
+    {
+      ...createObjectDefinition({
+        type: "MutationEnv"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    }
+  ],
+  enumTypes: []
+}

--- a/packages/test-cases/cases/compose/shared-environment/output/query.graphql
+++ b/packages/test-cases/cases/compose/shared-environment/output/query.graphql
@@ -1,0 +1,42 @@
+### Web3API Header START ###
+scalar UInt
+scalar UInt8
+scalar UInt16
+scalar UInt32
+scalar UInt64
+scalar Int
+scalar Int8
+scalar Int16
+scalar Int32
+scalar Int64
+scalar Bytes
+scalar BigInt
+
+directive @imported(
+  uri: String!
+  namespace: String!
+  nativeType: String!
+) on OBJECT | ENUM
+
+directive @imports(
+  types: [String!]!
+) on OBJECT
+### Web3API Header END ###
+
+type Query {
+  method(
+    str: String!
+  ): String!
+}
+
+type QueryEnv {
+  prop: String!
+}
+
+### Imported Queries START ###
+
+### Imported Queries END ###
+
+### Imported Objects START ###
+
+### Imported Objects END ###

--- a/packages/test-cases/cases/compose/shared-environment/output/query.ts
+++ b/packages/test-cases/cases/compose/shared-environment/output/query.ts
@@ -1,0 +1,59 @@
+import {
+  createArrayPropertyDefinition,
+  createMethodDefinition,
+  createQueryDefinition,
+  createScalarDefinition,
+  createScalarPropertyDefinition,
+  createArrayDefinition,
+  createObjectPropertyDefinition,
+  createObjectDefinition,
+  createEnumDefinition,
+  TypeInfo,
+  createEnumPropertyDefinition
+} from "@web3api/schema-parse";
+
+export const typeInfo: TypeInfo = {
+  environment: {
+    query: {},
+    mutation: {},
+  },
+  objectTypes: [
+    {
+      ...createObjectDefinition({
+        type: "QueryEnv"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    }
+  ],
+  queryTypes: [
+    {
+      ...createQueryDefinition({ type: "Query" }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method",
+            return: createScalarPropertyDefinition({
+              name: "method",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+          ]
+        },
+      ]
+    }
+  ],
+  enumTypes: [],
+  importedObjectTypes: [],
+  importedQueryTypes: [],
+  importedEnumTypes: [],
+}

--- a/packages/test-cases/cases/compose/shared-environment/output/schema.graphql
+++ b/packages/test-cases/cases/compose/shared-environment/output/schema.graphql
@@ -1,0 +1,52 @@
+### Web3API Header START ###
+scalar UInt
+scalar UInt8
+scalar UInt16
+scalar UInt32
+scalar UInt64
+scalar Int
+scalar Int8
+scalar Int16
+scalar Int32
+scalar Int64
+scalar Bytes
+scalar BigInt
+
+directive @imported(
+  uri: String!
+  namespace: String!
+  nativeType: String!
+) on OBJECT | ENUM
+
+directive @imports(
+  types: [String!]!
+) on OBJECT
+### Web3API Header END ###
+
+type Query {
+  method(
+    str: String!
+  ): String!
+}
+
+type Mutation {
+  method(
+    str: String!
+  ): String!
+}
+
+type QueryEnv {
+  prop: String!
+}
+
+type MutationEnv {
+  prop: String!
+}
+
+### Imported Queries START ###
+
+### Imported Queries END ###
+
+### Imported Objects START ###
+
+### Imported Objects END ###

--- a/packages/test-cases/cases/compose/shared-environment/output/schema.ts
+++ b/packages/test-cases/cases/compose/shared-environment/output/schema.ts
@@ -1,0 +1,84 @@
+import {
+  createMethodDefinition,
+  createQueryDefinition,
+  createScalarPropertyDefinition,
+  createObjectDefinition,
+  TypeInfo,
+} from "@web3api/schema-parse";
+
+export const typeInfo: TypeInfo = {
+  environment: {
+    query: {},
+    mutation: {},
+  },
+  importedObjectTypes: [],
+  importedEnumTypes: [],
+  importedQueryTypes: [],
+  queryTypes: [
+    {
+      ...createQueryDefinition({ type: "Query" }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "method",
+            return: createScalarPropertyDefinition({
+              name: "method",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+          ]
+        },
+      ]
+    },
+    {
+      ...createQueryDefinition({ type: "Mutation" }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "method",
+            return: createScalarPropertyDefinition({
+              name: "method",
+              type: "String",
+              required: true
+            })
+          }),
+          arguments: [
+            createScalarPropertyDefinition({
+              name: "str",
+              required: true,
+              type: "String"
+            }),
+          ]
+        },
+      ]
+    }
+  ],
+  objectTypes: [
+    {
+      ...createObjectDefinition({
+        type: "QueryEnv"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    },
+    {
+      ...createObjectDefinition({
+        type: "MutationEnv"
+      }),
+      properties: [
+        createScalarPropertyDefinition({ name: "prop", type: "String", required: true }),
+      ],
+    },
+  ],
+  enumTypes: []
+}

--- a/packages/test-cases/cases/parse/sanity/input.graphql
+++ b/packages/test-cases/cases/parse/sanity/input.graphql
@@ -70,6 +70,22 @@ type UserObject {
   fieldB: Int!
 }
 
+type QueryEnv {
+  prop: String!
+}
+
+type QueryClientEnv {
+  prop: String!
+}
+
+type MutationEnv {
+  prop: Int!
+}
+
+type MutationClientEnv {
+  prop: String!
+}
+
 type Query @imports(
   types: [ "TestImport_Query" ]
 ) {

--- a/packages/test-cases/cases/parse/sanity/input.graphql
+++ b/packages/test-cases/cases/parse/sanity/input.graphql
@@ -83,7 +83,7 @@ type MutationEnv {
 }
 
 type MutationClientEnv {
-  prop: String!
+  prop: String
 }
 
 type Query @imports(

--- a/packages/test-cases/cases/parse/sanity/input.graphql
+++ b/packages/test-cases/cases/parse/sanity/input.graphql
@@ -86,9 +86,15 @@ type MutationClientEnv {
   prop: String
 }
 
+type Mutation {
+  sanitizeMutationEnv(env: MutationClientEnv!): MutationEnv!
+}
+
 type Query @imports(
   types: [ "TestImport_Query" ]
 ) {
+  sanitizeQueryEnv(env: QueryClientEnv!): QueryEnv!
+
   queryMethod(
     arg: String!
   ): [Int]!

--- a/packages/test-cases/cases/parse/sanity/output.ts
+++ b/packages/test-cases/cases/parse/sanity/output.ts
@@ -235,11 +235,32 @@ export const output: TypeInfo = {
   ],
   queryTypes: [
     {
+      ...createQueryDefinition({ type: "Mutation" }),
+      methods: [
+        {
+          ...createMethodDefinition({
+            type: "mutation",
+            name: "sanitizeMutationEnv",
+            return: createObjectPropertyDefinition({ name: "sanitizeMutationEnv", type: "MutationEnv", required: true }),
+            arguments: [createObjectPropertyDefinition({ name: "env", type: "MutationClientEnv", required: true })],
+          })
+        },
+      ],
+    },
+    {
       ...createQueryDefinition({
         type: "Query",
         imports: [{ type: "TestImport_Query" }]
       }),
       methods: [
+        {
+          ...createMethodDefinition({
+            type: "query",
+            name: "sanitizeQueryEnv",
+            return: createObjectPropertyDefinition({ name: "sanitizeQueryEnv", type: "QueryEnv", required: true }),
+            arguments: [createObjectPropertyDefinition({ name: "env", type: "QueryClientEnv", required: true })],
+          })
+        },
         {
           ...createMethodDefinition({
             type: "query",

--- a/packages/test-cases/cases/parse/sanity/output.ts
+++ b/packages/test-cases/cases/parse/sanity/output.ts
@@ -16,7 +16,7 @@ import {
 } from "../../../../schema/parse/src/typeInfo";
 
 export const output: TypeInfo = {
-  enviroment: {
+  environment: {
     mutation: {
       sanitized: {
         ...createObjectDefinition({ type: "MutationEnv" }),

--- a/packages/test-cases/cases/parse/sanity/output.ts
+++ b/packages/test-cases/cases/parse/sanity/output.ts
@@ -16,6 +16,36 @@ import {
 } from "../../../../schema/parse/src/typeInfo";
 
 export const output: TypeInfo = {
+  enviroment: {
+    mutation: {
+      sanitized: {
+        ...createObjectDefinition({ type: "MutationEnv" }),
+        properties: [
+          createScalarPropertyDefinition({ name: "prop", type: "Int", required: true })
+        ]
+      },
+      client: {
+        ...createObjectDefinition({ type: "MutationClientEnv" }),
+        properties: [
+          createScalarPropertyDefinition({ name: "prop", type: "String", required: false })
+        ]
+      }
+    },
+    query: {
+      sanitized: {
+        ...createObjectDefinition({ type: "QueryEnv" }),
+        properties: [
+          createScalarPropertyDefinition({ name: "prop", type: "String", required: true })
+        ]
+      },
+      client: {
+        ...createObjectDefinition({ type: "QueryClientEnv" }),
+        properties: [
+          createScalarPropertyDefinition({ name: "prop", type: "String", required: true })
+        ]
+      }
+    },
+  },
   objectTypes: [
     {
       ...createObjectDefinition({ type: "CustomType" }),


### PR DESCRIPTION
- add separate object enviroment in typeinfo for mutation and query
- add validation in parse for enviroment types
- separate shared env and resolve with specific env types for mutation and query

I am still not sure of the format of environment in typeinfo TBH.

Related to: #140 