### PR TITLE
Properly Support Recursive Object Definition Properties

### DIFF
--- a/packages/schema/compose/package.json
+++ b/packages/schema/compose/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@types/jest": "26.0.8",
     "@types/mustache": "4.0.1",
-    "@web3api/os-js": "0.0.1-prealpha.63",
     "@web3api/test-cases": "0.0.1-prealpha.63",
     "jest": "26.6.3",
     "rimraf": "3.0.2",

--- a/packages/schema/compose/src/__tests__/index.ts
+++ b/packages/schema/compose/src/__tests__/index.ts
@@ -1,11 +1,14 @@
 import { ComposerOutput, ComposerOptions, ComposerFilter } from "..";
 
 import path from "path";
-import { readdirSync, readFileSync, Dirent, existsSync } from "fs";
+import { readdirSync, Dirent } from "fs";
 
 import { TypeInfo } from "@web3api/schema-parse";
-import { GetPathToComposeTestFiles } from "@web3api/test-cases"
-import { normalizeLineEndings } from "@web3api/os-js";
+import {
+  GetPathToComposeTestFiles,
+  readFileIfExists,
+  readNamedExportIfExists,
+} from "@web3api/test-cases"
 
 const root = GetPathToComposeTestFiles();
 
@@ -20,78 +23,70 @@ type TestCases = {
   name: string;
 }[];
 
