### PR TITLE
Gelato Use-Case Requests: GraphNode Default Plugin + Ethereum `encodeFunction` Method

### DIFF
--- a/packages/cli/src/__tests__/plugin/expected-schema/schema.graphql
+++ b/packages/cli/src/__tests__/plugin/expected-schema/schema.graphql
@@ -79,6 +79,11 @@ type Ethereum_Query @imported(
     values: [String!]!
   ): String!
 
+  encodeFunction(
+    method: String!
+    args: [String!]
+  ): String!
+
   getSignerAddress(
     connection: Ethereum_Connection
   ): String!

--- a/packages/cli/src/__tests__/plugin/expected-types/schema.ts
+++ b/packages/cli/src/__tests__/plugin/expected-types/schema.ts
@@ -79,6 +79,11 @@ type Ethereum_Query @imported(
     values: [String!]!
   ): String!
 
+  encodeFunction(
+    method: String!
+    args: [String!]
+  ): String!
+
   getSignerAddress(
     connection: Ethereum_Connection
   ): String!

--- a/packages/cli/src/__tests__/plugin/expected-types/types.ts
+++ b/packages/cli/src/__tests__/plugin/expected-types/types.ts
@@ -129,6 +129,12 @@ interface Ethereum_Query_Input_encodeParams extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.web3api.eth" */
+interface Ethereum_Query_Input_encodeFunction extends Record<string, unknown> {
+  method: String;
+  args?: Array<String> | null;
+}
+
+/* URI: "ens/ethereum.web3api.eth" */
 interface Ethereum_Query_Input_getSignerAddress extends Record<string, unknown> {
   connection?: Types.Ethereum_Connection | null;
 }
@@ -231,6 +237,18 @@ export const Ethereum_Query = {
       uri: "ens/ethereum.web3api.eth",
       module: "query",
       method: "encodeParams",
+      input
+    });
+  },
+
+  encodeFunction: async (
+    input: Ethereum_Query_Input_encodeFunction,
+    client: Client
+  ): Promise<InvokeApiResult<String>> => {
+    return client.invoke<String>({
+      uri: "ens/ethereum.web3api.eth",
+      module: "query",
+      method: "encodeFunction",
       input
     });
   },

--- a/packages/cli/src/__tests__/project/sample.ts
+++ b/packages/cli/src/__tests__/project/sample.ts
@@ -69,6 +69,11 @@ type Ethereum_Query @imported(
     values: [String!]!
   ): String!
 
+  encodeFunction(
+    method: String!
+    args: [String!]
+  ): String!
+
   getSignerAddress(
     connection: Ethereum_Connection
   ): String!
