### PR TITLE
Reduce Rust Wasm Module Size By 85% (wasm-snip)

### DIFF
--- a/packages/cli/src/lib/build-envs/wasm/rust/Dockerfile.mustache
+++ b/packages/cli/src/lib/build-envs/wasm/rust/Dockerfile.mustache
@@ -18,6 +18,9 @@ RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_10
 # Install the toml-cli
 RUN cargo install toml-cli
 
+# Install wasm-snip
+RUN cargo install wasm-snip
+
 {{#web3api_linked_packages.length}}
 WORKDIR /linked-packages
 {{/web3api_linked_packages.length}}
@@ -105,5 +108,7 @@ RUN mkdir ./build
 # Use wasm-opt to perform the "asyncify" post-processing step over all modules
 {{#web3api_modules}}
 RUN WASM_MODULE=$(ls ./{{dir}}/target/wasm32-unknown-unknown/release/*.wasm); \
-    wasm-opt --asyncify -O2 $WASM_MODULE -o ./build/{{name}}.wasm
+    wasm-snip $WASM_MODULE -o ./build/snipped_{{name}}.wasm && \
+    wasm-opt --asyncify -Os ./build/snipped_{{name}}.wasm -o ./build/{{name}}.wasm && \
+    rm -rf ./build/snipped_{{name}}.wasm
 {{/web3api_modules}}


### PR DESCRIPTION
closes: https://github.com/polywrap/monorepo/issues/896

After going through the rust documentation here:
https://rustwasm.github.io/book/reference/code-size.html

I instrumented the wasm modules, and found out that ~85% of the code was "dead" and unreachable (thank you [`twiggy`](https://rustwasm.github.io/book/reference/code-size.html#the-twiggy-code-size-profiler)). I then used another tool the guide recommended, [`wasm-snip`](https://rustwasm.github.io/book/reference/code-size.html#use-the-wasm-snip-tool), and boom our module size shrank tremendously!
| name | old wasm-rs | wasm-rs | wasm-as |
|-|-|-|-|
| simple-storage | m=1.7mb; q=1.5mb; | m=282kb; q=136kb; | m=86kb; q=49kb; |
| object-types | 1.5mb | 135kb | 53kb |

The "dead code" in question was:
```
> ~/.../wasm-rs/simple-storage$ twiggy garbage ./build/mutation.wasm 
 Bytes   │ Size % │ Garbage Item
─────────┼────────┼──────────────────────────────────────────────────────────
  617852 ┊ 36.18% ┊ custom section '.debug_str'
  392794 ┊ 23.00% ┊ custom section '.debug_info'
  224924 ┊ 13.17% ┊ custom section '.debug_pubnames'
  161184 ┊  9.44% ┊ custom section '.debug_ranges'
   12627 ┊  0.74% ┊ custom section '.debug_line'
    5406 ┊  0.32% ┊ custom section '.debug_abbrev'
     540 ┊  0.03% ┊ custom section '.debug_pubtypes'
      75 ┊  0.00% ┊ custom section 'producers'
      14 ┊  0.00% ┊ import env::memory
      12 ┊  0.00% ┊ type[21]: (i32, i32, i32, i32, i32, i32, i32, i32) -> i32
 1415428 ┊ 82.88% ┊ Σ [10 Total Rows]
   33556 ┊  1.96% ┊ 1 potential false-positive data segments
```