### PR TITLE
Invalid Wasm Import Sanitization

### DIFF
--- a/packages/js/asyncify/src/AsyncWasmInstance.ts
+++ b/packages/js/asyncify/src/AsyncWasmInstance.ts
@@ -159,7 +159,7 @@ export class AsyncWasmInstance {
     return proxyGet(
       imports,
       (moduleImports: WasmModuleImports | undefined, name: string) => {
-        if (!moduleImports) {
+        if (moduleImports === undefined) {
           throw Error(
             `Unsupported wasm import namespace requested: "${name}"; ` +
               `Supported wasm import namespaces: ${Object.keys(imports)
@@ -167,7 +167,7 @@ export class AsyncWasmInstance {
                 .join(", ")}`
           );
         }
-        this._wrapModuleImports(moduleImports);
+        return this._wrapModuleImports(moduleImports);
       }
     );
   }
@@ -176,7 +176,7 @@ export class AsyncWasmInstance {
     return proxyGet(
       imports,
       (importValue: WasmImportValue | undefined, name: string) => {
-        if (!importValue) {
+        if (importValue === undefined) {
           throw Error(
             `Unsupported wasm import requested: "${name}"; ` +
               `Supported wasm imports: ${Object.keys(imports)

--- a/packages/js/asyncify/src/AsyncWasmInstance.ts
+++ b/packages/js/asyncify/src/AsyncWasmInstance.ts
@@ -159,7 +159,7 @@ export class AsyncWasmInstance {
     return proxyGet(imports, (moduleImports: WasmModuleImports | undefined, name: string) => {
       if (!moduleImports) {
         throw Error(
-          `Unsupported import namespace requested: ${name}; Supported import namespaces: ${Object.keys(imports).join(", ")}`
+          `Unsupported wasm import namespace requested: ${name}; Supported wasm import namespaces: ${Object.keys(imports).join(", ")}`
         );
       }
       this._wrapModuleImports(moduleImports)
@@ -170,7 +170,7 @@ export class AsyncWasmInstance {
     return proxyGet(imports, (importValue: WasmImportValue | undefined, name: string) => {
       if (!importValue) {
         throw Error(
-          `Unsupported import requested: ${name}; Supported imports: ${Object.keys(imports).join(", ")}`
+          `Unsupported wasm import requested: ${name}; Supported wasm imports: ${Object.keys(imports).join(", ")}`
         );
       }
       if (typeof importValue === "function") {

--- a/packages/js/asyncify/src/AsyncWasmInstance.ts
+++ b/packages/js/asyncify/src/AsyncWasmInstance.ts
@@ -156,13 +156,23 @@ export class AsyncWasmInstance {
   }
 
   private _wrapImports(imports: WasmImports): WasmImports {
-    return proxyGet(imports, (moduleImports: WasmModuleImports) =>
+    return proxyGet(imports, (moduleImports: WasmModuleImports | undefined, name: string) => {
+      if (!moduleImports) {
+        throw Error(
+          `Unsupported import namespace requested: ${name}; Supported import namespaces: ${Object.keys(imports).join(", ")}`
+        );
+      }
       this._wrapModuleImports(moduleImports)
-    );
+    });
   }
 
   private _wrapModuleImports(imports: WasmModuleImports) {
-    return proxyGet(imports, (importValue: WasmImportValue) => {
+    return proxyGet(imports, (importValue: WasmImportValue | undefined, name: string) => {
+      if (!importValue) {
+        throw Error(
+          `Unsupported import requested: ${name}; Supported imports: ${Object.keys(imports).join(", ")}`
+        );
+      }
       if (typeof importValue === "function") {
         return this._wrapImportFn(importValue);
       }

--- a/packages/js/asyncify/src/AsyncWasmInstance.ts
+++ b/packages/js/asyncify/src/AsyncWasmInstance.ts
@@ -156,28 +156,40 @@ export class AsyncWasmInstance {
   }
 
   private _wrapImports(imports: WasmImports): WasmImports {
-    return proxyGet(imports, (moduleImports: WasmModuleImports | undefined, name: string) => {
-      if (!moduleImports) {
-        throw Error(
-          `Unsupported wasm import namespace requested: ${name}; Supported wasm import namespaces: ${Object.keys(imports).join(", ")}`
-        );
+    return proxyGet(
+      imports,
+      (moduleImports: WasmModuleImports | undefined, name: string) => {
+        if (!moduleImports) {
+          throw Error(
+            `Unsupported wasm import namespace requested: "${name}"; ` +
+              `Supported wasm import namespaces: ${Object.keys(imports)
+                .map((x) => `"${x}"`)
+                .join(", ")}`
+          );
+        }
+        this._wrapModuleImports(moduleImports);
       }
-      this._wrapModuleImports(moduleImports)
-    });
+    );
   }
 
   private _wrapModuleImports(imports: WasmModuleImports) {
-    return proxyGet(imports, (importValue: WasmImportValue | undefined, name: string) => {
-      if (!importValue) {
-        throw Error(
-          `Unsupported wasm import requested: ${name}; Supported wasm imports: ${Object.keys(imports).join(", ")}`
-        );
+    return proxyGet(
+      imports,
+      (importValue: WasmImportValue | undefined, name: string) => {
+        if (!importValue) {
+          throw Error(
+            `Unsupported wasm import requested: "${name}"; ` +
+              `Supported wasm imports: ${Object.keys(imports)
+                .map((x) => `"${x}"`)
+                .join(", ")}`
+          );
+        }
+        if (typeof importValue === "function") {
+          return this._wrapImportFn(importValue);
+        }
+        return importValue;
       }
-      if (typeof importValue === "function") {
-        return this._wrapImportFn(importValue);
-      }
-      return importValue;
-    });
+    );
   }
 
   private _wrapImportFn(fn: Function) {

--- a/packages/js/asyncify/src/utils.ts
+++ b/packages/js/asyncify/src/utils.ts
@@ -8,10 +8,12 @@ export function isPromise<T extends unknown>(
 
 export function proxyGet<T extends Record<string, unknown>>(
   obj: T,
-  transform: (value: unknown) => unknown
+  transform: (value: unknown, name: string) => unknown
 ): T {
   return new Proxy<T>(obj, {
-    get: (obj: T, name: string) => transform(obj[name]),
+    get: (obj: T, name: string) => {
+      return transform(obj[name], name);
+    },
   });
 }
 


### PR DESCRIPTION
Currently, wasm modules that expect imports that are unsupported by Polywrap will fail with an ambiguous error:
```
npx w3 build
Error: Invalid Wasm module found. `mutation` at <home>/integration/protocol/substrate/core-wrapper/build/mutation.wasm is invalid. Error: ,TypeError: Cannot create proxy with a non-object as target or handler
    at Compiler.<anonymous> (<home>/integration/protocol/substrate/core-wrapper/node_modules/@web3api/cli/build/lib/Compiler.js:680:31)
    at step (<home>/protocol/substrate/core-wrapper/node_modules/@web3api/cli/build/lib/Compiler.js:54:23)
    at Object.throw (<home>/integration/protocol/substrate/core-wrapper/node_modules/@web3api/cli/build/lib/Compiler.js:35:53)
    at rejected (<home>/integration/protocol/substrate/core-wrapper/node_modules/@web3api/cli/build/lib/Compiler.js:27:65)
error Command failed with exit code 1.
```

The error handling within this PR will now change the error code into something more actionable for the user:
```
Error: Unsupported wasm import namespace requested: "__wbindgen_placeholder__"; Supported wasm import namespaces: "env", "w3"
```