### PR TITLE
Fix: Web assembly async instantiation

### DIFF
--- a/packages/js/asyncify/src/AsyncWasmInstance.ts
+++ b/packages/js/asyncify/src/AsyncWasmInstance.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-empty-function */
 
 type MaybeAsync<T> = Promise<T> | T;
 

--- a/packages/js/asyncify/src/__tests__/AsyncWasmInstance.spec.ts
+++ b/packages/js/asyncify/src/__tests__/AsyncWasmInstance.spec.ts
@@ -43,7 +43,7 @@ const getModule = async (name: string) => {
   const wasmPath = path.join(__dirname, "cases", "build", `${name}.wasm`);
   const buffer = fs.readFileSync(wasmPath);
   const bytes = new Uint8Array(buffer).buffer;
-  return new WebAssembly.Module(bytes);
+  return bytes;
 };
 
 describe("AsyncWasmInstance", () => {
@@ -71,7 +71,7 @@ describe("AsyncWasmInstance", () => {
     const module = await getModule("simpleSleep");
     const memory = new WebAssembly.Memory({ initial: 1 });
     const logs: number[] = [];
-    const instance = new AsyncWasmInstance({
+    const instance = await AsyncWasmInstance.createInstance({
       module,
       imports: {
         w3: {
@@ -106,7 +106,7 @@ describe("AsyncWasmInstance", () => {
     const module = await getModule("simpleSleep");
     const memory = new WebAssembly.Memory({ initial: 1 });
     const logs: number[] = [];
-    const instance = new AsyncWasmInstance({
+    const instance = await AsyncWasmInstance.createInstance({
       module,
       imports: {
         w3: {
@@ -141,7 +141,7 @@ describe("AsyncWasmInstance", () => {
     const module = await getModule("multipleSleep");
     const memory = new WebAssembly.Memory({ initial: 1 });
     const logs: number[] = [];
-    const instance = new AsyncWasmInstance({
+    const instance = await AsyncWasmInstance.createInstance({
       module,
       imports: {
         w3: {
@@ -180,7 +180,7 @@ describe("AsyncWasmInstance", () => {
         }, ms);
       });
 
-    const instance = new AsyncWasmInstance({
+    const instance = await AsyncWasmInstance.createInstance({
       module,
       imports: {
         w3: {
@@ -247,7 +247,7 @@ describe("AsyncWasmInstance", () => {
       })
     };
 
-    const instance = new AsyncWasmInstance({
+    const instance = await AsyncWasmInstance.createInstance({
       module,
       imports: {
         w3: {

--- a/packages/js/client/src/wasm/WasmWeb3Api.ts
+++ b/packages/js/client/src/wasm/WasmWeb3Api.ts
@@ -93,7 +93,7 @@ export class WasmWeb3Api extends Api {
               `Input: ${JSON.stringify(input, null, 2)}\nMessage: ${message}.\n`
           );
         };
-        
+
         const memory = new WebAssembly.Memory({ initial: 1 });
         const instance = await AsyncWasmInstance.createInstance({
           module: wasm,

--- a/packages/js/client/src/wasm/WasmWeb3Api.ts
+++ b/packages/js/client/src/wasm/WasmWeb3Api.ts
@@ -93,11 +93,10 @@ export class WasmWeb3Api extends Api {
               `Input: ${JSON.stringify(input, null, 2)}\nMessage: ${message}.\n`
           );
         };
-
-        const module = new WebAssembly.Module(wasm);
+        
         const memory = new WebAssembly.Memory({ initial: 1 });
-        const instance = new AsyncWasmInstance({
-          module,
+        const instance = await AsyncWasmInstance.createInstance({
+          module: wasm,
           imports: createImports({
             state,
             client,


### PR DESCRIPTION
If the WASM files are bigger than 4kb, the main thread will be disallowed (See more here https://stackoverflow.com/questions/45284788/webassembly-compile-is-disallowed-on-the-main-thread-if-the-buffer-size-is-larg?rq=1)

The change on this PR implements the instantiation of the WebAssembly class through an async method, which is `instantiate`