### PR TITLE
http plugin: json payload support

### DIFF
--- a/packages/js/plugins/http/package.json
+++ b/packages/js/plugins/http/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@web3api/core-js": "0.0.1-prealpha.62",
-    "axios": "0.21.2"
+    "axios": "0.21.4"
   },
   "devDependencies": {
     "@types/jest": "26.0.8",

--- a/packages/js/plugins/http/src/__tests__/e2e/e2e.spec.ts
+++ b/packages/js/plugins/http/src/__tests__/e2e/e2e.spec.ts
@@ -146,6 +146,48 @@ describe("e2e tests for HttpPlugin", () => {
 
   describe("post method", () => {
 
+    test("succesfull request with request type as application/json", async () => {
+      const reqPayload = {
+        data: "test-request",
+      };
+      const reqPayloadStringified = JSON.stringify(reqPayload);
+      
+      const resPayload = {
+        data: "test-response"
+      };
+      const resPayloadStringfified = JSON.stringify(resPayload);
+
+      nock("http://www.example.com")
+          .defaultReplyHeaders(defaultReplyHeaders)
+          .post("/api", reqPayloadStringified)
+          .reply(200, resPayloadStringfified)
+
+      const response = await web3ApiClient.query<{ post: Response }>({
+        uri: "w3://ens/http.web3api.eth",
+        query: `
+          query {
+            post(
+              url: "http://www.example.com/api"
+              request: {
+                headers: [
+                  { key: "Content-Type", value: "application/json" },
+                ],
+                responseType: TEXT
+                body: "{\\"data\\":\\"test-request\\"}"
+              }
+            )
+          }
+        `
+      })
+
+      expect(response.data).toBeDefined()
+      expect(response.errors).toBeUndefined()
+      expect(response.data?.post.status).toBe(200)
+      // expect(response.data?.get.statusText).toBe("OK")
+      expect(response.data?.post.body).toBe(resPayloadStringfified)
+      expect(response.data?.post.headers?.length).toEqual(2) // default reply headers
+    });
+
     test("succesfull request with response type as TEXT", async () => {
       nock("http://www.example.com")
         .defaultReplyHeaders(defaultReplyHeaders)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5242,7 +5242,7 @@ axios@0.21.2:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^0.21.4:
+axios@0.21.4, axios@^0.21.4:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==


### PR DESCRIPTION
Closes: https://github.com/polywrap/monorepo/issues/676

There is a bug in axios library in the version before 0.21.4, which produce wrong body payload