### PR TITLE
http plugin: response header as a list

### DIFF
--- a/packages/js/plugins/http/src/__tests__/unit/util.test.ts
+++ b/packages/js/plugins/http/src/__tests__/unit/util.test.ts
@@ -19,6 +19,25 @@ describe("converting axios response", () => {
     expect(response.statusText).toBe("Ok");
     expect(response.body).toBe("body-content");
   });
+  
+  test("response type: text; with header as a map", () => {
+    const response = fromAxiosResponse({
+      status: 200,
+      statusText: "Ok",
+      data: "body-content",
+      headers: { ["Accept"]: "application-json", ["X-Header"]: "test-value", ["set-cookie"]: ['key=val;', 'key2=val2;'] },
+      config: { responseType: "text" },
+    });
+
+    expect(response.headers).toStrictEqual([
+      { key: "Accept", value: "application-json" },
+      { key: "X-Header", value: "test-value" },
+      { key: "set-cookie", value: "key=val; key2=val2;" },
+    ]);
+    expect(response.status).toBe(200);
+    expect(response.statusText).toBe("Ok");
+    expect(response.body).toBe("body-content");
+  });
 
   test("response type: arraybuffer", () => {
     const response = fromAxiosResponse({

--- a/packages/js/plugins/http/src/util.ts
+++ b/packages/js/plugins/http/src/util.ts
@@ -12,7 +12,12 @@ export function fromAxiosResponse(
 ): Response {
   const responseHeaders: Header[] = [];
   for (const key of Object.keys(axiosResponse.headers)) {
-    responseHeaders.push({ key: key, value: axiosResponse.headers[key] });
+    responseHeaders.push({
+      key: key,
+      value: Array.isArray(axiosResponse.headers[key])
+        ? axiosResponse.headers[key].join(" ")
+        : axiosResponse.headers[key],
+    });
   }
 
   const response = {


### PR DESCRIPTION
Axios could return value in response header as a list (array) instead of string. We need to handle it and convert it to string

Closes: #655