@@ -603,6 +608,11 @@ type Ethereum_Query @imported(
   encodeParams(
     types: [String!]!
     values: [String!]!
+  ): String!
+
+  encodeFunction(
+    method: String!
+    args: [String!]
   ): String!
 
   getSignerAddress(

--- a/packages/js/client/package.json
+++ b/packages/js/client/package.json
@@ -25,6 +25,7 @@
     "@web3api/core-js": "0.0.1-prealpha.46",
     "@web3api/ens-plugin-js": "0.0.1-prealpha.46",
     "@web3api/ethereum-plugin-js": "0.0.1-prealpha.46",
+    "@web3api/graph-node-plugin-js": "0.0.1-prealpha.46",
     "@web3api/http-plugin-js": "0.0.1-prealpha.46",
     "@web3api/ipfs-plugin-js": "0.0.1-prealpha.46",
     "@web3api/logger-plugin-js": "0.0.1-prealpha.46",

--- a/packages/js/client/src/__tests__/Web3ApiClient.spec.ts
+++ b/packages/js/client/src/__tests__/Web3ApiClient.spec.ts
@@ -74,6 +74,7 @@ describe("Web3ApiClient", () => {
         new Uri("w3://ens/js-logger.web3api.eth"),
         new Uri("w3://ens/uts46.web3api.eth"),
         new Uri("w3://ens/sha3.web3api.eth"),
+        new Uri("w3://ens/graph-node.web3api.eth"),
       ]);
     expect(
         client.interfaces()
@@ -127,6 +128,7 @@ describe("Web3ApiClient", () => {
       "w3://ens/js-logger.web3api.eth",
       "w3://ens/uts46.web3api.eth",
       "w3://ens/sha3.web3api.eth",
+      "w3://ens/graph-node.web3api.eth",
     ];
 
     const client = new Web3ApiClient({

--- a/packages/js/client/src/default-client-config.ts
+++ b/packages/js/client/src/default-client-config.ts
@@ -60,9 +60,9 @@ export const getDefaultClientConfig = Tracer.traceFunc(
         {
           uri: new Uri("w3://ens/graph-node.web3api.eth"),
           plugin: graphNodePlugin({
-            provider: "https://api.thegraph.com"
-          })
-        }
+            provider: "https://api.thegraph.com",
+          }),
+        },
       ],
       interfaces: [
         {

--- a/packages/js/client/src/default-client-config.ts
+++ b/packages/js/client/src/default-client-config.ts
@@ -4,6 +4,7 @@ import { Uri, coreInterfaceUris } from "@web3api/core-js";
 import { ipfsPlugin } from "@web3api/ipfs-plugin-js";
 import { ethereumPlugin } from "@web3api/ethereum-plugin-js";
 import { ensPlugin } from "@web3api/ens-plugin-js";
+import { graphNodePlugin } from "@web3api/graph-node-plugin-js";
 import { httpPlugin } from "@web3api/http-plugin-js";
 import { uts46Plugin } from "@web3api/uts46-plugin-js";
 import { sha3Plugin } from "@web3api/sha3-plugin-js";
@@ -56,6 +57,12 @@ export const getDefaultClientConfig = Tracer.traceFunc(
           uri: new Uri("w3://ens/sha3.web3api.eth"),
           plugin: sha3Plugin(),
         },
+        {
+          uri: new Uri("w3://ens/graph-node.web3api.eth"),
+          plugin: graphNodePlugin({
+            provider: "https://api.thegraph.com"
+          })
+        }
       ],
       interfaces: [
         {

--- a/packages/js/plugins/ethereum/schema.graphql
+++ b/packages/js/plugins/ethereum/schema.graphql
@@ -112,6 +112,11 @@ type Query {
     values: [String!]!
   ): String!
 
+  encodeFunction(
+    method: String!
+    args: [String!]
+  ): String!
+
   getSignerAddress(
     connection: Connection
   ): String!

--- a/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
+++ b/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
@@ -179,6 +179,23 @@ describe("Ethereum Plugin", () => {
       expect(response.data?.encodeParams).toBe("0x000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000")
     });
 
+    it("encodeFunction", async () => {
+      const response = await client.query<{ encodeFunction: string }>({
+        uri,
+        query: `
+          query {
+            encodeFunction(
+              method: "function increaseCount(uint256)",
+              args: ["100"]
+            )
+          }
+        `,
+      });
+
+      expect(response.errors).toBeUndefined();
+      expect(response.data?.encodeFunction).toBe("0x46d4adf20000000000000000000000000000000000000000000000000000000000000064")
+    });
+
     it("getSignerAddress", async () => {
       const response = await client.query<{ getSignerAddress: string }>({
         uri,

--- a/packages/js/plugins/ethereum/src/__tests__/integration/src/query/index.ts
+++ b/packages/js/plugins/ethereum/src/__tests__/integration/src/query/index.ts
@@ -6,6 +6,7 @@ import {
   Input_callContractView,
   Input_callContractStatic,
   Input_encodeParams,
+  Input_encodeFunction,
   Input_getSignerAddress,
   Input_getSignerBalance,
   Input_getSignerTransactionCount,
@@ -49,6 +50,15 @@ export function encodeParams(
   return Ethereum_Query.encodeParams({
     types: input.types,
     values: input.values
+  });
+}
+
+export function encodeFunction(
+  input: Input_encodeFunction
+): string {
+  return Ethereum_Query.encodeFunction({
+    method: input.method,
+    args: input.args
   });
 }
 

--- a/packages/js/plugins/ethereum/src/__tests__/integration/src/query/schema.graphql
+++ b/packages/js/plugins/ethereum/src/__tests__/integration/src/query/schema.graphql
@@ -21,6 +21,11 @@ type Query {
     values: [String!]!
   ): String!
 
+  encodeFunction(
+    method: String!
+    args: [String!]
+  ): String!
+
   getSignerAddress(
     connection: Ethereum_Connection
   ): String!

--- a/packages/js/plugins/ethereum/src/index.ts
+++ b/packages/js/plugins/ethereum/src/index.ts
@@ -198,6 +198,16 @@ export class EthereumPlugin extends Plugin {
     return defaultAbiCoder.encode(input.types, input.values);
   }
 
+  public encodeFunction(input: Query.Input_encodeFunction): string {
+    const functionInterface = ethers.Contract.getInterface([input.method]);
+    return functionInterface.encodeFunctionData(
+      functionInterface.functions[
+        Object.keys(functionInterface.functions)[0]
+      ],
+      input.args || undefined
+    );
+  }
+
   public async getSignerAddress(
     input: Query.Input_getSignerAddress
   ): Promise<string> {

--- a/packages/js/plugins/ethereum/src/index.ts
+++ b/packages/js/plugins/ethereum/src/index.ts
@@ -201,9 +201,7 @@ export class EthereumPlugin extends Plugin {
   public encodeFunction(input: Query.Input_encodeFunction): string {
     const functionInterface = ethers.Contract.getInterface([input.method]);
     return functionInterface.encodeFunctionData(
-      functionInterface.functions[
-        Object.keys(functionInterface.functions)[0]
-      ],
+      functionInterface.functions[Object.keys(functionInterface.functions)[0]],
       input.args || undefined
     );
   }

--- a/packages/js/plugins/ethereum/src/resolvers.ts
+++ b/packages/js/plugins/ethereum/src/resolvers.ts
@@ -59,6 +59,10 @@ export const query = (plugin: Plugin): Query.Module => ({
     return plugin.encodeParams(input);
   },
 
+  encodeFunction: async (input: Query.Input_encodeFunction): Promise<string> => {
+    return plugin.encodeFunction(input);
+  },
+
   getSignerAddress: async (
     input: Query.Input_getSignerAddress
   ): Promise<string> => {

--- a/packages/js/plugins/ethereum/src/resolvers.ts
+++ b/packages/js/plugins/ethereum/src/resolvers.ts
@@ -59,7 +59,9 @@ export const query = (plugin: Plugin): Query.Module => ({
     return plugin.encodeParams(input);
   },
 
-  encodeFunction: async (input: Query.Input_encodeFunction): Promise<string> => {
+  encodeFunction: async (
+    input: Query.Input_encodeFunction
+  ): Promise<string> => {
     return plugin.encodeFunction(input);
   },
 


### PR DESCRIPTION
After speaking with one of Gelato's devs today, these two additions would make their use-case much easier to implement.