-const importCase = async (basePath: string, dirent: Dirent): Promise<TestCase | undefined> => {
-  // The case must be a folder
-  if (!dirent.isDirectory()) {
-    return undefined;
-  }
+export function fetchTestCases(): TestCases {
+  const testCases: TestCases = [];
 
-  const getFilePath = (
-    subpath: string,
-    absolute = false
-  ): string => {
-    if (absolute) {
-      return subpath
-    } else {
-      return path.join(basePath, dirent.name, subpath);
-    }
-  }
-
-  const fetchIfExists = (
-    subpath: string,
-    absolute = false
-  ): string | undefined => {
-    const filePath = getFilePath(subpath, absolute);
-
-    if (existsSync(filePath)) {
-      return normalizeLineEndings(
-        readFileSync(filePath, { encoding: "utf-8" }),
-        "\n"
+  readdirSync(root, { withFileTypes: true }).forEach(
+    (dirent: Dirent) => {
+      buildTestCases(
+        path.join(root, dirent.name),
+        dirent.name,
+        testCases
       );
-    } else {
-      return undefined;
     }
-  };
+  );
 
-  const importIfExists = async (
-    subpath: string,
-    absolute = false
-  ): Promise<TypeInfo | undefined> => {
-    const filePath = getFilePath(subpath, absolute);
+  return testCases;
+}
 
-    if (existsSync(filePath)) {
-      const module = await import(filePath);
+function buildTestCases(
+  directory: string,
+  name: string,
+  testCases: TestCases
+): void {
+  const items = readdirSync(directory, { withFileTypes: true });
 
-      if (!module.typeInfo) {
-        throw Error(
-          `Required named export "typeInfo" is missing in ${filePath}`
-        );
-      }
-
-      return module.typeInfo as TypeInfo;
-    } else {
-      return undefined;
+  if (
+    items.some(x => x.name.startsWith("input")) &&
+    items.some(x => x.name.startsWith("output"))
+  ) {
+    testCases.push({
+      promise: importCase(directory, name),
+      name: name
+    });
+  } else {
+    for (const item of items) {
+      buildTestCases(
+        path.join(directory, item.name),
+        item.name,
+        testCases
+      );
     }
   }
+}
 
+async function importCase(
+  directory: string,
+  name: string,
+): Promise<TestCase | undefined> {
   // Fetch the input schemas
-  const queryInput = fetchIfExists("input/query.graphql");
-  const mutationInput = fetchIfExists("input/mutation.graphql");
+  const queryInput = readFileIfExists("input/query.graphql", directory);
+  const mutationInput = readFileIfExists("input/mutation.graphql", directory);
 
   // Fetch the output schemas
-  const querySchema = fetchIfExists("output/query.graphql");
-  const ModuleTypeInfo = await importIfExists("output/query.ts");
-  const mutationSchema = fetchIfExists("output/mutation.graphql");
-  const mutationTypeInfo = await importIfExists("output/mutation.ts");
-  const schemaSchema = fetchIfExists("output/schema.graphql");
-  const schemaTypeInfo = await importIfExists("output/schema.ts");
+  const querySchema = readFileIfExists("output/query.graphql", directory);
+  const ModuleTypeInfo = await readNamedExportIfExists<TypeInfo>("typeInfo", "output/query.ts", directory);
+  const mutationSchema = readFileIfExists("output/mutation.graphql", directory);
+  const mutationTypeInfo = await readNamedExportIfExists<TypeInfo>("typeInfo", "output/mutation.ts", directory);
+  const schemaSchema = readFileIfExists("output/schema.graphql", directory);
+  const schemaTypeInfo = await readNamedExportIfExists<TypeInfo>("typeInfo", "output/schema.ts", directory);
 
   const resolveExternal = (uri: string): Promise<string> => {
-    return Promise.resolve(fetchIfExists(`imports-ext/${uri}/schema.graphql`) || "");
+    return Promise.resolve(readFileIfExists(`imports-ext/${uri}/schema.graphql`, directory) || "");
   };
 
   const resolveLocal = (path: string): Promise<string> => {
-    return Promise.resolve(fetchIfExists(path, true) || "");
+    return Promise.resolve(readFileIfExists(path, directory, true) || "");
   };
 
   const input: ComposerOptions = {
@@ -107,8 +102,7 @@ const importCase = async (basePath: string, dirent: Dirent): Promise<TestCase | 
     input.schemas.query = {
       schema: queryInput,
       absolutePath: path.join(
-        basePath,
-        dirent.name,
+        directory,
         "input/query.graphql"
       ),
     };
@@ -118,8 +112,7 @@ const importCase = async (basePath: string, dirent: Dirent): Promise<TestCase | 
     input.schemas.mutation = {
       schema: mutationInput,
       absolutePath: path.join(
-        basePath,
-        dirent.name,
+        directory,
         "input/mutation.graphql"
       ),
     };
@@ -151,39 +144,8 @@ const importCase = async (basePath: string, dirent: Dirent): Promise<TestCase | 
   }
 
   return {
-    name: dirent.name,
+    name,
     input,
     output,
   };
-};
-
-export function fetchTestCases(): TestCases {
-  const testCases: TestCases = [];
-
-  readdirSync(root, { withFileTypes: true }).forEach(
-    (dirent: Dirent) => {
-      buildTestCases(root, root, dirent, testCases)
-    }
-  );
-
-  return testCases;
-}
-
-export const buildTestCases = (rootPath: string, basePath: string, dirent: Dirent, testCases: TestCases) => {
-  const fullPath = path.join(basePath, dirent.name);
-
-  const items = readdirSync(fullPath, { withFileTypes: true });
-
-  if(items.some(x => x.name === "input") && 
-    items.some(x => x.name === "output")
-  ) {
-    testCases.push({
-      promise: importCase(basePath, dirent),
-      name: path.relative(rootPath, fullPath), 
-    });
-  } else {
-    for(const item of items) {
-      buildTestCases(rootPath, fullPath, item, testCases);
-    }
-  }
 }

--- a/packages/schema/parse/package.json
+++ b/packages/schema/parse/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "graphql": "15.5.0",
-    "graphql-schema-cycles": "1.1.3"
+    "@dorgjelli/graphql-schema-cycles": "1.1.4"
   },
   "devDependencies": {
     "@types/deep-equal": "1.0.1",

--- a/packages/schema/parse/src/__tests__/test-cases.spec.ts
+++ b/packages/schema/parse/src/__tests__/test-cases.spec.ts
@@ -5,9 +5,15 @@ describe("Web3API Schema Parser Test Cases", () => {
   const cases = fetchTestCases();
 
   for (const test of cases) {
-    it(`Case: ${test.name}`, () => {
-      const result = parseSchema(test.input);
-      expect(result).toMatchObject(test.output);
+    it(`Case: ${test.name}`, async () => {
+      const testCase = await test.promise;
+
+      if (!testCase) {
+        return;
+      }
+
+      const result = parseSchema(testCase.input);
+      expect(result).toMatchObject(testCase.output);
     });
   }
 });

--- a/packages/schema/parse/src/__tests__/validate-types.spec.ts
+++ b/packages/schema/parse/src/__tests__/validate-types.spec.ts
@@ -217,6 +217,30 @@ type B {
 }
 `
 
+const circularTypes7 = `
+type A {
+  prop: A
+}
+`
+
+const circularTypes8 = `
+type A {
+  prop: [A!]!
+}
+`
+
+const circularTypes9 = `
+type A {
+  prop: [A!]
+}
+`
+
+const circularTypes10 = `
+type A {
+  prop: [A]
+}
+`
+
 describe("Web3API Schema Type Validation", () => {
   it("typeDefinitions", () => {
     const exec = (schema: string) => () => parseSchema(schema, {
@@ -304,5 +328,13 @@ describe("Web3API Schema Type Validation", () => {
 
     //Should allow circular references on nullable fields
     expect(exec(circularTypes6)).not.toThrow()
+
+    //Should allow recursive referece on nullable fields
+    expect(exec(circularTypes7)).not.toThrow()
+
+    //Should allow array of recursive references
+    expect(exec(circularTypes8)).not.toThrow()
+    expect(exec(circularTypes9)).not.toThrow()
+    expect(exec(circularTypes10)).not.toThrow()
   })
 });

--- a/packages/schema/parse/src/index.ts
+++ b/packages/schema/parse/src/index.ts
@@ -57,15 +57,15 @@ const validate = (
 ) => {
   const allValidators = validators.map((getValidator) => getValidator());
   const allVisitors = allValidators.map((x) => x.visitor);
-  const allDisplayValidationMessages = allValidators.map(
-    (x) => x.displayValidationMessagesIfExist
+  const allCleanup = allValidators.map(
+    (x) => x.cleanup
   );
 
   visit(astNode, visitInParallel(allVisitors));
 
-  for (const displayValidationMessagesIfExist of allDisplayValidationMessages) {
-    if (displayValidationMessagesIfExist) {
-      displayValidationMessagesIfExist(astNode);
+  for (const cleanup of allCleanup) {
+    if (cleanup) {
+      cleanup(astNode);
     }
   }
 };

--- a/packages/schema/parse/src/index.ts
+++ b/packages/schema/parse/src/index.ts
@@ -57,9 +57,7 @@ const validate = (
 ) => {
   const allValidators = validators.map((getValidator) => getValidator());
   const allVisitors = allValidators.map((x) => x.visitor);
-  const allCleanup = allValidators.map(
-    (x) => x.cleanup
-  );
+  const allCleanup = allValidators.map((x) => x.cleanup);
 
   visit(astNode, visitInParallel(allVisitors));
 

--- a/packages/schema/parse/src/validate/directives.ts
+++ b/packages/schema/parse/src/validate/directives.ts
@@ -24,7 +24,7 @@ export const getSupportedDirectivesValidator = (): SchemaValidator => {
         },
       },
     },
-    displayValidationMessagesIfExist: () => {
+    cleanup: () => {
       if (unsupportedUsages.length) {
         throw new Error(
           `Found the following usages of unsupported directives:${unsupportedUsages.map(

--- a/packages/schema/parse/src/validate/index.ts
+++ b/packages/schema/parse/src/validate/index.ts
@@ -5,7 +5,7 @@ import { ASTVisitor, DocumentNode } from "graphql";
 
 export type SchemaValidator = {
   visitor: ASTVisitor;
-  displayValidationMessagesIfExist?: (documentNode: DocumentNode) => void;
+  cleanup?: (documentNode: DocumentNode) => void;
 };
 
 export type SchemaValidatorBuilder = () => SchemaValidator;

--- a/packages/schema/parse/src/validate/types.ts
+++ b/packages/schema/parse/src/validate/types.ts
@@ -19,7 +19,7 @@ import {
   StringValueNode,
   UnionTypeDefinitionNode,
 } from "graphql";
-import { getSchemaCycles } from "graphql-schema-cycles";
+import { getSchemaCycles } from "@dorgjelli/graphql-schema-cycles";
 
 export const getTypeDefinitionsValidator = (): SchemaValidator => {
   const objectTypes: Record<string, boolean> = {};
@@ -177,7 +177,7 @@ export const getPropertyTypesValidator = (): SchemaValidator => {
         },
       },
     },
-    displayValidationMessagesIfExist: () => {
+    cleanup: () => {
       // Ensure all property types are either a
       // supported scalar, enum or an object type definition
       for (const field of fieldTypes) {
@@ -226,7 +226,7 @@ export function getCircularDefinitionsValidator(): SchemaValidator {
         },
       },
     },
-    displayValidationMessagesIfExist: (documentNode: DocumentNode) => {
+    cleanup: (documentNode: DocumentNode) => {
       const { cycleStrings, foundCycle } = getSchemaCycles(documentNode, {
         ignoreTypeNames: operationTypes,
         allowOnNullableFields: true,

--- a/packages/test-cases/cases/parse/recursive-properties/input.graphql
+++ b/packages/test-cases/cases/parse/recursive-properties/input.graphql
@@ -1,0 +1,7 @@
+type Object {
+  recursive: Object
+  recursiveArray: [Object!]!
+  recursiveOptArray: [Object!]
+  recursiveArrayOpt: [Object]!
+  recursiveOptArrayOpt: [Object]
+}

--- a/packages/test-cases/cases/parse/recursive-properties/output.ts
+++ b/packages/test-cases/cases/parse/recursive-properties/output.ts
@@ -1,0 +1,64 @@
+import {
+  TypeInfo,
+  createTypeInfo,
+  createObjectDefinition,
+  createObjectPropertyDefinition,
+  createArrayPropertyDefinition,
+  createObjectRef,
+} from "../../../../schema/parse/src/typeInfo";
+
+export const typeInfo: TypeInfo = {
+  ...createTypeInfo(),
+  objectTypes: [
+    {
+      ...createObjectDefinition({ type: "Object" }),
+      properties: [
+        createObjectPropertyDefinition({
+          name: "recursive",
+          type: "Object",
+          required: false
+        }),
+        createArrayPropertyDefinition({
+          name: "recursiveArray",
+          type: "[Object]",
+          required: true,
+          item: createObjectRef({
+            name: "recursiveArray",
+            type: "Object",
+            required: true,
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "recursiveOptArray",
+          type: "[Object]",
+          required: false,
+          item: createObjectRef({
+            name: "recursiveOptArray",
+            type: "Object",
+            required: true,
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "recursiveArrayOpt",
+          type: "[Object]",
+          required: true,
+          item: createObjectRef({
+            name: "recursiveArrayOpt",
+            type: "Object",
+            required: false,
+          })
+        }),
+        createArrayPropertyDefinition({
+          name: "recursiveOptArrayOpt",
+          type: "[Object]",
+          required: false,
+          item: createObjectRef({
+            name: "recursiveOptArrayOpt",
+            type: "Object",
+            required: false,
+          })
+        }),
+      ],
+    },
+  ],
+}

--- a/packages/test-cases/cases/parse/sanity/output.ts
+++ b/packages/test-cases/cases/parse/sanity/output.ts
@@ -21,7 +21,7 @@ import {
   createEnvDefinition
 } from "../../../../schema/parse/src/typeInfo";
 
-export const output: TypeInfo = {
+export const typeInfo: TypeInfo = {
   interfaceTypes: [
     createInterfaceDefinition({
       type: "TestImport",

--- a/packages/test-cases/index.ts
+++ b/packages/test-cases/index.ts
@@ -1,4 +1,65 @@
+import path from "path";
+import { readFileSync, existsSync } from "fs";
+
+import { normalizeLineEndings } from "@web3api/os-js";
+
 export const GetPathToBindTestFiles = () => `${__dirname}/cases/bind`
 export const GetPathToComposeTestFiles = () => `${__dirname}/cases/compose`
 export const GetPathToParseTestFiles = () => `${__dirname}/cases/parse`
 export const GetPathToTestApis = () => `${__dirname}/cases/apis`
+
+export function readFileIfExists(
+  file: string,
+  directory: string,
+  absolute = false
+): string | undefined {
+  const filePath = getFilePath( 
+    file,
+    directory,
+    absolute
+  );
+
+  if (existsSync(filePath)) {
+    return normalizeLineEndings(
+      readFileSync(filePath, { encoding: "utf-8" }),
+      "\n"
+    );
+  } else {
+    return undefined;
+  }
+};
+
+export async function readNamedExportIfExists<TExport>(
+  namedExport: string,
+  file: string,
+  directory: string,
+  absolute = false
+): Promise<TExport | undefined> {
+  const filePath = getFilePath(file, directory, absolute);
+
+  if (existsSync(filePath)) {
+    const module = await import(filePath);
+
+    if (!module[namedExport]) {
+      throw Error(
+        `Required named export "${namedExport}" is missing in ${filePath}`
+      );
+    }
+
+    return module[namedExport] as TExport;
+  } else {
+    return undefined;
+  }
+}
+
+function getFilePath(
+  file: string,
+  directory: string,
+  absolute = false
+): string {
+  if (absolute) {
+    return file;
+  } else {
+    return path.join(directory, file);
+  }
+}

--- a/packages/test-cases/package.json
+++ b/packages/test-cases/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "version": "0.0.1-prealpha.63",
   "license": "MIT",
-  "main": "index.ts"
+  "main": "index.ts",
+  "dependencies": {
+    "@web3api/os-js": "0.0.1-prealpha.63"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,6 +1513,14 @@
     pull-stream-to-async-iterator "^1.0.2"
     querystring "^0.2.0"
 
+"@dorgjelli/graphql-schema-cycles@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@dorgjelli/graphql-schema-cycles/-/graphql-schema-cycles-1.1.4.tgz#31f230c61f624f7c2ceca7e18fad8b2cb07d392f"
+  integrity sha512-U5ARitMQWKjOAvwn1+0Z52R9sbNe1wpbgAbj2hOfRFb/vupfPlRwZLbuUZAlotMpkoxbTbk+GRmoiNzGcJfyHw==
+  dependencies:
+    graphql "15.5.0"
+    graphql-json-transform "^1.1.0-alpha.0"
+
 "@dsherret/to-absolute-glob@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz#1f6475dc8bd974cea07a2daf3864b317b1dd332c"
@@ -10332,14 +10340,6 @@ graphql-json-transform@^1.1.0-alpha.0:
   version "1.1.0-alpha.0"
   resolved "https://registry.yarnpkg.com/graphql-json-transform/-/graphql-json-transform-1.1.0-alpha.0.tgz#fb0c88d24840067e6c55ac64bbc8d4e5de245d2d"
   integrity sha512-I6lR/lYEezSz4iru0f7a/wR8Rzi3pCafk7S0bX2b/WQOtK0vKabxLShGBXIslsi0arMehIjvOPHJl7MpOUqj0w==
-
-graphql-schema-cycles@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/graphql-schema-cycles/-/graphql-schema-cycles-1.1.3.tgz#80c148e2d1bb9f741372b7b54dff950aa2f9c0d2"
-  integrity sha512-0hQZNUeHlwaoTT6apNWLSeO/gJv/+AbZO1JOPqafMlZUmq+fN+KN3ifjoxIt6kxYSlOOpsEWLf0GWEOMdMwTdg==
-  dependencies:
-    graphql "15.5.0"
-    graphql-json-transform "^1.1.0-alpha.0"
 
 graphql-tag@2.10.4:
   version "2.10.4"


### PR DESCRIPTION
**Purpose**
Ensure that we properly support recursive property definitions. Example:
```graphql
type Object {
  recursive: Object
  recursiveArray: [Object!]!
  recursiveOptArray: [Object!]
  recursiveArrayOpt: [Object]!
  recursiveOptArrayOpt: [Object]
}
```

**Discussion**
https://discord.com/channels/796821176743362611/814588073581084723/943462452279017512

**Fix in Dependency**
https://github.com/polywrap/graphql-cycles-detector/commit/3ad5ff06e43342d3c0b19753acb75857ff42ab11

**Other Changes**
- Improved the test-case runners in the parse & compose packages.
- Rename validation visitor's `displayValidationMessagesIfExist` function to `cleanup`.