### PR TITLE
rename nullable to optional #937

### DIFF
--- a/packages/schema/bind/src/bindings/assemblyscript/wasm-as/functions.ts
+++ b/packages/schema/bind/src/bindings/assemblyscript/wasm-as/functions.ts
@@ -20,7 +20,7 @@ export const toMsgPack: MustacheFn = () => {
     if (type[type.length - 1] === "!") {
       type = type.substring(0, type.length - 1);
     } else {
-      modifier = "Nullable";
+      modifier = "Optional";
     }
 
     if (type[0] === "[") {
@@ -50,12 +50,12 @@ export const toWasmInit: MustacheFn = () => {
       type = type.substring(0, type.length - 1);
     } else {
       const nullType = toWasm()(value, render);
-      const nullable = "Option";
+      const optional = "Option";
       const nullOptional = "| null";
 
       if (nullType.endsWith(nullOptional)) {
         return "null";
-      } else if (nullType.startsWith(nullable)) {
+      } else if (nullType.startsWith(optional)) {
         type = nullType.substring(6);
         return `Option.None${type}()`;
       }
@@ -112,19 +112,19 @@ export const toWasm: MustacheFn = () => {
     let type = render(value);
     let isEnum = false;
 
-    let nullable = false;
+    let optional = false;
     if (type[type.length - 1] === "!") {
       type = type.substring(0, type.length - 1);
     } else {
-      nullable = true;
+      optional = true;
     }
 
     if (type[0] === "[") {
-      return toWasmArray(type, nullable);
+      return toWasmArray(type, optional);
     }
 
     if (type.startsWith("Map<")) {
-      return toWasmMap(type, nullable);
+      return toWasmMap(type, optional);
     }
 
     switch (type) {
@@ -177,11 +177,11 @@ export const toWasm: MustacheFn = () => {
         }
     }
 
-    return applyNullable(type, nullable, isEnum);
+    return applyOptional(type, optional, isEnum);
   };
 };
 
-const toWasmArray = (type: string, nullable: boolean): string => {
+const toWasmArray = (type: string, optional: boolean): string => {
   const result = type.match(/(\[)([[\]A-Za-z0-9_.!]+)(\])/);
 
   if (!result || result.length !== 4) {
@@ -189,10 +189,10 @@ const toWasmArray = (type: string, nullable: boolean): string => {
   }
 
   const wasmType = toWasm()(result[2], (str) => str);
-  return applyNullable("Array<" + wasmType + ">", nullable, false);
+  return applyOptional("Array<" + wasmType + ">", optional, false);
 };
 
-const toWasmMap = (type: string, nullable: boolean): string => {
+const toWasmMap = (type: string, optional: boolean): string => {
   const firstOpenBracketIdx = type.indexOf("<");
   const lastCloseBracketIdx = type.lastIndexOf(">");
 
@@ -212,15 +212,15 @@ const toWasmMap = (type: string, nullable: boolean): string => {
   const keyType = toWasm()(keyValTypes[0], (str) => str);
   const valType = toWasm()(keyValTypes[1], (str) => str);
 
-  return applyNullable(`Map<${keyType}, ${valType}>`, nullable, false);
+  return applyOptional(`Map<${keyType}, ${valType}>`, optional, false);
 };
 
-const applyNullable = (
+const applyOptional = (
   type: string,
-  nullable: boolean,
+  optional: boolean,
   isEnum: boolean
 ): string => {
-  if (nullable) {
+  if (optional) {
     if (
       type.indexOf("Array") === 0 ||
       type.indexOf("string") === 0 ||

--- a/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/imported/module-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/imported/module-type/serialization-ts.mustache
@@ -50,7 +50,7 @@ export function write{{name}}Args(
   writer.writeInt32(input.{{#handleKeywords}}{{name}}{{/handleKeywords}});
   {{/required}}
   {{^required}}
-  writer.writeNullableInt32(input.{{#handleKeywords}}{{name}}{{/handleKeywords}});
+  writer.writeOptionalInt32(input.{{#handleKeywords}}{{name}}{{/handleKeywords}});
   {{/required}}
   {{/enum}}
   {{#object}}

--- a/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/imported/object-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/imported/object-type/serialization-ts.mustache
@@ -52,7 +52,7 @@ export function write{{type}}(writer: Write, type: {{type}}): void {
   writer.writeInt32(type.{{#handleKeywords}}{{name}}{{/handleKeywords}});
   {{/required}}
   {{^required}}
-  writer.writeNullableInt32(type.{{#handleKeywords}}{{name}}{{/handleKeywords}});
+  writer.writeOptionalInt32(type.{{#handleKeywords}}{{name}}{{/handleKeywords}});
   {{/required}}
   {{/enum}}
   writer.context().pop();

--- a/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/module-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/module-type/serialization-ts.mustache
@@ -130,7 +130,7 @@ export function write{{name}}Result(writer: Write, result: {{#return}}{{#toWasm}
   writer.writeInt32(result);
   {{/required}}
   {{^required}}
-  writer.writeNullableInt32(result);
+  writer.writeOptionalInt32(result);
   {{/required}}
   {{/enum}}
   {{#object}}

--- a/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/object-type/serialization-ts.mustache
+++ b/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/object-type/serialization-ts.mustache
@@ -52,7 +52,7 @@ export function write{{type}}(writer: Write, type: {{type}}): void {
   writer.writeInt32(type.{{#handleKeywords}}{{name}}{{/handleKeywords}});
   {{/required}}
   {{^required}}
-  writer.writeNullableInt32(type.{{#handleKeywords}}{{name}}{{/handleKeywords}});
+  writer.writeOptionalInt32(type.{{#handleKeywords}}{{name}}{{/handleKeywords}});
   {{/required}}
   {{/enum}}
   writer.context().pop();

--- a/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/serialize_enum.mustache
+++ b/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/serialize_enum.mustache
@@ -2,5 +2,5 @@
 writer.writeInt32(item);
 {{/required}}
 {{^required}}
-writer.writeNullableInt32(item);
+writer.writeOptionalInt32(item);
 {{/required}}

--- a/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/serialize_map_value.mustache
+++ b/packages/schema/bind/src/bindings/assemblyscript/wasm-as/templates/serialize_map_value.mustache
@@ -18,7 +18,7 @@ writer.write{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}(value, (writer: Write,
 writer.writeInt32(value);
 {{/required}}
 {{^required}}
-writer.writeNullableInt32(value);
+writer.writeOptionalInt32(value);
 {{/required}}
 {{/enum}}
 {{#object}}

--- a/packages/schema/bind/src/bindings/rust/wasm-rs/templates/imported/module-type/serialization-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/wasm-rs/templates/imported/module-type/serialization-rs.mustache
@@ -72,7 +72,7 @@ pub fn write_{{#toLower}}{{name}}{{/toLower}}_args<W: Write>(input: &Input{{#toU
     writer.write_i32(&(input.{{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}} as i32))?;
     {{/required}}
     {{^required}}
-    writer.write_nullable_i32(&input.{{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}.map(|f| f as i32))?;
+    writer.write_optional_i32(&input.{{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}.map(|f| f as i32))?;
     {{/required}}
     {{/enum}}
     {{#object}}

--- a/packages/schema/bind/src/bindings/rust/wasm-rs/templates/imported/object-type/serialization-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/wasm-rs/templates/imported/object-type/serialization-rs.mustache
@@ -75,7 +75,7 @@ pub fn write_{{#toLower}}{{type}}{{/toLower}}<W: Write>(input: &{{#toUpper}}{{ty
     writer.write_i32(&(input.{{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}} as i32))?;
     {{/required}}
     {{^required}}
-    writer.write_nullable_i32(&input.{{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}.map(|f| f as i32))?;
+    writer.write_optional_i32(&input.{{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}.map(|f| f as i32))?;
     {{/required}}
     {{/enum}}
     writer.context().pop();

--- a/packages/schema/bind/src/bindings/rust/wasm-rs/templates/module-type/serialization-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/wasm-rs/templates/module-type/serialization-rs.mustache
@@ -153,7 +153,7 @@ pub fn write_{{#toLower}}{{name}}{{/toLower}}_result<W: Write>(result: {{#return
     writer.write_i32(&(*result as i32))?;
     {{/required}}
     {{^required}}
-    writer.write_nullable_i32(&result.map(|f| f as i32))?;
+    writer.write_optional_i32(&result.map(|f| f as i32))?;
     {{/required}}
     {{/enum}}
     {{#object}}

--- a/packages/schema/bind/src/bindings/rust/wasm-rs/templates/object-type/serialization-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/wasm-rs/templates/object-type/serialization-rs.mustache
@@ -75,7 +75,7 @@ pub fn write_{{#toLower}}{{type}}{{/toLower}}<W: Write>(input: &{{#toUpper}}{{ty
     writer.write_i32(&(input.{{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}} as i32))?;
     {{/required}}
     {{^required}}
-    writer.write_nullable_i32(&input.{{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}.map(|f| f as i32))?;
+    writer.write_optional_i32(&input.{{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}.map(|f| f as i32))?;
     {{/required}}
     {{/enum}}
     writer.context().pop();

--- a/packages/schema/bind/src/bindings/rust/wasm-rs/templates/serialize_enum.mustache
+++ b/packages/schema/bind/src/bindings/rust/wasm-rs/templates/serialize_enum.mustache
@@ -2,5 +2,5 @@
 writer.write_i32(&(*item as i32))
 {{/required}}
 {{^required}}
-writer.write_nullable_i32(&item.map(|f| f as i32))
+writer.write_optional_i32(&item.map(|f| f as i32))
 {{/required}}

--- a/packages/schema/bind/src/bindings/rust/wasm-rs/templates/serialize_map_value.mustache
+++ b/packages/schema/bind/src/bindings/rust/wasm-rs/templates/serialize_map_value.mustache
@@ -20,7 +20,7 @@ writer.write_{{#toLower}}{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}{{/toLower
 writer.write_i32(&(*value as i32))
 {{/required}}
 {{^required}}
-writer.write_nullable_i32(&value.map(|f| f as i32))
+writer.write_optional_i32(&value.map(|f| f as i32))
 {{/required}}
 {{/enum}}
 {{#object}}

--- a/packages/schema/bind/src/bindings/typescript/functions.ts
+++ b/packages/schema/bind/src/bindings/typescript/functions.ts
@@ -49,19 +49,19 @@ const _toTypescript = (
 ) => {
   let type = render(value);
 
-  let nullable = false;
+  let optional = false;
   if (type[type.length - 1] === "!") {
     type = type.substring(0, type.length - 1);
   } else {
-    nullable = true;
+    optional = true;
   }
 
   if (type[0] === "[") {
-    return toTypescriptArray(type, nullable);
+    return toTypescriptArray(type, optional);
   }
 
   if (type.startsWith("Map<")) {
-    return toTypescriptMap(type, nullable);
+    return toTypescriptMap(type, optional);
   }
 
   switch (type) {
@@ -77,11 +77,11 @@ const _toTypescript = (
   }
 
   return undefinable
-    ? applyUndefinable(type, nullable)
-    : applyNullable(type, nullable);
+    ? applyUndefinable(type, optional)
+    : applyOptional(type, optional);
 };
 
-const toTypescriptArray = (type: string, nullable: boolean): string => {
+const toTypescriptArray = (type: string, optional: boolean): string => {
   const result = type.match(/(\[)([[\]A-Za-z0-9_.!]+)(\])/);
 
   if (!result || result.length !== 4) {
@@ -89,10 +89,10 @@ const toTypescriptArray = (type: string, nullable: boolean): string => {
   }
 
   const tsType = _toTypescript(result[2], (str) => str);
-  return applyNullable("Array<" + tsType + ">", nullable);
+  return applyOptional("Array<" + tsType + ">", optional);
 };
 
-const toTypescriptMap = (type: string, nullable: boolean): string => {
+const toTypescriptMap = (type: string, optional: boolean): string => {
   const openAngleBracketIdx = type.indexOf("<");
   const closeAngleBracketIdx = type.lastIndexOf(">");
 
@@ -104,11 +104,11 @@ const toTypescriptMap = (type: string, nullable: boolean): string => {
   const tsKeyType = _toTypescript(keyType, (str) => str);
   const tsValType = _toTypescript(valtype, (str) => str, true);
 
-  return applyNullable(`Map<${tsKeyType}, ${tsValType}>`, nullable);
+  return applyOptional(`Map<${tsKeyType}, ${tsValType}>`, optional);
 };
 
-const applyNullable = (type: string, nullable: boolean): string => {
-  if (nullable) {
+const applyOptional = (type: string, optional: boolean): string => {
+  if (optional) {
     return `${type} | null`;
   } else {
     return type;

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/AnotherType/serialization.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/AnotherType/serialization.ts
@@ -28,7 +28,7 @@ export function writeAnotherType(writer: Write, type: AnotherType): void {
   writer.writeMapLength(3);
   writer.context().push("prop", "string | null", "writing property");
   writer.writeString("prop");
-  writer.writeNullableString(type.prop);
+  writer.writeOptionalString(type.prop);
   writer.context().pop();
   writer.context().push("circular", "Types.CustomType | null", "writing property");
   writer.writeString("circular");
@@ -40,7 +40,7 @@ export function writeAnotherType(writer: Write, type: AnotherType): void {
   writer.context().pop();
   writer.context().push("const", "string | null", "writing property");
   writer.writeString("const");
-  writer.writeNullableString(type.m_const);
+  writer.writeOptionalString(type.m_const);
   writer.context().pop();
 }
 
@@ -64,7 +64,7 @@ export function readAnotherType(reader: Read): AnotherType {
     reader.context().push(field, "unknown", "searching for property type");
     if (field == "prop") {
       reader.context().push(field, "string | null", "type found, reading property");
-      _prop = reader.readNullableString();
+      _prop = reader.readOptionalString();
       reader.context().pop();
     }
     else if (field == "circular") {
@@ -78,7 +78,7 @@ export function readAnotherType(reader: Read): AnotherType {
     }
     else if (field == "const") {
       reader.context().push(field, "string | null", "type found, reading property");
-      _const = reader.readNullableString();
+      _const = reader.readOptionalString();
       reader.context().pop();
     }
     reader.context().pop();

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/CustomType/serialization.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/CustomType/serialization.ts
@@ -32,7 +32,7 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("optStr", "string | null", "writing property");
   writer.writeString("optStr");
-  writer.writeNullableString(type.optStr);
+  writer.writeOptionalString(type.optStr);
   writer.context().pop();
   writer.context().push("u", "u32", "writing property");
   writer.writeString("u");
@@ -40,7 +40,7 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("optU", "Option<u32>", "writing property");
   writer.writeString("optU");
-  writer.writeNullableUInt32(type.optU);
+  writer.writeOptionalUInt32(type.optU);
   writer.context().pop();
   writer.context().push("u8", "u8", "writing property");
   writer.writeString("u8");
@@ -76,7 +76,7 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("optBigint", "BigInt | null", "writing property");
   writer.writeString("optBigint");
-  writer.writeNullableBigInt(type.optBigint);
+  writer.writeOptionalBigInt(type.optBigint);
   writer.context().pop();
   writer.context().push("bignumber", "BigNumber", "writing property");
   writer.writeString("bignumber");
@@ -84,7 +84,7 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("optBignumber", "BigNumber | null", "writing property");
   writer.writeString("optBignumber");
-  writer.writeNullableBigNumber(type.optBignumber);
+  writer.writeOptionalBigNumber(type.optBignumber);
   writer.context().pop();
   writer.context().push("json", "JSON.Value", "writing property");
   writer.writeString("json");
@@ -92,7 +92,7 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("optJson", "JSON.Value | null", "writing property");
   writer.writeString("optJson");
-  writer.writeNullableJSON(type.optJson);
+  writer.writeOptionalJSON(type.optJson);
   writer.context().pop();
   writer.context().push("bytes", "ArrayBuffer", "writing property");
   writer.writeString("bytes");
@@ -100,7 +100,7 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("optBytes", "ArrayBuffer | null", "writing property");
   writer.writeString("optBytes");
-  writer.writeNullableBytes(type.optBytes);
+  writer.writeOptionalBytes(type.optBytes);
   writer.context().pop();
   writer.context().push("boolean", "bool", "writing property");
   writer.writeString("boolean");
@@ -108,7 +108,7 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("optBoolean", "Option<bool>", "writing property");
   writer.writeString("optBoolean");
-  writer.writeNullableBool(type.optBoolean);
+  writer.writeOptionalBool(type.optBoolean);
   writer.context().pop();
   writer.context().push("uArray", "Array<u32>", "writing property");
   writer.writeString("uArray");
@@ -118,20 +118,20 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("uOptArray", "Array<u32> | null", "writing property");
   writer.writeString("uOptArray");
-  writer.writeNullableArray(type.uOptArray, (writer: Write, item: u32): void => {
+  writer.writeOptionalArray(type.uOptArray, (writer: Write, item: u32): void => {
     writer.writeUInt32(item);
   });
   writer.context().pop();
   writer.context().push("optUOptArray", "Array<Option<u32>> | null", "writing property");
   writer.writeString("optUOptArray");
-  writer.writeNullableArray(type.optUOptArray, (writer: Write, item: Option<u32>): void => {
-    writer.writeNullableUInt32(item);
+  writer.writeOptionalArray(type.optUOptArray, (writer: Write, item: Option<u32>): void => {
+    writer.writeOptionalUInt32(item);
   });
   writer.context().pop();
   writer.context().push("optStrOptArray", "Array<string | null> | null", "writing property");
   writer.writeString("optStrOptArray");
-  writer.writeNullableArray(type.optStrOptArray, (writer: Write, item: string | null): void => {
-    writer.writeNullableString(item);
+  writer.writeOptionalArray(type.optStrOptArray, (writer: Write, item: string | null): void => {
+    writer.writeOptionalString(item);
   });
   writer.context().pop();
   writer.context().push("uArrayArray", "Array<Array<u32>>", "writing property");
@@ -145,15 +145,15 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().push("uOptArrayOptArray", "Array<Array<Option<u32>> | null>", "writing property");
   writer.writeString("uOptArrayOptArray");
   writer.writeArray(type.uOptArrayOptArray, (writer: Write, item: Array<Option<u32>> | null): void => {
-    writer.writeNullableArray(item, (writer: Write, item: Option<u32>): void => {
-      writer.writeNullableUInt32(item);
+    writer.writeOptionalArray(item, (writer: Write, item: Option<u32>): void => {
+      writer.writeOptionalUInt32(item);
     });
   });
   writer.context().pop();
   writer.context().push("uArrayOptArrayArray", "Array<Array<Array<u32>> | null>", "writing property");
   writer.writeString("uArrayOptArrayArray");
   writer.writeArray(type.uArrayOptArrayArray, (writer: Write, item: Array<Array<u32>> | null): void => {
-    writer.writeNullableArray(item, (writer: Write, item: Array<u32>): void => {
+    writer.writeOptionalArray(item, (writer: Write, item: Array<u32>): void => {
       writer.writeArray(item, (writer: Write, item: u32): void => {
         writer.writeUInt32(item);
       });
@@ -162,10 +162,10 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("crazyArray", "Array<Array<Array<Array<u32> | null>> | null> | null", "writing property");
   writer.writeString("crazyArray");
-  writer.writeNullableArray(type.crazyArray, (writer: Write, item: Array<Array<Array<u32> | null>> | null): void => {
-    writer.writeNullableArray(item, (writer: Write, item: Array<Array<u32> | null>): void => {
+  writer.writeOptionalArray(type.crazyArray, (writer: Write, item: Array<Array<Array<u32> | null>> | null): void => {
+    writer.writeOptionalArray(item, (writer: Write, item: Array<Array<u32> | null>): void => {
       writer.writeArray(item, (writer: Write, item: Array<u32> | null): void => {
-        writer.writeNullableArray(item, (writer: Write, item: u32): void => {
+        writer.writeOptionalArray(item, (writer: Write, item: u32): void => {
           writer.writeUInt32(item);
         });
       });
@@ -192,7 +192,7 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("optObjectArray", "Array<Types.AnotherType | null> | null", "writing property");
   writer.writeString("optObjectArray");
-  writer.writeNullableArray(type.optObjectArray, (writer: Write, item: Types.AnotherType | null): void => {
+  writer.writeOptionalArray(type.optObjectArray, (writer: Write, item: Types.AnotherType | null): void => {
     if (item) {
       Types.AnotherType.write(writer, item as Types.AnotherType);
     } else {
@@ -206,7 +206,7 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("optEnum", "Option<Types.CustomEnum>", "writing property");
   writer.writeString("optEnum");
-  writer.writeNullableInt32(type.optEnum);
+  writer.writeOptionalInt32(type.optEnum);
   writer.context().pop();
   writer.context().push("enumArray", "Array<Types.CustomEnum>", "writing property");
   writer.writeString("enumArray");
@@ -216,8 +216,8 @@ export function writeCustomType(writer: Write, type: CustomType): void {
   writer.context().pop();
   writer.context().push("optEnumArray", "Array<Option<Types.CustomEnum>> | null", "writing property");
   writer.writeString("optEnumArray");
-  writer.writeNullableArray(type.optEnumArray, (writer: Write, item: Option<Types.CustomEnum>): void => {
-    writer.writeNullableInt32(item);
+  writer.writeOptionalArray(type.optEnumArray, (writer: Write, item: Option<Types.CustomEnum>): void => {
+    writer.writeOptionalInt32(item);
   });
   writer.context().pop();
 }
@@ -304,7 +304,7 @@ export function readCustomType(reader: Read): CustomType {
     }
     else if (field == "optStr") {
       reader.context().push(field, "string | null", "type found, reading property");
-      _optStr = reader.readNullableString();
+      _optStr = reader.readOptionalString();
       reader.context().pop();
     }
     else if (field == "u") {
@@ -315,7 +315,7 @@ export function readCustomType(reader: Read): CustomType {
     }
     else if (field == "optU") {
       reader.context().push(field, "Option<u32>", "type found, reading property");
-      _optU = reader.readNullableUInt32();
+      _optU = reader.readOptionalUInt32();
       reader.context().pop();
     }
     else if (field == "u8") {
@@ -368,7 +368,7 @@ export function readCustomType(reader: Read): CustomType {
     }
     else if (field == "optBigint") {
       reader.context().push(field, "BigInt | null", "type found, reading property");
-      _optBigint = reader.readNullableBigInt();
+      _optBigint = reader.readOptionalBigInt();
       reader.context().pop();
     }
     else if (field == "bignumber") {
@@ -379,7 +379,7 @@ export function readCustomType(reader: Read): CustomType {
     }
     else if (field == "optBignumber") {
       reader.context().push(field, "BigNumber | null", "type found, reading property");
-      _optBignumber = reader.readNullableBigNumber();
+      _optBignumber = reader.readOptionalBigNumber();
       reader.context().pop();
     }
     else if (field == "json") {
@@ -390,7 +390,7 @@ export function readCustomType(reader: Read): CustomType {
     }
     else if (field == "optJson") {
       reader.context().push(field, "JSON.Value | null", "type found, reading property");
-      _optJson = reader.readNullableJSON();
+      _optJson = reader.readOptionalJSON();
       reader.context().pop();
     }
     else if (field == "bytes") {
@@ -401,7 +401,7 @@ export function readCustomType(reader: Read): CustomType {
     }
     else if (field == "optBytes") {
       reader.context().push(field, "ArrayBuffer | null", "type found, reading property");
-      _optBytes = reader.readNullableBytes();
+      _optBytes = reader.readOptionalBytes();
       reader.context().pop();
     }
     else if (field == "boolean") {
@@ -412,7 +412,7 @@ export function readCustomType(reader: Read): CustomType {
     }
     else if (field == "optBoolean") {
       reader.context().push(field, "Option<bool>", "type found, reading property");
-      _optBoolean = reader.readNullableBool();
+      _optBoolean = reader.readOptionalBool();
       reader.context().pop();
     }
     else if (field == "uArray") {
@@ -425,22 +425,22 @@ export function readCustomType(reader: Read): CustomType {
     }
     else if (field == "uOptArray") {
       reader.context().push(field, "Array<u32> | null", "type found, reading property");
-      _uOptArray = reader.readNullableArray((reader: Read): u32 => {
+      _uOptArray = reader.readOptionalArray((reader: Read): u32 => {
         return reader.readUInt32();
       });
       reader.context().pop();
     }
     else if (field == "optUOptArray") {
       reader.context().push(field, "Array<Option<u32>> | null", "type found, reading property");
-      _optUOptArray = reader.readNullableArray((reader: Read): Option<u32> => {
-        return reader.readNullableUInt32();
+      _optUOptArray = reader.readOptionalArray((reader: Read): Option<u32> => {
+        return reader.readOptionalUInt32();
       });
       reader.context().pop();
     }
     else if (field == "optStrOptArray") {
       reader.context().push(field, "Array<string | null> | null", "type found, reading property");
-      _optStrOptArray = reader.readNullableArray((reader: Read): string | null => {
-        return reader.readNullableString();
+      _optStrOptArray = reader.readOptionalArray((reader: Read): string | null => {
+        return reader.readOptionalString();
       });
       reader.context().pop();
     }
@@ -457,8 +457,8 @@ export function readCustomType(reader: Read): CustomType {
     else if (field == "uOptArrayOptArray") {
       reader.context().push(field, "Array<Array<Option<u32>> | null>", "type found, reading property");
       _uOptArrayOptArray = reader.readArray((reader: Read): Array<Option<u32>> | null => {
-        return reader.readNullableArray((reader: Read): Option<u32> => {
-          return reader.readNullableUInt32();
+        return reader.readOptionalArray((reader: Read): Option<u32> => {
+          return reader.readOptionalUInt32();
         });
       });
       _uOptArrayOptArraySet = true;
@@ -467,7 +467,7 @@ export function readCustomType(reader: Read): CustomType {
     else if (field == "uArrayOptArrayArray") {
       reader.context().push(field, "Array<Array<Array<u32>> | null>", "type found, reading property");
       _uArrayOptArrayArray = reader.readArray((reader: Read): Array<Array<u32>> | null => {
-        return reader.readNullableArray((reader: Read): Array<u32> => {
+        return reader.readOptionalArray((reader: Read): Array<u32> => {
           return reader.readArray((reader: Read): u32 => {
             return reader.readUInt32();
           });
@@ -478,10 +478,10 @@ export function readCustomType(reader: Read): CustomType {
     }
     else if (field == "crazyArray") {
       reader.context().push(field, "Array<Array<Array<Array<u32> | null>> | null> | null", "type found, reading property");
-      _crazyArray = reader.readNullableArray((reader: Read): Array<Array<Array<u32> | null>> | null => {
-        return reader.readNullableArray((reader: Read): Array<Array<u32> | null> => {
+      _crazyArray = reader.readOptionalArray((reader: Read): Array<Array<Array<u32> | null>> | null => {
+        return reader.readOptionalArray((reader: Read): Array<Array<u32> | null> => {
           return reader.readArray((reader: Read): Array<u32> | null => {
-            return reader.readNullableArray((reader: Read): u32 => {
+            return reader.readOptionalArray((reader: Read): u32 => {
               return reader.readUInt32();
             });
           });
@@ -516,7 +516,7 @@ export function readCustomType(reader: Read): CustomType {
     }
     else if (field == "optObjectArray") {
       reader.context().push(field, "Array<Types.AnotherType | null> | null", "type found, reading property");
-      _optObjectArray = reader.readNullableArray((reader: Read): Types.AnotherType | null => {
+      _optObjectArray = reader.readOptionalArray((reader: Read): Types.AnotherType | null => {
         let object: Types.AnotherType | null = null;
         if (!reader.isNextNil()) {
           object = Types.AnotherType.read(reader);
@@ -575,7 +575,7 @@ export function readCustomType(reader: Read): CustomType {
     }
     else if (field == "optEnumArray") {
       reader.context().push(field, "Array<Option<Types.CustomEnum>> | null", "type found, reading property");
-      _optEnumArray = reader.readNullableArray((reader: Read): Option<Types.CustomEnum> => {
+      _optEnumArray = reader.readOptionalArray((reader: Read): Option<Types.CustomEnum> => {
         let value: Option<Types.CustomEnum>;
         if (!reader.isNextNil()) {
           if (reader.isNextString()) {

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/Env/serialization.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/Env/serialization.ts
@@ -32,14 +32,14 @@ export function writeEnv(writer: Write, type: Env): void {
   writer.context().pop();
   writer.context().push("optProp", "string | null", "writing property");
   writer.writeString("optProp");
-  writer.writeNullableString(type.optProp);
+  writer.writeOptionalString(type.optProp);
   writer.context().pop();
   writer.context().push("optMap", "Map<string, Option<i32>> | null", "writing property");
   writer.writeString("optMap");
-  writer.writeNullableExtGenericMap(type.optMap, (writer: Write, key: string) => {
+  writer.writeOptionalExtGenericMap(type.optMap, (writer: Write, key: string) => {
     writer.writeString(key);
   }, (writer: Write, value: Option<i32>): void => {
-    writer.writeNullableInt32(value);
+    writer.writeOptionalInt32(value);
   });
   writer.context().pop();
 }
@@ -71,15 +71,15 @@ export function readEnv(reader: Read): Env {
     }
     else if (field == "optProp") {
       reader.context().push(field, "string | null", "type found, reading property");
-      _optProp = reader.readNullableString();
+      _optProp = reader.readOptionalString();
       reader.context().pop();
     }
     else if (field == "optMap") {
       reader.context().push(field, "Map<string, Option<i32>> | null", "type found, reading property");
-      _optMap = reader.readNullableExtGenericMap((reader: Read): string => {
+      _optMap = reader.readOptionalExtGenericMap((reader: Read): string => {
         return reader.readString();
       }, (reader: Read): Option<i32> => {
-        return reader.readNullableInt32();
+        return reader.readOptionalInt32();
       });
       reader.context().pop();
     }

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/Module/serialization.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/Module/serialization.ts
@@ -52,7 +52,7 @@ export function deserializemoduleMethodArgs(argsBuf: ArrayBuffer): Input_moduleM
     }
     else if (field == "optStr") {
       reader.context().push(field, "string | null", "type found, reading property");
-      _optStr = reader.readNullableString();
+      _optStr = reader.readOptionalString();
       reader.context().pop();
     }
     else if (field == "en") {
@@ -105,7 +105,7 @@ export function deserializemoduleMethodArgs(argsBuf: ArrayBuffer): Input_moduleM
     }
     else if (field == "optEnumArray") {
       reader.context().push(field, "Array<Option<Types.CustomEnum>> | null", "type found, reading property");
-      _optEnumArray = reader.readNullableArray((reader: Read): Option<Types.CustomEnum> => {
+      _optEnumArray = reader.readOptionalArray((reader: Read): Option<Types.CustomEnum> => {
         let value: Option<Types.CustomEnum>;
         if (!reader.isNextNil()) {
           if (reader.isNextString()) {
@@ -230,7 +230,7 @@ export function deserializeobjectMethodArgs(argsBuf: ArrayBuffer): Input_objectM
     }
     else if (field == "optObjectArray") {
       reader.context().push(field, "Array<Types.AnotherType | null> | null", "type found, reading property");
-      _optObjectArray = reader.readNullableArray((reader: Read): Types.AnotherType | null => {
+      _optObjectArray = reader.readOptionalArray((reader: Read): Types.AnotherType | null => {
         let object: Types.AnotherType | null = null;
         if (!reader.isNextNil()) {
           object = Types.AnotherType.read(reader);

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/TestImport_Module/serialization.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/TestImport_Module/serialization.ts
@@ -50,7 +50,7 @@ export function writeimportedMethodArgs(
   writer.context().pop();
   writer.context().push("optStr", "string | null", "writing property");
   writer.writeString("optStr");
-  writer.writeNullableString(input.optStr);
+  writer.writeOptionalString(input.optStr);
   writer.context().pop();
   writer.context().push("u", "u32", "writing property");
   writer.writeString("u");
@@ -58,13 +58,13 @@ export function writeimportedMethodArgs(
   writer.context().pop();
   writer.context().push("optU", "Option<u32>", "writing property");
   writer.writeString("optU");
-  writer.writeNullableUInt32(input.optU);
+  writer.writeOptionalUInt32(input.optU);
   writer.context().pop();
   writer.context().push("uArrayArray", "Array<Array<Option<u32>> | null>", "writing property");
   writer.writeString("uArrayArray");
   writer.writeArray(input.uArrayArray, (writer: Write, item: Array<Option<u32>> | null): void => {
-    writer.writeNullableArray(item, (writer: Write, item: Option<u32>): void => {
-      writer.writeNullableUInt32(item);
+    writer.writeOptionalArray(item, (writer: Write, item: Option<u32>): void => {
+      writer.writeOptionalUInt32(item);
     });
   });
   writer.context().pop();
@@ -88,7 +88,7 @@ export function writeimportedMethodArgs(
   writer.context().pop();
   writer.context().push("optObjectArray", "Array<Types.TestImport_Object | null> | null", "writing property");
   writer.writeString("optObjectArray");
-  writer.writeNullableArray(input.optObjectArray, (writer: Write, item: Types.TestImport_Object | null): void => {
+  writer.writeOptionalArray(input.optObjectArray, (writer: Write, item: Types.TestImport_Object | null): void => {
     if (item) {
       Types.TestImport_Object.write(writer, item as Types.TestImport_Object);
     } else {
@@ -102,7 +102,7 @@ export function writeimportedMethodArgs(
   writer.context().pop();
   writer.context().push("optEnum", "Option<Types.TestImport_Enum>", "writing property");
   writer.writeString("optEnum");
-  writer.writeNullableInt32(input.optEnum);
+  writer.writeOptionalInt32(input.optEnum);
   writer.context().pop();
   writer.context().push("enumArray", "Array<Types.TestImport_Enum>", "writing property");
   writer.writeString("enumArray");
@@ -112,8 +112,8 @@ export function writeimportedMethodArgs(
   writer.context().pop();
   writer.context().push("optEnumArray", "Array<Option<Types.TestImport_Enum>> | null", "writing property");
   writer.writeString("optEnumArray");
-  writer.writeNullableArray(input.optEnumArray, (writer: Write, item: Option<Types.TestImport_Enum>): void => {
-    writer.writeNullableInt32(item);
+  writer.writeOptionalArray(input.optEnumArray, (writer: Write, item: Option<Types.TestImport_Enum>): void => {
+    writer.writeOptionalInt32(item);
   });
   writer.context().pop();
 }

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/TestImport_Object/serialization.ts
@@ -46,7 +46,7 @@ export function writeTestImport_Object(writer: Write, type: TestImport_Object): 
   writer.context().pop();
   writer.context().push("optObjectArray", "Array<Types.TestImport_AnotherObject | null> | null", "writing property");
   writer.writeString("optObjectArray");
-  writer.writeNullableArray(type.optObjectArray, (writer: Write, item: Types.TestImport_AnotherObject | null): void => {
+  writer.writeOptionalArray(type.optObjectArray, (writer: Write, item: Types.TestImport_AnotherObject | null): void => {
     if (item) {
       Types.TestImport_AnotherObject.write(writer, item as Types.TestImport_AnotherObject);
     } else {
@@ -60,7 +60,7 @@ export function writeTestImport_Object(writer: Write, type: TestImport_Object): 
   writer.context().pop();
   writer.context().push("optEnum", "Option<Types.TestImport_Enum>", "writing property");
   writer.writeString("optEnum");
-  writer.writeNullableInt32(type.optEnum);
+  writer.writeOptionalInt32(type.optEnum);
   writer.context().pop();
   writer.context().push("enumArray", "Array<Types.TestImport_Enum>", "writing property");
   writer.writeString("enumArray");
@@ -70,8 +70,8 @@ export function writeTestImport_Object(writer: Write, type: TestImport_Object): 
   writer.context().pop();
   writer.context().push("optEnumArray", "Array<Option<Types.TestImport_Enum>> | null", "writing property");
   writer.writeString("optEnumArray");
-  writer.writeNullableArray(type.optEnumArray, (writer: Write, item: Option<Types.TestImport_Enum>): void => {
-    writer.writeNullableInt32(item);
+  writer.writeOptionalArray(type.optEnumArray, (writer: Write, item: Option<Types.TestImport_Enum>): void => {
+    writer.writeOptionalInt32(item);
   });
   writer.context().pop();
 }
@@ -130,7 +130,7 @@ export function readTestImport_Object(reader: Read): TestImport_Object {
     }
     else if (field == "optObjectArray") {
       reader.context().push(field, "Array<Types.TestImport_AnotherObject | null> | null", "type found, reading property");
-      _optObjectArray = reader.readNullableArray((reader: Read): Types.TestImport_AnotherObject | null => {
+      _optObjectArray = reader.readOptionalArray((reader: Read): Types.TestImport_AnotherObject | null => {
         let object: Types.TestImport_AnotherObject | null = null;
         if (!reader.isNextNil()) {
           object = Types.TestImport_AnotherObject.read(reader);
@@ -189,7 +189,7 @@ export function readTestImport_Object(reader: Read): TestImport_Object {
     }
     else if (field == "optEnumArray") {
       reader.context().push(field, "Array<Option<Types.TestImport_Enum>> | null", "type found, reading property");
-      _optEnumArray = reader.readNullableArray((reader: Read): Option<Types.TestImport_Enum> => {
+      _optEnumArray = reader.readOptionalArray((reader: Read): Option<Types.TestImport_Enum> => {
         let value: Option<Types.TestImport_Enum>;
         if (!reader.isNextNil()) {
           if (reader.isNextString()) {

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/another_type/serialization.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/another_type/serialization.rs
@@ -28,7 +28,7 @@ pub fn write_another_type<W: Write>(input: &AnotherType, writer: &mut W) -> Resu
     writer.write_map_length(&3)?;
     writer.context().push("prop", "Option<String>", "writing property");
     writer.write_string("prop")?;
-    writer.write_nullable_string(&input.prop)?;
+    writer.write_optional_string(&input.prop)?;
     writer.context().pop();
     writer.context().push("circular", "Option<CustomType>", "writing property");
     writer.write_string("circular")?;
@@ -40,7 +40,7 @@ pub fn write_another_type<W: Write>(input: &AnotherType, writer: &mut W) -> Resu
     writer.context().pop();
     writer.context().push("const", "Option<String>", "writing property");
     writer.write_string("const")?;
-    writer.write_nullable_string(&input.m_const)?;
+    writer.write_optional_string(&input.m_const)?;
     writer.context().pop();
     Ok(())
 }
@@ -66,7 +66,7 @@ pub fn read_another_type<R: Read>(reader: &mut R) -> Result<AnotherType, DecodeE
         match field.as_str() {
             "prop" => {
                 reader.context().push(&field, "Option<String>", "type found, reading property");
-                _prop = reader.read_nullable_string()?;
+                _prop = reader.read_optional_string()?;
                 reader.context().pop();
             }
             "circular" => {
@@ -82,7 +82,7 @@ pub fn read_another_type<R: Read>(reader: &mut R) -> Result<AnotherType, DecodeE
             }
             "const" => {
                 reader.context().push(&field, "Option<String>", "type found, reading property");
-                _const = reader.read_nullable_string()?;
+                _const = reader.read_optional_string()?;
                 reader.context().pop();
             }
             err => return Err(DecodeError::UnknownFieldName(err.to_string())),

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/custom_type/serialization.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/custom_type/serialization.rs
@@ -37,7 +37,7 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("optStr", "Option<String>", "writing property");
     writer.write_string("optStr")?;
-    writer.write_nullable_string(&input.opt_str)?;
+    writer.write_optional_string(&input.opt_str)?;
     writer.context().pop();
     writer.context().push("u", "u32", "writing property");
     writer.write_string("u")?;
@@ -45,7 +45,7 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("optU", "Option<u32>", "writing property");
     writer.write_string("optU")?;
-    writer.write_nullable_u32(&input.opt_u)?;
+    writer.write_optional_u32(&input.opt_u)?;
     writer.context().pop();
     writer.context().push("u8", "u8", "writing property");
     writer.write_string("u8")?;
@@ -81,7 +81,7 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("optBigint", "Option<BigInt>", "writing property");
     writer.write_string("optBigint")?;
-    writer.write_nullable_bigint(&input.opt_bigint)?;
+    writer.write_optional_bigint(&input.opt_bigint)?;
     writer.context().pop();
     writer.context().push("bignumber", "BigNumber", "writing property");
     writer.write_string("bignumber")?;
@@ -89,7 +89,7 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("optBignumber", "Option<BigNumber>", "writing property");
     writer.write_string("optBignumber")?;
-    writer.write_nullable_bignumber(&input.opt_bignumber)?;
+    writer.write_optional_bignumber(&input.opt_bignumber)?;
     writer.context().pop();
     writer.context().push("json", "JSON::Value", "writing property");
     writer.write_string("json")?;
@@ -97,7 +97,7 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("optJson", "Option<JSON::Value>", "writing property");
     writer.write_string("optJson")?;
-    writer.write_nullable_json(&input.opt_json)?;
+    writer.write_optional_json(&input.opt_json)?;
     writer.context().pop();
     writer.context().push("bytes", "Vec<u8>", "writing property");
     writer.write_string("bytes")?;
@@ -105,7 +105,7 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("optBytes", "Option<Vec<u8>>", "writing property");
     writer.write_string("optBytes")?;
-    writer.write_nullable_bytes(&input.opt_bytes)?;
+    writer.write_optional_bytes(&input.opt_bytes)?;
     writer.context().pop();
     writer.context().push("boolean", "bool", "writing property");
     writer.write_string("boolean")?;
@@ -113,7 +113,7 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("optBoolean", "Option<bool>", "writing property");
     writer.write_string("optBoolean")?;
-    writer.write_nullable_bool(&input.opt_boolean)?;
+    writer.write_optional_bool(&input.opt_boolean)?;
     writer.context().pop();
     writer.context().push("uArray", "Vec<u32>", "writing property");
     writer.write_string("uArray")?;
@@ -123,20 +123,20 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("uOptArray", "Option<Vec<u32>>", "writing property");
     writer.write_string("uOptArray")?;
-    writer.write_nullable_array(&input.u_opt_array, |writer, item| {
+    writer.write_optional_array(&input.u_opt_array, |writer, item| {
         writer.write_u32(item)
     })?;
     writer.context().pop();
     writer.context().push("optUOptArray", "Option<Vec<Option<u32>>>", "writing property");
     writer.write_string("optUOptArray")?;
-    writer.write_nullable_array(&input.opt_u_opt_array, |writer, item| {
-        writer.write_nullable_u32(item)
+    writer.write_optional_array(&input.opt_u_opt_array, |writer, item| {
+        writer.write_optional_u32(item)
     })?;
     writer.context().pop();
     writer.context().push("optStrOptArray", "Option<Vec<Option<String>>>", "writing property");
     writer.write_string("optStrOptArray")?;
-    writer.write_nullable_array(&input.opt_str_opt_array, |writer, item| {
-        writer.write_nullable_string(item)
+    writer.write_optional_array(&input.opt_str_opt_array, |writer, item| {
+        writer.write_optional_string(item)
     })?;
     writer.context().pop();
     writer.context().push("uArrayArray", "Vec<Vec<u32>>", "writing property");
@@ -150,15 +150,15 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().push("uOptArrayOptArray", "Vec<Option<Vec<Option<u32>>>>", "writing property");
     writer.write_string("uOptArrayOptArray")?;
     writer.write_array(&input.u_opt_array_opt_array, |writer, item| {
-        writer.write_nullable_array(item, |writer, item| {
-            writer.write_nullable_u32(item)
+        writer.write_optional_array(item, |writer, item| {
+            writer.write_optional_u32(item)
         })
     })?;
     writer.context().pop();
     writer.context().push("uArrayOptArrayArray", "Vec<Option<Vec<Vec<u32>>>>", "writing property");
     writer.write_string("uArrayOptArrayArray")?;
     writer.write_array(&input.u_array_opt_array_array, |writer, item| {
-        writer.write_nullable_array(item, |writer, item| {
+        writer.write_optional_array(item, |writer, item| {
             writer.write_array(item, |writer, item| {
                 writer.write_u32(item)
             })
@@ -167,10 +167,10 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("crazyArray", "Option<Vec<Option<Vec<Vec<Option<Vec<u32>>>>>>>", "writing property");
     writer.write_string("crazyArray")?;
-    writer.write_nullable_array(&input.crazy_array, |writer, item| {
-        writer.write_nullable_array(item, |writer, item| {
+    writer.write_optional_array(&input.crazy_array, |writer, item| {
+        writer.write_optional_array(item, |writer, item| {
             writer.write_array(item, |writer, item| {
-                writer.write_nullable_array(item, |writer, item| {
+                writer.write_optional_array(item, |writer, item| {
                     writer.write_u32(item)
                 })
             })
@@ -197,7 +197,7 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("optObjectArray", "Option<Vec<Option<AnotherType>>>", "writing property");
     writer.write_string("optObjectArray")?;
-    writer.write_nullable_array(&input.opt_object_array, |writer, item| {
+    writer.write_optional_array(&input.opt_object_array, |writer, item| {
         if item.is_some() {
             AnotherType::write(item.as_ref().as_ref().unwrap(), writer)
         } else {
@@ -211,7 +211,7 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("optEnum", "Option<CustomEnum>", "writing property");
     writer.write_string("optEnum")?;
-    writer.write_nullable_i32(&input.opt_enum.map(|f| f as i32))?;
+    writer.write_optional_i32(&input.opt_enum.map(|f| f as i32))?;
     writer.context().pop();
     writer.context().push("enumArray", "Vec<CustomEnum>", "writing property");
     writer.write_string("enumArray")?;
@@ -221,8 +221,8 @@ pub fn write_custom_type<W: Write>(input: &CustomType, writer: &mut W) -> Result
     writer.context().pop();
     writer.context().push("optEnumArray", "Option<Vec<Option<CustomEnum>>>", "writing property");
     writer.write_string("optEnumArray")?;
-    writer.write_nullable_array(&input.opt_enum_array, |writer, item| {
-        writer.write_nullable_i32(&item.map(|f| f as i32))
+    writer.write_optional_array(&input.opt_enum_array, |writer, item| {
+        writer.write_optional_i32(&item.map(|f| f as i32))
     })?;
     writer.context().pop();
     Ok(())
@@ -311,7 +311,7 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             }
             "optStr" => {
                 reader.context().push(&field, "Option<String>", "type found, reading property");
-                _opt_str = reader.read_nullable_string()?;
+                _opt_str = reader.read_optional_string()?;
                 reader.context().pop();
             }
             "u" => {
@@ -322,7 +322,7 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             }
             "optU" => {
                 reader.context().push(&field, "Option<u32>", "type found, reading property");
-                _opt_u = reader.read_nullable_u32()?;
+                _opt_u = reader.read_optional_u32()?;
                 reader.context().pop();
             }
             "u8" => {
@@ -375,7 +375,7 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             }
             "optBigint" => {
                 reader.context().push(&field, "Option<BigInt>", "type found, reading property");
-                _opt_bigint = reader.read_nullable_bigint()?;
+                _opt_bigint = reader.read_optional_bigint()?;
                 reader.context().pop();
             }
             "bignumber" => {
@@ -386,7 +386,7 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             }
             "optBignumber" => {
                 reader.context().push(&field, "Option<BigNumber>", "type found, reading property");
-                _opt_bignumber = reader.read_nullable_bignumber()?;
+                _opt_bignumber = reader.read_optional_bignumber()?;
                 reader.context().pop();
             }
             "json" => {
@@ -397,7 +397,7 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             }
             "optJson" => {
                 reader.context().push(&field, "Option<JSON::Value>", "type found, reading property");
-                _opt_json = reader.read_nullable_json()?;
+                _opt_json = reader.read_optional_json()?;
                 reader.context().pop();
             }
             "bytes" => {
@@ -408,7 +408,7 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             }
             "optBytes" => {
                 reader.context().push(&field, "Option<Vec<u8>>", "type found, reading property");
-                _opt_bytes = reader.read_nullable_bytes()?;
+                _opt_bytes = reader.read_optional_bytes()?;
                 reader.context().pop();
             }
             "boolean" => {
@@ -419,7 +419,7 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             }
             "optBoolean" => {
                 reader.context().push(&field, "Option<bool>", "type found, reading property");
-                _opt_boolean = reader.read_nullable_bool()?;
+                _opt_boolean = reader.read_optional_bool()?;
                 reader.context().pop();
             }
             "uArray" => {
@@ -432,22 +432,22 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             }
             "uOptArray" => {
                 reader.context().push(&field, "Option<Vec<u32>>", "type found, reading property");
-                _u_opt_array = reader.read_nullable_array(|reader| {
+                _u_opt_array = reader.read_optional_array(|reader| {
                     reader.read_u32()
                 })?;
                 reader.context().pop();
             }
             "optUOptArray" => {
                 reader.context().push(&field, "Option<Vec<Option<u32>>>", "type found, reading property");
-                _opt_u_opt_array = reader.read_nullable_array(|reader| {
-                    reader.read_nullable_u32()
+                _opt_u_opt_array = reader.read_optional_array(|reader| {
+                    reader.read_optional_u32()
                 })?;
                 reader.context().pop();
             }
             "optStrOptArray" => {
                 reader.context().push(&field, "Option<Vec<Option<String>>>", "type found, reading property");
-                _opt_str_opt_array = reader.read_nullable_array(|reader| {
-                    reader.read_nullable_string()
+                _opt_str_opt_array = reader.read_optional_array(|reader| {
+                    reader.read_optional_string()
                 })?;
                 reader.context().pop();
             }
@@ -464,8 +464,8 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             "uOptArrayOptArray" => {
                 reader.context().push(&field, "Vec<Option<Vec<Option<u32>>>>", "type found, reading property");
                 _u_opt_array_opt_array = reader.read_array(|reader| {
-                    reader.read_nullable_array(|reader| {
-                        reader.read_nullable_u32()
+                    reader.read_optional_array(|reader| {
+                        reader.read_optional_u32()
                     })
                 })?;
                 _u_opt_array_opt_array_set = true;
@@ -474,7 +474,7 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             "uArrayOptArrayArray" => {
                 reader.context().push(&field, "Vec<Option<Vec<Vec<u32>>>>", "type found, reading property");
                 _u_array_opt_array_array = reader.read_array(|reader| {
-                    reader.read_nullable_array(|reader| {
+                    reader.read_optional_array(|reader| {
                         reader.read_array(|reader| {
                             reader.read_u32()
                         })
@@ -485,10 +485,10 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             }
             "crazyArray" => {
                 reader.context().push(&field, "Option<Vec<Option<Vec<Vec<Option<Vec<u32>>>>>>>", "type found, reading property");
-                _crazy_array = reader.read_nullable_array(|reader| {
-                    reader.read_nullable_array(|reader| {
+                _crazy_array = reader.read_optional_array(|reader| {
+                    reader.read_optional_array(|reader| {
                         reader.read_array(|reader| {
-                            reader.read_nullable_array(|reader| {
+                            reader.read_optional_array(|reader| {
                                 reader.read_u32()
                             })
                         })
@@ -525,7 +525,7 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             }
             "optObjectArray" => {
                 reader.context().push(&field, "Option<Vec<Option<AnotherType>>>", "type found, reading property");
-                _opt_object_array = reader.read_nullable_array(|reader| {
+                _opt_object_array = reader.read_optional_array(|reader| {
                     let mut object: Option<AnotherType> = None;
                     if !reader.is_next_nil()? {
                         object = Some(AnotherType::read(reader)?);
@@ -582,7 +582,7 @@ pub fn read_custom_type<R: Read>(reader: &mut R) -> Result<CustomType, DecodeErr
             }
             "optEnumArray" => {
                 reader.context().push(&field, "Option<Vec<Option<CustomEnum>>>", "type found, reading property");
-                _opt_enum_array = reader.read_nullable_array(|reader| {
+                _opt_enum_array = reader.read_optional_array(|reader| {
                     let mut value: Option<CustomEnum> = None;
                     if !reader.is_next_nil()? {
                         if reader.is_next_string()? {

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_module/serialization.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_module/serialization.rs
@@ -53,7 +53,7 @@ pub fn write_imported_method_args<W: Write>(input: &InputImportedMethod, writer:
     writer.context().pop();
     writer.context().push("optStr", "Option<String>", "writing property");
     writer.write_string("optStr")?;
-    writer.write_nullable_string(&input.opt_str)?;
+    writer.write_optional_string(&input.opt_str)?;
     writer.context().pop();
     writer.context().push("u", "u32", "writing property");
     writer.write_string("u")?;
@@ -61,13 +61,13 @@ pub fn write_imported_method_args<W: Write>(input: &InputImportedMethod, writer:
     writer.context().pop();
     writer.context().push("optU", "Option<u32>", "writing property");
     writer.write_string("optU")?;
-    writer.write_nullable_u32(&input.opt_u)?;
+    writer.write_optional_u32(&input.opt_u)?;
     writer.context().pop();
     writer.context().push("uArrayArray", "Vec<Option<Vec<Option<u32>>>>", "writing property");
     writer.write_string("uArrayArray")?;
     writer.write_array(&input.u_array_array, |writer, item| {
-        writer.write_nullable_array(item, |writer, item| {
-            writer.write_nullable_u32(item)
+        writer.write_optional_array(item, |writer, item| {
+            writer.write_optional_u32(item)
         })
     })?;
     writer.context().pop();
@@ -91,7 +91,7 @@ pub fn write_imported_method_args<W: Write>(input: &InputImportedMethod, writer:
     writer.context().pop();
     writer.context().push("optObjectArray", "Option<Vec<Option<TestImportObject>>>", "writing property");
     writer.write_string("optObjectArray")?;
-    writer.write_nullable_array(&input.opt_object_array, |writer, item| {
+    writer.write_optional_array(&input.opt_object_array, |writer, item| {
         if item.is_some() {
             TestImportObject::write(item.as_ref().as_ref().unwrap(), writer)
         } else {
@@ -105,7 +105,7 @@ pub fn write_imported_method_args<W: Write>(input: &InputImportedMethod, writer:
     writer.context().pop();
     writer.context().push("optEnum", "Option<TestImportEnum>", "writing property");
     writer.write_string("optEnum")?;
-    writer.write_nullable_i32(&input.opt_enum.map(|f| f as i32))?;
+    writer.write_optional_i32(&input.opt_enum.map(|f| f as i32))?;
     writer.context().pop();
     writer.context().push("enumArray", "Vec<TestImportEnum>", "writing property");
     writer.write_string("enumArray")?;
@@ -115,8 +115,8 @@ pub fn write_imported_method_args<W: Write>(input: &InputImportedMethod, writer:
     writer.context().pop();
     writer.context().push("optEnumArray", "Option<Vec<Option<TestImportEnum>>>", "writing property");
     writer.write_string("optEnumArray")?;
-    writer.write_nullable_array(&input.opt_enum_array, |writer, item| {
-        writer.write_nullable_i32(&item.map(|f| f as i32))
+    writer.write_optional_array(&input.opt_enum_array, |writer, item| {
+        writer.write_optional_i32(&item.map(|f| f as i32))
     })?;
     writer.context().pop();
     Ok(())

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_object/serialization.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_object/serialization.rs
@@ -51,7 +51,7 @@ pub fn write_test_import_object<W: Write>(input: &TestImportObject, writer: &mut
     writer.context().pop();
     writer.context().push("optObjectArray", "Option<Vec<Option<TestImportAnotherObject>>>", "writing property");
     writer.write_string("optObjectArray")?;
-    writer.write_nullable_array(&input.opt_object_array, |writer, item| {
+    writer.write_optional_array(&input.opt_object_array, |writer, item| {
         if item.is_some() {
             TestImportAnotherObject::write(item.as_ref().as_ref().unwrap(), writer)
         } else {
@@ -65,7 +65,7 @@ pub fn write_test_import_object<W: Write>(input: &TestImportObject, writer: &mut
     writer.context().pop();
     writer.context().push("optEnum", "Option<TestImportEnum>", "writing property");
     writer.write_string("optEnum")?;
-    writer.write_nullable_i32(&input.opt_enum.map(|f| f as i32))?;
+    writer.write_optional_i32(&input.opt_enum.map(|f| f as i32))?;
     writer.context().pop();
     writer.context().push("enumArray", "Vec<TestImportEnum>", "writing property");
     writer.write_string("enumArray")?;
@@ -75,8 +75,8 @@ pub fn write_test_import_object<W: Write>(input: &TestImportObject, writer: &mut
     writer.context().pop();
     writer.context().push("optEnumArray", "Option<Vec<Option<TestImportEnum>>>", "writing property");
     writer.write_string("optEnumArray")?;
-    writer.write_nullable_array(&input.opt_enum_array, |writer, item| {
-        writer.write_nullable_i32(&item.map(|f| f as i32))
+    writer.write_optional_array(&input.opt_enum_array, |writer, item| {
+        writer.write_optional_i32(&item.map(|f| f as i32))
     })?;
     writer.context().pop();
     Ok(())
@@ -139,7 +139,7 @@ pub fn read_test_import_object<R: Read>(reader: &mut R) -> Result<TestImportObje
             }
             "optObjectArray" => {
                 reader.context().push(&field, "Option<Vec<Option<TestImportAnotherObject>>>", "type found, reading property");
-                _opt_object_array = reader.read_nullable_array(|reader| {
+                _opt_object_array = reader.read_optional_array(|reader| {
                     let mut object: Option<TestImportAnotherObject> = None;
                     if !reader.is_next_nil()? {
                         object = Some(TestImportAnotherObject::read(reader)?);
@@ -196,7 +196,7 @@ pub fn read_test_import_object<R: Read>(reader: &mut R) -> Result<TestImportObje
             }
             "optEnumArray" => {
                 reader.context().push(&field, "Option<Vec<Option<TestImportEnum>>>", "type found, reading property");
-                _opt_enum_array = reader.read_nullable_array(|reader| {
+                _opt_enum_array = reader.read_optional_array(|reader| {
                     let mut value: Option<TestImportEnum> = None;
                     if !reader.is_next_nil()? {
                         if reader.is_next_string()? {

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/module/serialization.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/module/serialization.rs
@@ -64,7 +64,7 @@ pub fn deserialize_module_method_args(input: &[u8]) -> Result<InputModuleMethod,
             }
             "optStr" => {
                 reader.context().push(&field, "Option<String>", "type found, reading argument");
-                _opt_str = reader.read_nullable_string()?;
+                _opt_str = reader.read_optional_string()?;
                 reader.context().pop();
             }
             "en" => {
@@ -113,7 +113,7 @@ pub fn deserialize_module_method_args(input: &[u8]) -> Result<InputModuleMethod,
             }
             "optEnumArray" => {
                 reader.context().push(&field, "Option<Vec<Option<CustomEnum>>>", "type found, reading argument");
-                _opt_enum_array = reader.read_nullable_array(|reader| {
+                _opt_enum_array = reader.read_optional_array(|reader| {
                     let mut value: Option<CustomEnum> = None;
                     if !reader.is_next_nil()? {
                         if reader.is_next_string()? {
@@ -237,7 +237,7 @@ pub fn deserialize_object_method_args(input: &[u8]) -> Result<InputObjectMethod,
             }
             "optObjectArray" => {
                 reader.context().push(&field, "Option<Vec<Option<AnotherType>>>", "type found, reading argument");
-                _opt_object_array = reader.read_nullable_array(|reader| {
+                _opt_object_array = reader.read_optional_array(|reader| {
                     let mut object: Option<AnotherType> = None;
                     if !reader.is_next_nil()? {
                         object = Some(AnotherType::read(reader)?);

--- a/packages/wasm/as/assembly/__tests__/msgpack.spec.ts
+++ b/packages/wasm/as/assembly/__tests__/msgpack.spec.ts
@@ -101,7 +101,7 @@ class Sanity {
 function serializeSanity(writer: Write, type: Sanity): void {
   writer.writeMapLength(23);
   writer.writeString("nil");
-  writer.writeNullableString(type.nil);
+  writer.writeOptionalString(type.nil);
   writer.writeString("int8");
   writer.writeInt8(type.int8);
   writer.writeString("int16");
@@ -117,9 +117,9 @@ function serializeSanity(writer: Write, type: Sanity): void {
   writer.writeString("boolean");
   writer.writeBool(type.boolean);
   writer.writeString("optUint32");
-  writer.writeNullableUInt32(type.optUint32);
+  writer.writeOptionalUInt32(type.optUint32);
   writer.writeString("optBool");
-  writer.writeNullableBool(type.optBool);
+  writer.writeOptionalBool(type.optBool);
   writer.writeString("float32");
   writer.writeFloat32(type.float32);
   writer.writeString("float64");
@@ -174,7 +174,7 @@ function deserializeSanity(reader: Read, type: Sanity): void {
     const field = reader.readString();
 
     if (field == "nil") {
-      type.nil = reader.readNullableString();
+      type.nil = reader.readOptionalString();
     } else if (field == "int8") {
       type.int8 = reader.readInt8();
     } else if (field == "int16") {
@@ -190,9 +190,9 @@ function deserializeSanity(reader: Read, type: Sanity): void {
     } else if (field == "boolean") {
       type.boolean = reader.readBool();
     } else if (field == "optUint32") {
-      type.optUint32 = reader.readNullableUInt32();
+      type.optUint32 = reader.readOptionalUInt32();
     } else if (field == "optBool") {
-      type.optBool = reader.readNullableBool();
+      type.optBool = reader.readOptionalBool();
     } else if (field == "float32") {
       type.float32 = reader.readFloat32();
     } else if (field == "float64") {
@@ -254,7 +254,7 @@ function deserializeWithOverflow(reader: Read, type: Sanity): void {
     const field = reader.readString();
 
     if (field == "nil") {
-      type.nil = reader.readNullableString();
+      type.nil = reader.readOptionalString();
     } else if (field == "int8") {
       type.int8 = <i8>reader.readInt16();
     } else if (field == "int16") {
@@ -270,9 +270,9 @@ function deserializeWithOverflow(reader: Read, type: Sanity): void {
     } else if (field == "boolean") {
       type.boolean = reader.readBool();
     } else if (field == "optUint32") {
-      type.optUint32 = reader.readNullableUInt32();
+      type.optUint32 = reader.readOptionalUInt32();
     } else if (field == "optBool") {
-      type.optBool = reader.readNullableBool();
+      type.optBool = reader.readOptionalBool();
     } else if (field == "float32") {
       type.float32 = <f32>reader.readFloat64();
     } else if (field == "float64") {
@@ -320,7 +320,7 @@ function deserializeWithInvalidTypes(reader: Read, type: Sanity): void {
     const field = reader.readString();
 
     if (field == "nil") {
-      type.nil = reader.readNullableString();
+      type.nil = reader.readOptionalString();
     } else if (field == "int8") {
       type.str = reader.readString();
     } else if (field == "int8") {
@@ -338,9 +338,9 @@ function deserializeWithInvalidTypes(reader: Read, type: Sanity): void {
     } else if (field == "boolean") {
       type.boolean = reader.readBool();
     } else if (field == "optUint32") {
-      type.optUint32 = reader.readNullableUInt32();
+      type.optUint32 = reader.readOptionalUInt32();
     } else if (field == "optBool") {
-      type.optBool = reader.readNullableBool();
+      type.optBool = reader.readOptionalBool();
     } else if (field == "float32") {
       type.float32 = reader.readFloat32();
     } else if (field == "float64") {

--- a/packages/wasm/as/assembly/msgpack/Read.ts
+++ b/packages/wasm/as/assembly/msgpack/Read.ts
@@ -33,26 +33,26 @@ export abstract class Read {
     value_fn: (reader: Read) => V
   ): Map<K, V>;
 
-  abstract readNullableBool(): Option<bool>;
-  abstract readNullableInt8(): Option<i8>;
-  abstract readNullableInt16(): Option<i16>;
-  abstract readNullableInt32(): Option<i32>;
-  abstract readNullableUInt8(): Option<u8>;
-  abstract readNullableUInt16(): Option<u16>;
-  abstract readNullableUInt32(): Option<u32>;
-  abstract readNullableFloat32(): Option<f32>;
-  abstract readNullableFloat64(): Option<f64>;
-  abstract readNullableString(): string | null;
-  abstract readNullableBytes(): ArrayBuffer | null;
-  abstract readNullableBigInt(): BigInt | null;
-  abstract readNullableBigNumber(): BigNumber | null;
-  abstract readNullableJSON(): JSON.Value | null;
-  abstract readNullableArray<T>(fn: (decoder: Read) => T): Array<T> | null;
-  abstract readNullableMap<K, V>(
+  abstract readOptionalBool(): Option<bool>;
+  abstract readOptionalInt8(): Option<i8>;
+  abstract readOptionalInt16(): Option<i16>;
+  abstract readOptionalInt32(): Option<i32>;
+  abstract readOptionalUInt8(): Option<u8>;
+  abstract readOptionalUInt16(): Option<u16>;
+  abstract readOptionalUInt32(): Option<u32>;
+  abstract readOptionalFloat32(): Option<f32>;
+  abstract readOptionalFloat64(): Option<f64>;
+  abstract readOptionalString(): string | null;
+  abstract readOptionalBytes(): ArrayBuffer | null;
+  abstract readOptionalBigInt(): BigInt | null;
+  abstract readOptionalBigNumber(): BigNumber | null;
+  abstract readOptionalJSON(): JSON.Value | null;
+  abstract readOptionalArray<T>(fn: (decoder: Read) => T): Array<T> | null;
+  abstract readOptionalMap<K, V>(
     key_fn: (reader: Read) => K,
     value_fn: (reader: Read) => V
   ): Map<K, V> | null;
-  abstract readNullableExtGenericMap<K, V>(
+  abstract readOptionalExtGenericMap<K, V>(
     key_fn: (reader: Read) => K,
     value_fn: (reader: Read) => V
   ): Map<K, V> | null;

--- a/packages/wasm/as/assembly/msgpack/ReadDecoder.ts
+++ b/packages/wasm/as/assembly/msgpack/ReadDecoder.ts
@@ -364,98 +364,98 @@ export class ReadDecoder extends Read {
     return this.readMap(key_fn, value_fn);
   }
 
-  readNullableBool(): Option<bool> {
+  readOptionalBool(): Option<bool> {
     if (this.isNextNil()) {
       return Option.None<bool>();
     }
     return Option.Some<bool>(this.readBool());
   }
 
-  readNullableInt8(): Option<i8> {
+  readOptionalInt8(): Option<i8> {
     if (this.isNextNil()) {
       return Option.None<i8>();
     }
     return Option.Some<i8>(this.readInt8());
   }
 
-  readNullableInt16(): Option<i16> {
+  readOptionalInt16(): Option<i16> {
     if (this.isNextNil()) {
       return Option.None<i16>();
     }
     return Option.Some<i16>(this.readInt16());
   }
 
-  readNullableInt32(): Option<i32> {
+  readOptionalInt32(): Option<i32> {
     if (this.isNextNil()) {
       return Option.None<i32>();
     }
     return Option.Some<i32>(this.readInt32());
   }
 
-  readNullableUInt8(): Option<u8> {
+  readOptionalUInt8(): Option<u8> {
     if (this.isNextNil()) {
       return Option.None<u8>();
     }
     return Option.Some<u8>(this.readUInt8());
   }
 
-  readNullableUInt16(): Option<u16> {
+  readOptionalUInt16(): Option<u16> {
     if (this.isNextNil()) {
       return Option.None<u16>();
     }
     return Option.Some<u16>(this.readUInt16());
   }
 
-  readNullableUInt32(): Option<u32> {
+  readOptionalUInt32(): Option<u32> {
     if (this.isNextNil()) {
       return Option.None<u32>();
     }
     return Option.Some<u32>(this.readUInt32());
   }
 
-  readNullableFloat32(): Option<f32> {
+  readOptionalFloat32(): Option<f32> {
     if (this.isNextNil()) {
       return Option.None<f32>();
     }
     return Option.Some<f32>(this.readFloat32());
   }
 
-  readNullableFloat64(): Option<f64> {
+  readOptionalFloat64(): Option<f64> {
     if (this.isNextNil()) {
       return Option.None<f64>();
     }
     return Option.Some<f64>(this.readFloat64());
   }
 
-  readNullableString(): string | null {
+  readOptionalString(): string | null {
     if (this.isNextNil()) {
       return null;
     }
     return this.readString();
   }
 
-  readNullableBytes(): ArrayBuffer | null {
+  readOptionalBytes(): ArrayBuffer | null {
     if (this.isNextNil()) {
       return null;
     }
     return this.readBytes();
   }
 
-  readNullableBigInt(): BigInt | null {
+  readOptionalBigInt(): BigInt | null {
     if (this.isNextNil()) {
       return null;
     }
     return this.readBigInt();
   }
 
-  readNullableBigNumber(): BigNumber | null {
+  readOptionalBigNumber(): BigNumber | null {
     if (this.isNextNil()) {
       return null;
     }
     return this.readBigNumber();
   }
 
-  readNullableJSON(): JSON.Value | null {
+  readOptionalJSON(): JSON.Value | null {
     if (this.isNextNil()) {
       return null;
     }
@@ -463,14 +463,14 @@ export class ReadDecoder extends Read {
     return this.readJSON();
   }
 
-  readNullableArray<T>(fn: (decoder: Read) => T): Array<T> | null {
+  readOptionalArray<T>(fn: (decoder: Read) => T): Array<T> | null {
     if (this.isNextNil()) {
       return null;
     }
     return this.readArray(fn);
   }
 
-  readNullableMap<K, V>(
+  readOptionalMap<K, V>(
     key_fn: (decoder: Read) => K,
     value_fn: (decoder: Read) => V
   ): Map<K, V> | null {
@@ -480,7 +480,7 @@ export class ReadDecoder extends Read {
     return this.readMap(key_fn, value_fn);
   }
 
-  readNullableExtGenericMap<K, V>(
+  readOptionalExtGenericMap<K, V>(
     key_fn: (decoder: Read) => K,
     value_fn: (decoder: Read) => V
   ): Map<K, V> | null {

--- a/packages/wasm/as/assembly/msgpack/Write.ts
+++ b/packages/wasm/as/assembly/msgpack/Write.ts
@@ -39,30 +39,30 @@ export abstract class Write {
     value_fn: (writer: Write, value: V) => void
   ): void;
 
-  abstract writeNullableBool(value: Option<bool>): void;
-  abstract writeNullableInt8(value: Option<i8>): void;
-  abstract writeNullableInt16(value: Option<i16>): void;
-  abstract writeNullableInt32(value: Option<i32>): void;
-  abstract writeNullableUInt8(value: Option<u8>): void;
-  abstract writeNullableUInt16(value: Option<u16>): void;
-  abstract writeNullableUInt32(value: Option<u32>): void;
-  abstract writeNullableFloat32(value: Option<f32>): void;
-  abstract writeNullableFloat64(value: Option<f64>): void;
-  abstract writeNullableString(value: string | null): void;
-  abstract writeNullableBytes(value: ArrayBuffer | null): void;
-  abstract writeNullableBigInt(value: BigInt | null): void;
-  abstract writeNullableBigNumber(value: BigNumber | null): void;
-  abstract writeNullableJSON(value: JSON.Value | null): void;
-  abstract writeNullableArray<T>(
+  abstract writeOptionalBool(value: Option<bool>): void;
+  abstract writeOptionalInt8(value: Option<i8>): void;
+  abstract writeOptionalInt16(value: Option<i16>): void;
+  abstract writeOptionalInt32(value: Option<i32>): void;
+  abstract writeOptionalUInt8(value: Option<u8>): void;
+  abstract writeOptionalUInt16(value: Option<u16>): void;
+  abstract writeOptionalUInt32(value: Option<u32>): void;
+  abstract writeOptionalFloat32(value: Option<f32>): void;
+  abstract writeOptionalFloat64(value: Option<f64>): void;
+  abstract writeOptionalString(value: string | null): void;
+  abstract writeOptionalBytes(value: ArrayBuffer | null): void;
+  abstract writeOptionalBigInt(value: BigInt | null): void;
+  abstract writeOptionalBigNumber(value: BigNumber | null): void;
+  abstract writeOptionalJSON(value: JSON.Value | null): void;
+  abstract writeOptionalArray<T>(
     a: Array<T> | null,
     fn: (writer: Write, item: T) => void
   ): void;
-  abstract writeNullableMap<K, V>(
+  abstract writeOptionalMap<K, V>(
     m: Map<K, V> | null,
     key_fn: (writer: Write, key: K) => void,
     value_fn: (writer: Write, value: V) => void
   ): void;
-  abstract writeNullableExtGenericMap<K, V>(
+  abstract writeOptionalExtGenericMap<K, V>(
     m: Map<K, V>,
     key_fn: (writer: Write, key: K) => void,
     value_fn: (writer: Write, value: V) => void

--- a/packages/wasm/as/assembly/msgpack/WriteEncoder.ts
+++ b/packages/wasm/as/assembly/msgpack/WriteEncoder.ts
@@ -235,7 +235,7 @@ export class WriteEncoder extends Write {
     this.writeMap(m, key_fn, value_fn);
   }
 
-  writeNullableBool(value: Option<bool>): void {
+  writeOptionalBool(value: Option<bool>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -244,7 +244,7 @@ export class WriteEncoder extends Write {
     this.writeBool(value.unwrap());
   }
 
-  writeNullableInt8(value: Option<i8>): void {
+  writeOptionalInt8(value: Option<i8>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -253,7 +253,7 @@ export class WriteEncoder extends Write {
     this.writeInt8(value.unwrap());
   }
 
-  writeNullableInt16(value: Option<i16>): void {
+  writeOptionalInt16(value: Option<i16>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -262,7 +262,7 @@ export class WriteEncoder extends Write {
     this.writeInt16(value.unwrap());
   }
 
-  writeNullableInt32(value: Option<i32>): void {
+  writeOptionalInt32(value: Option<i32>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -271,7 +271,7 @@ export class WriteEncoder extends Write {
     this.writeInt32(value.unwrap());
   }
 
-  writeNullableUInt8(value: Option<u8>): void {
+  writeOptionalUInt8(value: Option<u8>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -280,7 +280,7 @@ export class WriteEncoder extends Write {
     this.writeUInt8(value.unwrap());
   }
 
-  writeNullableUInt16(value: Option<u16>): void {
+  writeOptionalUInt16(value: Option<u16>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -289,7 +289,7 @@ export class WriteEncoder extends Write {
     this.writeUInt16(value.unwrap());
   }
 
-  writeNullableUInt32(value: Option<u32>): void {
+  writeOptionalUInt32(value: Option<u32>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -298,7 +298,7 @@ export class WriteEncoder extends Write {
     this.writeUInt32(value.unwrap());
   }
 
-  writeNullableFloat32(value: Option<f32>): void {
+  writeOptionalFloat32(value: Option<f32>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -307,7 +307,7 @@ export class WriteEncoder extends Write {
     this.writeFloat32(value.unwrap());
   }
 
-  writeNullableFloat64(value: Option<f64>): void {
+  writeOptionalFloat64(value: Option<f64>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -316,7 +316,7 @@ export class WriteEncoder extends Write {
     this.writeFloat64(value.unwrap());
   }
 
-  writeNullableString(value: string | null): void {
+  writeOptionalString(value: string | null): void {
     if (value === null) {
       this.writeNil();
       return;
@@ -325,7 +325,7 @@ export class WriteEncoder extends Write {
     this.writeString(value);
   }
 
-  writeNullableBytes(value: ArrayBuffer | null): void {
+  writeOptionalBytes(value: ArrayBuffer | null): void {
     if (value === null) {
       this.writeNil();
       return;
@@ -334,7 +334,7 @@ export class WriteEncoder extends Write {
     this.writeBytes(value);
   }
 
-  writeNullableBigInt(value: BigInt | null): void {
+  writeOptionalBigInt(value: BigInt | null): void {
     if (value === null) {
       this.writeNil();
       return;
@@ -343,7 +343,7 @@ export class WriteEncoder extends Write {
     this.writeBigInt(value);
   }
 
-  writeNullableBigNumber(value: BigNumber): void {
+  writeOptionalBigNumber(value: BigNumber): void {
     if (value === null) {
       this.writeNil();
       return;
@@ -352,7 +352,7 @@ export class WriteEncoder extends Write {
     this.writeBigNumber(value);
   }
 
-  writeNullableJSON(value: JSON.Value | null): void {
+  writeOptionalJSON(value: JSON.Value | null): void {
     if (value === null) {
       this.writeNil();
       return;
@@ -361,7 +361,7 @@ export class WriteEncoder extends Write {
     this.writeJSON(value);
   }
 
-  writeNullableArray<T>(
+  writeOptionalArray<T>(
     a: Array<T> | null,
     fn: (encoder: Write, item: T) => void
   ): void {
@@ -372,7 +372,7 @@ export class WriteEncoder extends Write {
     this.writeArray(a, fn);
   }
 
-  writeNullableMap<K, V>(
+  writeOptionalMap<K, V>(
     m: Map<K, V> | null,
     key_fn: (encoder: Write, key: K) => void,
     value_fn: (encoder: Write, value: V) => void
@@ -384,7 +384,7 @@ export class WriteEncoder extends Write {
     this.writeMap(m, key_fn, value_fn);
   }
 
-  writeNullableExtGenericMap<K, V>(
+  writeOptionalExtGenericMap<K, V>(
     m: Map<K, V> | null,
     key_fn: (encoder: Write, key: K) => void,
     value_fn: (encoder: Write, value: V) => void

--- a/packages/wasm/as/assembly/msgpack/WriteSizer.ts
+++ b/packages/wasm/as/assembly/msgpack/WriteSizer.ts
@@ -195,7 +195,7 @@ export class WriteSizer extends Write {
     this.extByteLengths.push(byteLength);
   }
 
-  writeNullableBool(value: Option<bool>): void {
+  writeOptionalBool(value: Option<bool>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -204,7 +204,7 @@ export class WriteSizer extends Write {
     this.writeBool(value.unwrap());
   }
 
-  writeNullableInt8(value: Option<i8>): void {
+  writeOptionalInt8(value: Option<i8>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -213,7 +213,7 @@ export class WriteSizer extends Write {
     this.writeInt8(value.unwrap());
   }
 
-  writeNullableInt16(value: Option<i16>): void {
+  writeOptionalInt16(value: Option<i16>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -222,7 +222,7 @@ export class WriteSizer extends Write {
     this.writeInt16(value.unwrap());
   }
 
-  writeNullableInt32(value: Option<i32>): void {
+  writeOptionalInt32(value: Option<i32>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -231,7 +231,7 @@ export class WriteSizer extends Write {
     this.writeInt32(value.unwrap());
   }
 
-  writeNullableUInt8(value: Option<u8>): void {
+  writeOptionalUInt8(value: Option<u8>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -240,7 +240,7 @@ export class WriteSizer extends Write {
     this.writeUInt8(value.unwrap());
   }
 
-  writeNullableUInt16(value: Option<u16>): void {
+  writeOptionalUInt16(value: Option<u16>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -249,7 +249,7 @@ export class WriteSizer extends Write {
     this.writeUInt16(value.unwrap());
   }
 
-  writeNullableUInt32(value: Option<u32>): void {
+  writeOptionalUInt32(value: Option<u32>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -258,7 +258,7 @@ export class WriteSizer extends Write {
     this.writeUInt32(value.unwrap());
   }
 
-  writeNullableFloat32(value: Option<f32>): void {
+  writeOptionalFloat32(value: Option<f32>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -267,7 +267,7 @@ export class WriteSizer extends Write {
     this.writeFloat32(value.unwrap());
   }
 
-  writeNullableFloat64(value: Option<f64>): void {
+  writeOptionalFloat64(value: Option<f64>): void {
     if (value.isNone) {
       this.writeNil();
       return;
@@ -276,7 +276,7 @@ export class WriteSizer extends Write {
     this.writeFloat64(value.unwrap());
   }
 
-  writeNullableString(value: string | null): void {
+  writeOptionalString(value: string | null): void {
     if (value === null) {
       this.writeNil();
       return;
@@ -285,7 +285,7 @@ export class WriteSizer extends Write {
     this.writeString(value);
   }
 
-  writeNullableBytes(value: ArrayBuffer | null): void {
+  writeOptionalBytes(value: ArrayBuffer | null): void {
     if (value === null) {
       this.writeNil();
       return;
@@ -294,7 +294,7 @@ export class WriteSizer extends Write {
     this.writeBytes(value);
   }
 
-  writeNullableBigInt(value: BigInt | null): void {
+  writeOptionalBigInt(value: BigInt | null): void {
     if (value === null) {
       this.writeNil();
       return;
@@ -303,7 +303,7 @@ export class WriteSizer extends Write {
     this.writeBigInt(value);
   }
 
-  writeNullableBigNumber(value: BigNumber): void {
+  writeOptionalBigNumber(value: BigNumber): void {
     if (value === null) {
       this.writeNil();
       return;
@@ -312,7 +312,7 @@ export class WriteSizer extends Write {
     this.writeBigNumber(value);
   }
 
-  writeNullableJSON(value: JSON.Value | null): void {
+  writeOptionalJSON(value: JSON.Value | null): void {
     if (value === null) {
       this.writeNil();
       return;
@@ -321,7 +321,7 @@ export class WriteSizer extends Write {
     this.writeJSON(value);
   }
 
-  writeNullableArray<T>(
+  writeOptionalArray<T>(
     a: Array<T> | null,
     fn: (sizer: Write, item: T) => void
   ): void {
@@ -333,7 +333,7 @@ export class WriteSizer extends Write {
     this.writeArray(a, fn);
   }
 
-  writeNullableMap<K, V>(
+  writeOptionalMap<K, V>(
     m: Map<K, V> | null,
     key_fn: (sizer: Write, key: K) => void,
     value_fn: (sizer: Write, value: V) => void
@@ -346,7 +346,7 @@ export class WriteSizer extends Write {
     this.writeMap(m, key_fn, value_fn);
   }
 
-  writeNullableExtGenericMap<K, V>(
+  writeOptionalExtGenericMap<K, V>(
     m: Map<K, V> | null,
     key_fn: (sizer: Write, key: K) => void,
     value_fn: (sizer: Write, value: V) => void

--- a/packages/wasm/rs/src/msgpack/read.rs
+++ b/packages/wasm/rs/src/msgpack/read.rs
@@ -41,32 +41,32 @@ pub trait Read {
     where
         K: Eq + Hash + Ord;
 
-    fn read_nullable_bool(&mut self) -> Result<Option<bool>, DecodeError>;
-    fn read_nullable_i8(&mut self) -> Result<Option<i8>, DecodeError>;
-    fn read_nullable_i16(&mut self) -> Result<Option<i16>, DecodeError>;
-    fn read_nullable_i32(&mut self) -> Result<Option<i32>, DecodeError>;
-    fn read_nullable_u8(&mut self) -> Result<Option<u8>, DecodeError>;
-    fn read_nullable_u16(&mut self) -> Result<Option<u16>, DecodeError>;
-    fn read_nullable_u32(&mut self) -> Result<Option<u32>, DecodeError>;
-    fn read_nullable_f32(&mut self) -> Result<Option<f32>, DecodeError>;
-    fn read_nullable_f64(&mut self) -> Result<Option<f64>, DecodeError>;
-    fn read_nullable_string(&mut self) -> Result<Option<String>, DecodeError>;
-    fn read_nullable_bytes(&mut self) -> Result<Option<Vec<u8>>, DecodeError>;
-    fn read_nullable_bigint(&mut self) -> Result<Option<BigInt>, DecodeError>;
-    fn read_nullable_bignumber(&mut self) -> Result<Option<BigNumber>, DecodeError>;
-    fn read_nullable_json(&mut self) -> Result<Option<JSON::Value>, DecodeError>;
-    fn read_nullable_array<T>(
+    fn read_optional_bool(&mut self) -> Result<Option<bool>, DecodeError>;
+    fn read_optional_i8(&mut self) -> Result<Option<i8>, DecodeError>;
+    fn read_optional_i16(&mut self) -> Result<Option<i16>, DecodeError>;
+    fn read_optional_i32(&mut self) -> Result<Option<i32>, DecodeError>;
+    fn read_optional_u8(&mut self) -> Result<Option<u8>, DecodeError>;
+    fn read_optional_u16(&mut self) -> Result<Option<u16>, DecodeError>;
+    fn read_optional_u32(&mut self) -> Result<Option<u32>, DecodeError>;
+    fn read_optional_f32(&mut self) -> Result<Option<f32>, DecodeError>;
+    fn read_optional_f64(&mut self) -> Result<Option<f64>, DecodeError>;
+    fn read_optional_string(&mut self) -> Result<Option<String>, DecodeError>;
+    fn read_optional_bytes(&mut self) -> Result<Option<Vec<u8>>, DecodeError>;
+    fn read_optional_bigint(&mut self) -> Result<Option<BigInt>, DecodeError>;
+    fn read_optional_bignumber(&mut self) -> Result<Option<BigNumber>, DecodeError>;
+    fn read_optional_json(&mut self) -> Result<Option<JSON::Value>, DecodeError>;
+    fn read_optional_array<T>(
         &mut self,
         item_reader: impl FnMut(&mut Self) -> Result<T, DecodeError>,
     ) -> Result<Option<Vec<T>>, DecodeError>;
-    fn read_nullable_map<K, V>(
+    fn read_optional_map<K, V>(
         &mut self,
         key_reader: impl FnMut(&mut Self) -> Result<K, DecodeError>,
         val_reader: impl FnMut(&mut Self) -> Result<V, DecodeError>,
     ) -> Result<Option<BTreeMap<K, V>>, DecodeError>
     where
         K: Eq + Hash + Ord;
-    fn read_nullable_ext_generic_map<K, V>(
+    fn read_optional_ext_generic_map<K, V>(
         &mut self,
         key_reader: impl FnMut(&mut Self) -> Result<K, DecodeError>,
         val_reader: impl FnMut(&mut Self) -> Result<V, DecodeError>,

--- a/packages/wasm/rs/src/msgpack/read_decoder.rs
+++ b/packages/wasm/rs/src/msgpack/read_decoder.rs
@@ -497,7 +497,7 @@ impl Read for ReadDecoder {
         self.read_map(key_reader, val_reader)
     }
 
-    fn read_nullable_bool(&mut self) -> Result<Option<bool>, DecodeError> {
+    fn read_optional_bool(&mut self) -> Result<Option<bool>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -508,7 +508,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_i8(&mut self) -> Result<Option<i8>, DecodeError> {
+    fn read_optional_i8(&mut self) -> Result<Option<i8>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -519,7 +519,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_i16(&mut self) -> Result<Option<i16>, DecodeError> {
+    fn read_optional_i16(&mut self) -> Result<Option<i16>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -530,7 +530,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_i32(&mut self) -> Result<Option<i32>, DecodeError> {
+    fn read_optional_i32(&mut self) -> Result<Option<i32>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -541,7 +541,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_u8(&mut self) -> Result<Option<u8>, DecodeError> {
+    fn read_optional_u8(&mut self) -> Result<Option<u8>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -552,7 +552,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_u16(&mut self) -> Result<Option<u16>, DecodeError> {
+    fn read_optional_u16(&mut self) -> Result<Option<u16>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -563,7 +563,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_u32(&mut self) -> Result<Option<u32>, DecodeError> {
+    fn read_optional_u32(&mut self) -> Result<Option<u32>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -574,7 +574,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_f32(&mut self) -> Result<Option<f32>, DecodeError> {
+    fn read_optional_f32(&mut self) -> Result<Option<f32>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -585,7 +585,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_f64(&mut self) -> Result<Option<f64>, DecodeError> {
+    fn read_optional_f64(&mut self) -> Result<Option<f64>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -596,7 +596,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_string(&mut self) -> Result<Option<String>, DecodeError> {
+    fn read_optional_string(&mut self) -> Result<Option<String>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -607,7 +607,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_bytes(&mut self) -> Result<Option<Vec<u8>>, DecodeError> {
+    fn read_optional_bytes(&mut self) -> Result<Option<Vec<u8>>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -618,7 +618,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_bigint(&mut self) -> Result<Option<BigInt>, DecodeError> {
+    fn read_optional_bigint(&mut self) -> Result<Option<BigInt>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -629,7 +629,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_bignumber(&mut self) -> Result<Option<BigNumber>, DecodeError> {
+    fn read_optional_bignumber(&mut self) -> Result<Option<BigNumber>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -640,7 +640,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_json(&mut self) -> Result<Option<JSON::Value>, DecodeError> {
+    fn read_optional_json(&mut self) -> Result<Option<JSON::Value>, DecodeError> {
         if self.is_next_nil()? {
             Ok(None)
         } else {
@@ -651,7 +651,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_array<T>(
+    fn read_optional_array<T>(
         &mut self,
         item_reader: impl FnMut(&mut Self) -> Result<T, DecodeError>,
     ) -> Result<Option<Vec<T>>, DecodeError> {
@@ -665,7 +665,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_map<K, V>(
+    fn read_optional_map<K, V>(
         &mut self,
         key_reader: impl FnMut(&mut Self) -> Result<K, DecodeError>,
         val_reader: impl FnMut(&mut Self) -> Result<V, DecodeError>,
@@ -683,7 +683,7 @@ impl Read for ReadDecoder {
         }
     }
 
-    fn read_nullable_ext_generic_map<K, V>(
+    fn read_optional_ext_generic_map<K, V>(
         &mut self,
         key_reader: impl FnMut(&mut Self) -> Result<K, DecodeError>,
         val_reader: impl FnMut(&mut Self) -> Result<V, DecodeError>,

--- a/packages/wasm/rs/src/msgpack/write.rs
+++ b/packages/wasm/rs/src/msgpack/write.rs
@@ -45,26 +45,26 @@ pub trait Write {
     where
         K: Clone + Eq + Hash + Ord;
 
-    fn write_nullable_bool(&mut self, value: &Option<bool>) -> Result<(), EncodeError>;
-    fn write_nullable_i8(&mut self, value: &Option<i8>) -> Result<(), EncodeError>;
-    fn write_nullable_i16(&mut self, value: &Option<i16>) -> Result<(), EncodeError>;
-    fn write_nullable_i32(&mut self, value: &Option<i32>) -> Result<(), EncodeError>;
-    fn write_nullable_u8(&mut self, value: &Option<u8>) -> Result<(), EncodeError>;
-    fn write_nullable_u16(&mut self, value: &Option<u16>) -> Result<(), EncodeError>;
-    fn write_nullable_u32(&mut self, value: &Option<u32>) -> Result<(), EncodeError>;
-    fn write_nullable_f32(&mut self, value: &Option<f32>) -> Result<(), EncodeError>;
-    fn write_nullable_f64(&mut self, value: &Option<f64>) -> Result<(), EncodeError>;
-    fn write_nullable_string(&mut self, value: &Option<String>) -> Result<(), EncodeError>;
-    fn write_nullable_bytes(&mut self, value: &Option<Vec<u8>>) -> Result<(), EncodeError>;
-    fn write_nullable_bigint(&mut self, value: &Option<BigInt>) -> Result<(), EncodeError>;
-    fn write_nullable_bignumber(&mut self, value: &Option<BigNumber>) -> Result<(), EncodeError>;
-    fn write_nullable_json(&mut self, value: &Option<JSON::Value>) -> Result<(), EncodeError>;
-    fn write_nullable_array<T: Clone>(
+    fn write_optional_bool(&mut self, value: &Option<bool>) -> Result<(), EncodeError>;
+    fn write_optional_i8(&mut self, value: &Option<i8>) -> Result<(), EncodeError>;
+    fn write_optional_i16(&mut self, value: &Option<i16>) -> Result<(), EncodeError>;
+    fn write_optional_i32(&mut self, value: &Option<i32>) -> Result<(), EncodeError>;
+    fn write_optional_u8(&mut self, value: &Option<u8>) -> Result<(), EncodeError>;
+    fn write_optional_u16(&mut self, value: &Option<u16>) -> Result<(), EncodeError>;
+    fn write_optional_u32(&mut self, value: &Option<u32>) -> Result<(), EncodeError>;
+    fn write_optional_f32(&mut self, value: &Option<f32>) -> Result<(), EncodeError>;
+    fn write_optional_f64(&mut self, value: &Option<f64>) -> Result<(), EncodeError>;
+    fn write_optional_string(&mut self, value: &Option<String>) -> Result<(), EncodeError>;
+    fn write_optional_bytes(&mut self, value: &Option<Vec<u8>>) -> Result<(), EncodeError>;
+    fn write_optional_bigint(&mut self, value: &Option<BigInt>) -> Result<(), EncodeError>;
+    fn write_optional_bignumber(&mut self, value: &Option<BigNumber>) -> Result<(), EncodeError>;
+    fn write_optional_json(&mut self, value: &Option<JSON::Value>) -> Result<(), EncodeError>;
+    fn write_optional_array<T: Clone>(
         &mut self,
         opt_array: &Option<Vec<T>>,
         item_writer: impl FnMut(&mut Self, &T) -> Result<(), EncodeError>,
     ) -> Result<(), EncodeError>;
-    fn write_nullable_map<K, V: Clone>(
+    fn write_optional_map<K, V: Clone>(
         &mut self,
         opt_map: &Option<BTreeMap<K, V>>,
         key_writer: impl FnMut(&mut Self, &K) -> Result<(), EncodeError>,
@@ -72,7 +72,7 @@ pub trait Write {
     ) -> Result<(), EncodeError>
     where
         K: Clone + Eq + Hash + Ord;
-    fn write_nullable_ext_generic_map<K, V: Clone>(
+    fn write_optional_ext_generic_map<K, V: Clone>(
         &mut self,
         opt_map: &Option<BTreeMap<K, V>>,
         key_writer: impl FnMut(&mut Self, &K) -> Result<(), EncodeError>,

--- a/packages/wasm/rs/src/msgpack/write_encoder.rs
+++ b/packages/wasm/rs/src/msgpack/write_encoder.rs
@@ -308,105 +308,105 @@ impl Write for WriteEncoder {
         Ok(())
     }
 
-    fn write_nullable_bool(&mut self, value: &Option<bool>) -> Result<(), EncodeError> {
+    fn write_optional_bool(&mut self, value: &Option<bool>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(v) => Write::write_bool(self, v),
         }
     }
 
-    fn write_nullable_i8(&mut self, value: &Option<i8>) -> Result<(), EncodeError> {
+    fn write_optional_i8(&mut self, value: &Option<i8>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(v) => Write::write_i8(self, v),
         }
     }
 
-    fn write_nullable_i16(&mut self, value: &Option<i16>) -> Result<(), EncodeError> {
+    fn write_optional_i16(&mut self, value: &Option<i16>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(v) => Write::write_i16(self, v),
         }
     }
 
-    fn write_nullable_i32(&mut self, value: &Option<i32>) -> Result<(), EncodeError> {
+    fn write_optional_i32(&mut self, value: &Option<i32>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(v) => Write::write_i32(self, v),
         }
     }
 
-    fn write_nullable_u8(&mut self, value: &Option<u8>) -> Result<(), EncodeError> {
+    fn write_optional_u8(&mut self, value: &Option<u8>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(v) => Write::write_u8(self, v),
         }
     }
 
-    fn write_nullable_u16(&mut self, value: &Option<u16>) -> Result<(), EncodeError> {
+    fn write_optional_u16(&mut self, value: &Option<u16>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(v) => Write::write_u16(self, v),
         }
     }
 
-    fn write_nullable_u32(&mut self, value: &Option<u32>) -> Result<(), EncodeError> {
+    fn write_optional_u32(&mut self, value: &Option<u32>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(v) => Write::write_u32(self, v),
         }
     }
 
-    fn write_nullable_f32(&mut self, value: &Option<f32>) -> Result<(), EncodeError> {
+    fn write_optional_f32(&mut self, value: &Option<f32>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(v) => Write::write_f32(self, v),
         }
     }
 
-    fn write_nullable_f64(&mut self, value: &Option<f64>) -> Result<(), EncodeError> {
+    fn write_optional_f64(&mut self, value: &Option<f64>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(v) => Write::write_f64(self, v),
         }
     }
 
-    fn write_nullable_string(&mut self, value: &Option<String>) -> Result<(), EncodeError> {
+    fn write_optional_string(&mut self, value: &Option<String>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(s) => Write::write_string(self, s),
         }
     }
 
-    fn write_nullable_bytes(&mut self, value: &Option<Vec<u8>>) -> Result<(), EncodeError> {
+    fn write_optional_bytes(&mut self, value: &Option<Vec<u8>>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(bytes) => Write::write_bytes(self, bytes),
         }
     }
 
-    fn write_nullable_bigint(&mut self, value: &Option<BigInt>) -> Result<(), EncodeError> {
+    fn write_optional_bigint(&mut self, value: &Option<BigInt>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(bigint) => Write::write_bigint(self, bigint),
         }
     }
 
-    fn write_nullable_bignumber(&mut self, value: &Option<BigNumber>) -> Result<(), EncodeError> {
+    fn write_optional_bignumber(&mut self, value: &Option<BigNumber>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(bignumber) => Write::write_bignumber(self, bignumber)
         }
     }
 
-    fn write_nullable_json(&mut self, value: &Option<JSON::Value>) -> Result<(), EncodeError> {
+    fn write_optional_json(&mut self, value: &Option<JSON::Value>) -> Result<(), EncodeError> {
         match value {
             None => Write::write_nil(self),
             Some(json) => Write::write_json(self, json),
         }
     }
 
-    fn write_nullable_array<T: Clone>(
+    fn write_optional_array<T: Clone>(
         &mut self,
         opt_array: &Option<Vec<T>>,
         item_writer: impl FnMut(&mut Self, &T) -> Result<(), EncodeError>,
@@ -417,7 +417,7 @@ impl Write for WriteEncoder {
         }
     }
 
-    fn write_nullable_map<K, V: Clone>(
+    fn write_optional_map<K, V: Clone>(
         &mut self,
         opt_map: &Option<BTreeMap<K, V>>,
         key_writer: impl FnMut(&mut Self, &K) -> Result<(), EncodeError>,
@@ -432,7 +432,7 @@ impl Write for WriteEncoder {
         }
     }
 
-    fn write_nullable_ext_generic_map<K, V: Clone>(
+    fn write_optional_ext_generic_map<K, V: Clone>(
         &mut self,
         opt_map: &Option<BTreeMap<K, V>>,
         key_writer: impl FnMut(&mut Self, &K) -> Result<(), EncodeError>,

--- a/packages/wasm/rs/tests/msgpack_spec.rs
+++ b/packages/wasm/rs/tests/msgpack_spec.rs
@@ -91,9 +91,9 @@ fn serialize_sanity<W: Write>(writer: &mut W, sanity: &mut Sanity) -> Result<(),
     writer.write_string("boolean")?;
     writer.write_bool(&sanity.boolean)?;
     // writer.write_string("opt_uint32")?;
-    // writer.write_nullable_u32(&sanity.opt_uint32)?;
+    // writer.write_optional_u32(&sanity.opt_uint32)?;
     // writer.write_string("opt_bool")?;
-    // writer.write_nullable_bool(&sanity.opt_bool)?;
+    // writer.write_optional_bool(&sanity.opt_bool)?;
     // writer.write_string("float32")?;
     // writer.write_f32(sanity.float32)?;
     // writer.write_string("float64")?;
@@ -143,7 +143,7 @@ fn deserialize_sanity<R: Read>(reader: &mut R, sanity: &mut Sanity) -> Result<Sa
 
         match field.as_str() {
             "nil" => {
-                sanity.nil = reader.read_nullable_string()?;
+                sanity.nil = reader.read_optional_string()?;
             }
             "int8" => {
                 sanity.int8 = reader.read_i8()?;
@@ -167,10 +167,10 @@ fn deserialize_sanity<R: Read>(reader: &mut R, sanity: &mut Sanity) -> Result<Sa
                 sanity.boolean = reader.read_bool()?;
             }
             // 		"opt_uint32" => {
-            // 			sanity.opt_uint32 = reader.read_nullable_u32()?;
+            // 			sanity.opt_uint32 = reader.read_optional_u32()?;
             // 		},
             // 		"opt_bool" => {
-            // 			sanity.opt_bool = reader.read_nullable_bool()?;
+            // 			sanity.opt_bool = reader.read_optional_bool()?;
             // 		},
             // 		"float32" => {
             // 			sanity.float32 = reader.read_f32()?;
@@ -228,7 +228,7 @@ fn deserialize_with_overflow<R: Read>(
 
         match field.as_str() {
             "nil" => {
-                sanity.nil = reader.read_nullable_string()?;
+                sanity.nil = reader.read_optional_string()?;
             }
             "int8" => {
                 sanity.int8 = reader.read_i16()? as i8;
@@ -252,10 +252,10 @@ fn deserialize_with_overflow<R: Read>(
                 sanity.boolean = reader.read_bool()?;
             }
             // 		"opt_uint32" => {
-            // 			sanity.opt_uint32 = reader.read_nullable_u32()?;
+            // 			sanity.opt_uint32 = reader.read_optional_u32()?;
             // 		},
             // 		"opt_bool" => {
-            // 			sanity.opt_bool = reader.read_nullable_bool()?;
+            // 			sanity.opt_bool = reader.read_optional_bool()?;
             // 		},
             // 		"float32" => {
             // 			sanity.float32 = reader.read_f64()? as f32;
@@ -299,7 +299,7 @@ fn deserialize_with_invalid_types<R: Read>(
 
         match field.as_str() {
             "nil" => {
-                sanity.nil = reader.read_nullable_string()?;
+                sanity.nil = reader.read_optional_string()?;
             }
             "int8" => {
                 sanity.int8 = reader.read_i8()?;
@@ -323,10 +323,10 @@ fn deserialize_with_invalid_types<R: Read>(
                 sanity.boolean = reader.read_bool()?;
             }
             // 		"opt_uint32" => {
-            // 			sanity.opt_uint32 = reader.read_nullable_u32()?;
+            // 			sanity.opt_uint32 = reader.read_optional_u32()?;
             // 		},
             // 		"opt_bool" => {
-            // 			sanity.opt_bool = reader.read_nullable_bool()?;
+            // 			sanity.opt_bool = reader.read_optional_bool()?;
             // 		},
             // 		"float32" => {
             // 			sanity.float32 = reader.read_f32()?;


### PR DESCRIPTION
Values that are not guaranteed to exist can be called Nullable, if empty values equal null, or Optional, if empty values still encapsulate the original data type. 
At first assemblyscript msgpack implementation used nullable and the Nullable container. Then rust msgpack kept the same naming convention, even though it used Option types. Now that assemblyscript [also uses Option types](https://github.com/polywrap/monorepo/pull/944), the naming should be changed.