### PR TITLE
Custom ensName fix for `buildAndDeployApi`

### DIFF
--- a/packages/cli/src/__tests__/e2e/query.spec.ts
+++ b/packages/cli/src/__tests__/e2e/query.spec.ts
@@ -55,7 +55,7 @@ describe("e2e tests for query command", () => {
       ensRegistrarAddress: registrarAddress,
       ensResolverAddress: resolverAddress,
       ensRegistryAddress: ens,
-      ensName: "simplestorage",
+      ensName: "simplestorage.eth",
     })
   });
 

--- a/packages/js/test-env/src/index.ts
+++ b/packages/js/test-env/src/index.ts
@@ -163,8 +163,8 @@ export async function buildAndDeployApi({
   );
 
   // create a new ENS domain
-  const domainName = ensName ?? generateName();
-  const apiEns = `${domainName}.eth`;
+  const apiEns = ensName ?? `${generateName()}.eth`;
+  const domainName = apiEns.split(".").slice(0, -1).join(".");
 
   // build API
   const {

--- a/packages/test-cases/cases/cli/api/query/recipes/output.json
+++ b/packages/test-cases/cases/cli/api/query/recipes/output.json
@@ -1,0 +1,1 @@
+[{"api":"ens/testnet/simplestorage.eth"},{"constants":"./constants.json"},{"query":"./set.graphql","variables":{"address":"$SimpleStorageAddr","value":569,"network":"testnet"},"output":{"data":{},"errors":[{}]}}]


### PR DESCRIPTION
The `buildAndDeployApi` function assumed the custom `ensName` parameter was a name without the registrar root node suffix (`.eth`, `.test`, etc.); and simply appended `.eth` after the name.

This is not correct, as the registrar contract specified could have a different root node that's not `.eth`.

This PR eliminates that assumption