### PR TITLE
bug fix: Building example API fails

### DIFF
--- a/packages/templates/api/assemblyscript/web3api.build.yaml
+++ b/packages/templates/api/assemblyscript/web3api.build.yaml
@@ -1,0 +1,11 @@
+format: 0.0.1-prealpha.2
+docker:
+  name: build-env
+  dockerfile: ./Dockerfile.mustache
+config:
+  node_version: "14.16.0"
+  include:
+    - ./package.json
+    - src/query
+    - src/mutation
+    - src/contracts

--- a/packages/templates/api/assemblyscript/web3api.build.yaml
+++ b/packages/templates/api/assemblyscript/web3api.build.yaml
@@ -6,6 +6,4 @@ config:
   node_version: "14.16.0"
   include:
     - ./package.json
-    - src/query
-    - src/mutation
-    - src/contracts
+    - ./src

--- a/packages/templates/api/assemblyscript/web3api.yaml
+++ b/packages/templates/api/assemblyscript/web3api.yaml
@@ -1,15 +1,11 @@
-description: SimpleStorage Web3API Example
 repository: https://github.com/web3-api/monorepo
-format: 0.0.1-prealpha.1
-mutation:
-  schema:
-    file: ./src/mutation/schema.graphql
-  module:
-    language: wasm/assemblyscript
-    file: ./src/mutation/index.ts
-query:
-  schema:
-    file: ./src/query/schema.graphql
-  module:
-    language: wasm/assemblyscript
-    file: ./src/query/index.ts
+format: 0.0.1-prealpha.2
+language: wasm/assemblyscript
+build: ./web3api.build.yaml
+modules:
+  mutation:
+    schema: ./src/mutation/schema.graphql
+    module: ./src/mutation/index.ts
+  query:
+    schema: ./src/query/schema.graphql
+    module: ./src/query/index.ts


### PR DESCRIPTION
I updated the manifest in the API template to v2, added src/contracts to the build manifest, and confirmed it successfully builds.

Closes #387.