### PR TITLE
Changed chainId type from Bigint to UInt32

### DIFF
--- a/packages/cli/src/__tests__/plugin/expected-build/schema.graphql
+++ b/packages/cli/src/__tests__/plugin/expected-build/schema.graphql
@@ -293,7 +293,7 @@ type Ethereum_TxRequest @imported(
   gasPrice: BigInt
   data: String
   value: BigInt
-  chainId: BigInt
+  chainId: UInt32
   type: UInt32
 }
 
@@ -353,7 +353,7 @@ type Ethereum_Network @imported(
   nativeType: "Network"
 ) {
   name: String!
-  chainId: BigInt!
+  chainId: UInt32!
   ensAddress: String
 }
 
@@ -370,7 +370,7 @@ type Ethereum_TxResponse @imported(
   gasPrice: BigInt
   data: String!
   value: BigInt!
-  chainId: BigInt!
+  chainId: UInt32!
   blockNumber: BigInt
   blockHash: String
   timestamp: UInt32

--- a/packages/cli/src/__tests__/plugin/expected-types/schema.ts
+++ b/packages/cli/src/__tests__/plugin/expected-types/schema.ts
@@ -293,7 +293,7 @@ type Ethereum_TxRequest @imported(
   gasPrice: BigInt
   data: String
   value: BigInt
-  chainId: BigInt
+  chainId: UInt32
   type: UInt32
 }
 
@@ -353,7 +353,7 @@ type Ethereum_Network @imported(
   nativeType: "Network"
 ) {
   name: String!
-  chainId: BigInt!
+  chainId: UInt32!
   ensAddress: String
 }
 
@@ -370,7 +370,7 @@ type Ethereum_TxResponse @imported(
   gasPrice: BigInt
   data: String!
   value: BigInt!
-  chainId: BigInt!
+  chainId: UInt32!
   blockNumber: BigInt
   blockHash: String
   timestamp: UInt32

--- a/packages/cli/src/__tests__/plugin/expected-types/types.ts
+++ b/packages/cli/src/__tests__/plugin/expected-types/types.ts
@@ -104,7 +104,7 @@ export interface Ethereum_EventNotification {
 /* URI: "ens/ethereum.web3api.eth" */
 export interface Ethereum_Network {
   name: String;
-  chainId: BigInt;
+  chainId: UInt32;
   ensAddress?: String | null;
 }
 
@@ -118,7 +118,7 @@ export interface Ethereum_TxResponse {
   gasPrice?: BigInt | null;
   data: String;
   value: BigInt;
-  chainId: BigInt;
+  chainId: UInt32;
   blockNumber?: BigInt | null;
   blockHash?: String | null;
   timestamp?: UInt32 | null;

--- a/packages/cli/src/__tests__/project/sample.ts
+++ b/packages/cli/src/__tests__/project/sample.ts
@@ -215,7 +215,7 @@ type Ethereum_TxRequest @imported(
   gasPrice: BigInt
   data: String
   value: BigInt
-  chainId: BigInt
+  chainId: UInt32
   type: UInt32
 }
 
@@ -275,7 +275,7 @@ type Ethereum_Network @imported(
   nativeType: "Network"
 ) {
   name: String!
-  chainId: BigInt!
+  chainId: UInt32!
   ensAddress: String
 }
 
@@ -438,7 +438,7 @@ type Ethereum_TxResponse @imported(
   gasPrice: BigInt
   data: String!
   value: BigInt!
-  chainId: BigInt!
+  chainId: UInt32!
   blockNumber: BigInt
   blockHash: String
   timestamp: UInt32
@@ -512,7 +512,7 @@ type Ethereum_TxRequest @imported(
   gasPrice: BigInt
   data: String
   value: BigInt
-  chainId: BigInt
+  chainId: UInt32
   type: UInt32
 }
 
@@ -816,7 +816,7 @@ type Ethereum_TxRequest @imported(
   gasPrice: BigInt
   data: String
   value: BigInt
-  chainId: BigInt
+  chainId: UInt32
   type: UInt32
 }
 
@@ -876,7 +876,7 @@ type Ethereum_Network @imported(
   nativeType: "Network"
 ) {
   name: String!
-  chainId: BigInt!
+  chainId: UInt32!
   ensAddress: String
 }
 
@@ -893,7 +893,7 @@ type Ethereum_TxResponse @imported(
   gasPrice: BigInt
   data: String!
   value: BigInt!
-  chainId: BigInt!
+  chainId: UInt32!
   blockNumber: BigInt
   blockHash: String
   timestamp: UInt32

--- a/packages/js/plugins/ethereum/schema.graphql
+++ b/packages/js/plugins/ethereum/schema.graphql
@@ -27,7 +27,7 @@ type TxResponse {
   gasPrice: BigInt
   data: String!
   value: BigInt!
-  chainId: BigInt!
+  chainId: UInt32!
   blockNumber: BigInt
   blockHash: String
   timestamp: UInt32
@@ -48,7 +48,7 @@ type TxRequest {
   gasPrice: BigInt
   data: String
   value: BigInt
-  chainId: BigInt
+  chainId: UInt32
   type: UInt32
 }
 
@@ -93,7 +93,7 @@ type Connection {
 
 type Network {
   name: String!
-  chainId: BigInt!
+  chainId: UInt32!
   ensAddress: String
 }
 

--- a/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
+++ b/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
@@ -642,7 +642,7 @@ describe("Ethereum Plugin", () => {
 
       expect(mainnetNetwork.data).toBeTruthy();
       expect(mainnetNetwork.errors).toBeFalsy();
-      expect(mainnetNetwork.data?.getNetwork.chainId).toBe("1");
+      expect(mainnetNetwork.data?.getNetwork.chainId).toBe(1);
       expect(mainnetNetwork.data?.getNetwork.name).toBe("homestead");
       expect(mainnetNetwork.data?.getNetwork.ensAddress).toBe("0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e");
 
@@ -666,7 +666,7 @@ describe("Ethereum Plugin", () => {
 
       expect(polygonNetwork.data).toBeTruthy();
       expect(polygonNetwork.errors).toBeFalsy();
-      expect(polygonNetwork.data?.getNetwork.chainId).toBe("137");
+      expect(polygonNetwork.data?.getNetwork.chainId).toBe(137);
       expect(polygonNetwork.data?.getNetwork.name).toBe("matic");
       expect(polygonNetwork.data?.getNetwork.ensAddress).toBeFalsy();
     });

--- a/packages/js/plugins/ethereum/src/index.ts
+++ b/packages/js/plugins/ethereum/src/index.ts
@@ -154,7 +154,7 @@ export class EthereumPlugin extends Plugin {
     const network = await provider.getNetwork();
     return {
       name: network.name,
-      chainId: network.chainId.toString(),
+      chainId: network.chainId,
       ensAddress: network.ensAddress,
     };
   }

--- a/packages/js/plugins/ethereum/src/mapping.ts
+++ b/packages/js/plugins/ethereum/src/mapping.ts
@@ -57,7 +57,7 @@ export const toTxResponse = (
   gasPrice: response.gasPrice?.toString(),
   data: response.data,
   value: response.value.toString(),
-  chainId: response.chainId.toString(),
+  chainId: response.chainId,
   blockNumber: response.blockNumber?.toString(),
   blockHash: response.blockHash,
   timestamp: response.timestamp,
@@ -80,7 +80,7 @@ export const toTxRequest = (
   gasPrice: request.gasPrice?.toString(),
   data: request.data?.toString(),
   value: request.value?.toString(),
-  chainId: request.chainId?.toString(),
+  chainId: request.chainId,
   type: request.type,
 });
 
@@ -98,7 +98,7 @@ export const fromTxRequest = (
     : undefined,
   data: request.data || undefined,
   value: request.value ? ethers.BigNumber.from(request.value) : undefined,
-  chainId: request.chainId ? Number.parseInt(request.chainId) : undefined,
+  chainId: request.chainId ? request.chainId : undefined,
   type: request.type || undefined,
 });
 


### PR DESCRIPTION
This PR changes the Ethereum Plugin's `chainId` property from `BigInt` to `UInt32`

The ENS wrapper, used by the Hub, was deployed with version `0.0.1-prealpha.48` of the Ethereum Plugin, where `chainId` is an `UInt32`. But the hub uses the latest `0.0.1-prealpha.69`, where `chainId` is a `BigInt`, which serializes as string, which is indeed a breaking change.

Chain ID should indeed be a number and not a bigint, ethersjs docs validate this: https://docs.ethers.io/v5/api/providers/types/#providers-TransactionRequest.