### PR TITLE
bug fix: ethereum plugin encodeFunction(...) now accepts array type arguments

### DIFF
--- a/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
+++ b/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
@@ -196,6 +196,24 @@ describe("Ethereum Plugin", () => {
 
       expect(response.errors).toBeUndefined();
       expect(response.data?.encodeFunction).toBe("0x46d4adf20000000000000000000000000000000000000000000000000000000000000064")
+
+      const acceptsArrayArg = await client.query<{ encodeFunction: string }>({
+        uri,
+        query: `
+          query {
+            encodeFunction(
+              method: $method
+              args: $args
+            )
+          }
+        `,
+        variables: {
+          method: "function createArr(uint256[] memory)",
+          args: [JSON.stringify([1, 2])]
+        }
+      });
+
+      expect(acceptsArrayArg.errors).toBeUndefined();
     });
 
     it("getSignerAddress", async () => {

--- a/packages/js/plugins/ethereum/src/index.ts
+++ b/packages/js/plugins/ethereum/src/index.ts
@@ -213,7 +213,7 @@ export class EthereumPlugin extends Plugin {
     const functionInterface = ethers.Contract.getInterface([input.method]);
     return functionInterface.encodeFunctionData(
       functionInterface.functions[Object.keys(functionInterface.functions)[0]],
-      input.args || undefined
+      this.parseArgs(input.args)
     );
   }
 


### PR DESCRIPTION
The encodeFunction(...) function in the JS Ethereum plugin now parses array-type and object-type arguments like other Ethereum plugin functions.

Closes #566.