### PR TITLE
Bug fix: eslint `Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
       files: ["*.ts"],
       parser: "@typescript-eslint/parser",
       parserOptions: {
-        project: ["tsconfig.json"],
+        project: ["tsconfig.json", "./packages/**/tsconfig.json"],
       },
       plugins: [
         "eslint-plugin-import",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,6 @@
     "strictNullChecks": true
   },
   "include": [
-    "./src/**/*"
+    "./packages/**/src/**/*"
   ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,6 @@
     "strictNullChecks": true
   },
   "include": [
-    "./packages/**/src/**/*"
+    "./src/**/*"
   ],
 }


### PR DESCRIPTION
Added glob in "project" property of parser options in eslint config. The additional glob adds all package-level tsconfig files to the eslint project.