### PR TITLE
RS-CI: Github Actions (workflow) for Rust

### DIFF
--- a/.github/workflows/rs-ci.yaml
+++ b/.github/workflows/rs-ci.yaml
@@ -1,0 +1,130 @@
+name: RS-CI
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: False
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        profile: [release]
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+          - os: windows-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/
+            ./target/
+          key: cargo-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ github.job }}
+      - name: Cargo Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+      - name: List Cargo artifacts
+        run: ls target/${{ matrix.profile }}
+      - name: Prepare Artifacts
+        run: ./.github/copy-artifacts.sh
+        env:
+          OS: ${{ matrix.os }}
+      - uses: msys2/setup-msys2@v2
+        if: matrix.os == 'windows-latest'
+        with:
+          msystem: MINGW64
+          update: true
+          install: git mingw-w64-x86_64-toolchain mingw-w64-x86_64-tools-git
+      - name: Prepare Artifacts
+        run: ./.github/copy-artifacts.sh
+        env:
+          OS: ${{ matrix.os }}
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: bins-${{ runner.os }}-${{ matrix.profile }}
+          path: bins/
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: False
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Install Rust
+        run: |
+          rustup update nightly
+          rustup default nightly
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/
+            ./target/
+          key: cargo-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ github.job }}
+      - name: Cargo Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+  cargo-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install Rust
+        run: |
+          rustup update nightly
+          rustup default nightly
+      - name: Run `cargo fmt`
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+  cargo-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install Rust
+        run: |
+          rustup update nightly
+          rustup default nightly
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/
+            ./target/
+          key: cargo-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ github.job }}
+      - name: Run `cargo doc`
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --workspace --no-deps

--- a/.github/workflows/rs-ci.yaml
+++ b/.github/workflows/rs-ci.yaml
@@ -8,6 +8,7 @@ jobs:
     defaults:
       run:
         shell: bash
+        working-directory: ./packages/wasm/rs
     strategy:
       fail-fast: False
       matrix:
@@ -63,6 +64,10 @@ jobs:
           path: bins/
   test:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./packages/wasm/rs
     strategy:
       fail-fast: False
       matrix:
@@ -92,6 +97,10 @@ jobs:
           command: test
   cargo-fmt:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./packages/wasm/rs
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -106,6 +115,10 @@ jobs:
           args: --all -- --check
   cargo-doc:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./packages/wasm/rs
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
Prior to merging the [Rust/WASM Support](https://github.com/polywrap/monorepo/pull/523) PR into the toolchain, we need a CI workflow for subsequent Rust contributions, especially for the WASM runtime (`/packages/wasm/rs`). This PR addresses that need.