### PR TITLE
Bug fix: Ethereum plugin fromTxRequest(...) mapping

### DIFF
--- a/packages/js/plugins/ethereum/src/mapping.ts
+++ b/packages/js/plugins/ethereum/src/mapping.ts
@@ -90,10 +90,10 @@ export const fromTxRequest = (
   to: request.to || undefined,
   from: request.from || undefined,
   nonce: request.nonce || undefined,
-  gasLimit: request.gasLimit || undefined,
-  gasPrice: request.gasPrice || undefined,
+  gasLimit: request.gasLimit ? ethers.BigNumber.from(request.gasLimit) : undefined,
+  gasPrice: request.gasPrice ? ethers.BigNumber.from(request.gasPrice) : undefined,
   data: request.data || undefined,
-  value: request.value || undefined,
+  value: request.value ? ethers.BigNumber.from(request.value) : undefined,
   chainId: request.chainId || undefined,
   type: request.type || undefined,
 });

--- a/packages/js/plugins/ethereum/src/mapping.ts
+++ b/packages/js/plugins/ethereum/src/mapping.ts
@@ -90,8 +90,12 @@ export const fromTxRequest = (
   to: request.to || undefined,
   from: request.from || undefined,
   nonce: request.nonce || undefined,
-  gasLimit: request.gasLimit ? ethers.BigNumber.from(request.gasLimit) : undefined,
-  gasPrice: request.gasPrice ? ethers.BigNumber.from(request.gasPrice) : undefined,
+  gasLimit: request.gasLimit
+    ? ethers.BigNumber.from(request.gasLimit)
+    : undefined,
+  gasPrice: request.gasPrice
+    ? ethers.BigNumber.from(request.gasPrice)
+    : undefined,
   data: request.data || undefined,
   value: request.value ? ethers.BigNumber.from(request.value) : undefined,
   chainId: request.chainId || undefined,


### PR DESCRIPTION
Fixed bug where some TxRequest properties were not converted to BigNumber when mapped to ethers TransactionRequest type, but should have been. When the properties `gasLimit`, `gasPrice`, and `value` are left as strings, ethers throws an exception in its [hexlify function](https://github.com/ethers-io/ethers.js/blob/master/packages/bytes/src.ts/index.ts#L195).