### PR TITLE
Bug Fix: Fixed tuple/array parsing in Ethereum plugin function encodeParams(...)

### DIFF
--- a/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
+++ b/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
@@ -179,6 +179,24 @@ describe("Ethereum Plugin", () => {
       });
 
       expect(response.data?.encodeParams).toBe("0x000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000")
+
+      const acceptsTupleArg = await client.query<{ encodeFunction: string }>({
+        uri,
+        query: `
+          query {
+            encodeParams(
+              types: $types
+              values: $values
+            )
+          }
+        `,
+        variables: {
+          types: ["tuple(uint256 startTime, uint256 endTime, address token)"],
+          values: [JSON.stringify({ startTime: "8", endTime: "16", token: "0x0000000000000000000000000000000000000000" })]
+        }
+      });
+
+      expect(acceptsTupleArg.errors).toBeUndefined();
     });
 
     it("encodeFunction", async () => {

--- a/packages/js/plugins/ethereum/src/index.ts
+++ b/packages/js/plugins/ethereum/src/index.ts
@@ -206,7 +206,7 @@ export class EthereumPlugin extends Plugin {
   }
 
   public encodeParams(input: Query.Input_encodeParams): string {
-    return defaultAbiCoder.encode(input.types, input.values);
+    return defaultAbiCoder.encode(input.types, this.parseArgs(input.values));
   }
 
   public encodeFunction(input: Query.Input_encodeFunction): string {


### PR DESCRIPTION
Added parseArgs(...) transform to encodeParams(...) in Ethereum plugin. The parseArgs(...) function is used in other Ethereum plugin functions to correctly parse tuple and array values, but it was not used in encodeParams.