### PR TITLE
Bug: 0 value arguments are removed?

### DIFF
--- a/packages/js/core/src/__tests__/parse-query.spec.ts
+++ b/packages/js/core/src/__tests__/parse-query.spec.ts
@@ -285,6 +285,22 @@ describe("parseQuery", () => {
     ).toThrowError(/Missing variable/);
   });
 
+  it("succeeds when variables is defined by falsy", () => {
+    const doc = createQueryDocument(`
+      mutation {
+        someMethod(
+          arg1: $arg_1
+        )
+      }
+    `);
+
+    expect(() =>
+      parseQuery(dummy, doc, {
+        arg_1: 0,
+      })
+    ).not.toThrowError(/Missing variable/);
+  });
+
   it("fails when duplicate input arguments are provided", () => {
     const doc = createQueryDocument(`
       mutation {

--- a/packages/js/core/src/algorithms/parse-query.ts
+++ b/packages/js/core/src/algorithms/parse-query.ts
@@ -107,7 +107,7 @@ const extractValue = Tracer.traceFunc(
         );
       }
 
-      if (!variables[node.name.value]) {
+      if (variables[node.name.value] === undefined) {
         throw Error(`Missing variable: ${node.name.value}`);
       }
 


### PR DESCRIPTION
This PR prevents erasure of falsy variable values by changing a validation check from:
```
if (!variables[node.name.value]) {
        throw Error(`Missing variable: ${node.name.value}`);
      }
```
to:
```
if (variables[node.name.value] === undefined) {
        throw Error(`Missing variable: ${node.name.value}`);
      }
```

The PR also adds a unit test to confirm the parse-query algorithm does not throw when variable value is falsy.

Closes #485.