### PR TITLE
Fix CLI create command not accepting name for app and plugin

### DIFF
--- a/packages/cli/src/__tests__/e2e/create.spec.ts
+++ b/packages/cli/src/__tests__/e2e/create.spec.ts
@@ -13,9 +13,9 @@ Options:
 Commands:
   api [options] <language> <name>     Create a Web3API project langs:
                                       assemblyscript, interface
-  app [options] <language>            Create a Web3API application langs:
+  app [options] <language> <name>     Create a Web3API application langs:
                                       typescript-node, typescript-react
-  plugin [options] <lang> <language>  Create a Web3API plugin langs: typescript
+  plugin [options] <language> <name>  Create a Web3API plugin langs: typescript
   help [command]                      display help for command
 `;
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -60,6 +60,7 @@ export const create: Command = {
           .choices(supportedLangs.app)
           .argRequired()
       )
+      .addArgument(new Argument("<name>", nameStr).argRequired())
       .option(
         `-o, --output-dir <${pathStr}>`,
         `${intlMsg.commands_create_options_o()}`
@@ -69,7 +70,7 @@ export const create: Command = {
       });
 
     createCommand
-      .command(`plugin <${langStr}>`)
+      .command(`plugin`)
       .description(
         `${createPluginStr} ${langsStr}: ${supportedLangs.plugin.join(", ")}`
       )
@@ -78,6 +79,7 @@ export const create: Command = {
           .choices(supportedLangs.plugin)
           .argRequired()
       )
+      .addArgument(new Argument("<name>", nameStr).argRequired())
       .option(
         `-o, --output-dir <${pathStr}>`,
         `${intlMsg.commands_create_options_o()}`


### PR DESCRIPTION
Seems like there was a bug introduced between `prealpha.80` and `prealpha.83` wherein `w3 create plugin` and `w3 create app` didn't accept the `name` argument, but accepted two arguments called `lang` and `language`, both of which were constrained to their respective choices. 

The `language` arg would then weirdly resolve as the `name` arg, making every new plugin I create be named `typescript`.

If this is indeed a bug (seems like it), we might want to consider adding tests for this in addition to merging this fix.