### PR TITLE
CLI child process live logging

### DIFF
--- a/packages/cli/src/lib/system/child-process.ts
+++ b/packages/cli/src/lib/system/child-process.ts
@@ -16,7 +16,7 @@ export async function runCommand(
       stderr: string
     ) => {
       if (err) {
-        reject(err);
+        reject(stderr);
       } else {
         resolve({ stdout, stderr });
       }

--- a/packages/cli/src/lib/system/child-process.ts
+++ b/packages/cli/src/lib/system/child-process.ts
@@ -18,17 +18,11 @@ export async function runCommand(
       if (err) {
         reject(err);
       } else {
-        if (!quiet) {
-          // the *entire* stdout and stderr (buffered)
-          console.log(stdout);
-          console.error(stderr);
-        }
-
         resolve({ stdout, stderr });
       }
     };
 
-    exec(
+    const childObj = exec(
       command,
       {
         cwd: __dirname,
@@ -39,5 +33,15 @@ export async function runCommand(
       },
       callback
     );
+
+    if (!quiet) {
+      childObj.stdout?.on("data", (data) => {
+        console.log(data.toString());
+      });
+
+      childObj.stderr?.on("data", (data) => {
+        console.log(data.toString());
+      });
+    }
   });
 }


### PR DESCRIPTION
This PR aims to change the way we log to console when using `runCommand` which we use to run `docker` commands programatically.

Instead of logging everything buffered when the process exits, we attach listeners to `stdout` and `stderr` and let the user see the regular output as it happens (like it would be if the user ran the `docker` commands directly)