### PR TITLE
add getBalance function to Ethereum plugin

### DIFF
--- a/packages/js/plugins/ethereum/schema.graphql
+++ b/packages/js/plugins/ethereum/schema.graphql
@@ -113,6 +113,12 @@ type Query {
     txOverrides: TxOverrides
   ): StaticTxResult!
 
+  getBalance(
+    address: String!
+    blockTag: BigInt
+    connection: Connection
+  ): BigInt!
+
   encodeParams(
     types: [String!]!
     values: [String!]!

--- a/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
+++ b/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
@@ -165,6 +165,26 @@ describe("Ethereum Plugin", () => {
       expect(response.data?.callContractStatic.result).toBe("missing revert data in call exception");
     });
 
+    it("getBalance", async () => {
+      const signerAddressQuery = await client.invoke<string>({
+        uri,
+        module: "query",
+        method: "getSignerAddress",
+      });
+
+      const response = await client.invoke<string>({
+        uri,
+        module: "query",
+        method: "getBalance",
+        input: {
+          address: signerAddressQuery.data
+        }
+      })
+
+      expect(response.error).toBeUndefined()
+      expect(response.data).toBeDefined()
+    });
+
     it("encodeParams", async () => {
       const response = await client.query<{ encodeParams: string }>({
         uri,

--- a/packages/js/plugins/ethereum/src/__tests__/integration/src/query/index.ts
+++ b/packages/js/plugins/ethereum/src/__tests__/integration/src/query/index.ts
@@ -22,7 +22,7 @@ import {
   Input_toEth,
   Input_awaitTransaction,
   Input_waitForEvent,
-  Input_getNetwork
+  Input_getNetwork, Input_getBalance,
 } from "./w3";
 import { BigInt } from "@web3api/wasm-as";
 
@@ -46,6 +46,16 @@ export function callContractStatic(
     args: input.args,
     connection: input.connection,
     txOverrides: input.txOverrides
+  }).unwrap();
+}
+
+export function getBalance(
+  input: Input_getBalance
+): BigInt {
+  return Ethereum_Query.getBalance({
+    address: input.address,
+    blockTag: input.blockTag,
+    connection: input.connection
   }).unwrap();
 }
 

--- a/packages/js/plugins/ethereum/src/__tests__/integration/src/query/schema.graphql
+++ b/packages/js/plugins/ethereum/src/__tests__/integration/src/query/schema.graphql
@@ -16,6 +16,12 @@ type Query {
     txOverrides: Ethereum_TxOverrides
   ): Ethereum_StaticTxResult!
 
+  getBalance(
+    address: String!
+    blockTag: BigInt
+    connection: Ethereum_Connection
+  ): BigInt!
+
   encodeParams(
     types: [String!]!
     values: [String!]!

--- a/packages/js/plugins/ethereum/src/index.ts
+++ b/packages/js/plugins/ethereum/src/index.ts
@@ -205,6 +205,15 @@ export class EthereumPlugin extends Plugin {
     }
   }
 
+  public async getBalance(input: Query.Input_getBalance): Promise<string> {
+    const connection = await this.getConnection(input.connection);
+    return (
+      await connection
+        .getProvider()
+        .getBalance(input.address, input.blockTag || undefined)
+    ).toString();
+  }
+
   public encodeParams(input: Query.Input_encodeParams): string {
     return defaultAbiCoder.encode(input.types, this.parseArgs(input.values));
   }

--- a/packages/js/plugins/ethereum/src/resolvers.ts
+++ b/packages/js/plugins/ethereum/src/resolvers.ts
@@ -55,6 +55,10 @@ export const query = (plugin: Plugin): Query.Module => ({
     return plugin.callContractStatic(input);
   },
 
+  getBalance: async (input: Query.Input_getBalance): Promise<string> => {
+    return plugin.getBalance(input);
+  },
+
   encodeParams: async (input: Query.Input_encodeParams): Promise<string> => {
     return plugin.encodeParams(input);
   },


### PR DESCRIPTION
The Ethereum plugin has `getSignerBalance`, but does not support getting the Ether balance of arbitrary accounts. This PR adds `getBalance`, which takes an address as an argument and returns the Ether balance of the address. This is useful for defiwrapper.