### PR TITLE
Remove Docker Buildx Output Option

### DIFF
--- a/packages/cli/src/lib/Compiler.ts
+++ b/packages/cli/src/lib/Compiler.ts
@@ -292,7 +292,6 @@ export class Compiler {
     const useBuildx = !!dockerBuildxConfig;
 
     let cacheDir: string | undefined;
-    let buildxOutput: string | undefined;
     let removeBuilder = false;
 
     if (dockerBuildxConfig && typeof dockerBuildxConfig !== "boolean") {
@@ -308,14 +307,6 @@ export class Compiler {
         } else {
           cacheDir = cache;
         }
-      }
-
-      const output = dockerBuildxConfig.output;
-
-      if (output === true) {
-        buildxOutput = "docker";
-      } else if (typeof output === "string") {
-        buildxOutput = output;
       }
 
       removeBuilder = !!dockerBuildxConfig.removeBuilder;
@@ -334,7 +325,6 @@ export class Compiler {
       imageName,
       dockerfile,
       cacheDir,
-      buildxOutput,
       useBuildx,
       project.quiet
     );

--- a/packages/cli/src/lib/system/docker.ts
+++ b/packages/cli/src/lib/system/docker.ts
@@ -118,7 +118,6 @@ export async function createBuildImage(
   imageName: string,
   dockerfile: string,
   cacheDir?: string,
-  buildxOutput?: string,
   useBuildx = false,
   quiet = true
 ): Promise<string> {
@@ -131,9 +130,6 @@ export async function createBuildImage(
           ? `--cache-from type=local,src=${cacheDir}`
           : "";
       const cacheTo = cacheDir ? `--cache-to type=local,dest=${cacheDir}` : "";
-      const output = buildxOutput
-        ? `--output=type=${buildxOutput}`
-        : `--output=type=docker`;
 
       // Build the docker image
       let buildxUseFailed: boolean;
@@ -151,7 +147,7 @@ export async function createBuildImage(
         );
       }
       await runCommand(
-        `docker buildx build -f ${dockerfile} -t ${imageName} ${rootDir} ${cacheFrom} ${cacheTo} ${output}`,
+        `docker buildx build -f ${dockerfile} -t ${imageName} ${rootDir} ${cacheFrom} ${cacheTo} --output=type=docker`,
         quiet
       );
     } else {

--- a/packages/cli/src/lib/system/docker.ts
+++ b/packages/cli/src/lib/system/docker.ts
@@ -147,7 +147,7 @@ export async function createBuildImage(
         );
       }
       await runCommand(
-        `docker buildx build -f ${dockerfile} -t ${imageName} ${rootDir} ${cacheFrom} ${cacheTo} --output=type=docker`,
+        `docker buildx build -f ${dockerfile} -t ${imageName} ${rootDir} ${cacheFrom} ${cacheTo} --output=type=image`,
         quiet
       );
     } else {

--- a/packages/js/core/src/manifest/formats/polywrap.build/0.0.1-prealpha.3.ts
+++ b/packages/js/core/src/manifest/formats/polywrap.build/0.0.1-prealpha.3.ts
@@ -34,10 +34,6 @@ export interface BuildManifest {
            */
           cache?: string | boolean;
           /**
-           * Path to cache directory, set to true or false for default value.
-           */
-          output?: string | boolean;
-          /**
            * Remove the builder instance.
            */
           removeBuilder?: boolean;

--- a/packages/js/core/src/manifest/formats/polywrap.build/validate.ts
+++ b/packages/js/core/src/manifest/formats/polywrap.build/validate.ts
@@ -38,7 +38,6 @@ Validator.prototype.customFormats.dockerfileName = Validators.dockerfileName;
 Validator.prototype.customFormats.dockerImageId = Validators.dockerImageId;
 Validator.prototype.customFormats.regexString = Validators.regexString;
 Validator.prototype.customFormats.directory = Validators.directory;
-Validator.prototype.customFormats.buildxOutput = Validators.buildxOutput;
 
 export const validateBuildManifest = Tracer.traceFunc(
   "core: validateBuildManifest",

--- a/packages/js/core/src/manifest/validators.ts
+++ b/packages/js/core/src/manifest/validators.ts
@@ -140,19 +140,3 @@ export function directory(path: unknown): boolean {
 
   return !!validDirRegex.test(path);
 }
-
-export function buildxOutput(output: unknown): boolean {
-  if (typeof output === "boolean") {
-    return true;
-  }
-  if (typeof output !== "string") {
-    return false;
-  }
-  switch (output) {
-    case "docker":
-    case "registry":
-      return true;
-    default:
-      return false;
-  }
-}

--- a/packages/manifest-schemas/formats/polywrap.build/0.0.1-prealpha.3.json
+++ b/packages/manifest-schemas/formats/polywrap.build/0.0.1-prealpha.3.json
@@ -38,11 +38,6 @@
               "type": ["string", "boolean"],
               "format": "directory"
             },
-            "output": {
-              "description": "Path to cache directory, set to true or false for default value.",
-              "type": ["string", "boolean"],
-              "format": "buildxOutput"
-            },
             "removeBuilder": {
               "description": "Remove the builder instance.",
               "type": "boolean"


### PR DESCRIPTION
closes: https://github.com/polywrap/monorepo/issues/929

Based on the findings [here](https://github.com/polywrap/monorepo/issues/929), the docker buildx `--output` option was not properly implemented. I propose we remove this for now, and add it back when it's necessary.