### PR TITLE
fix typos in comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,7 @@ module.exports = {
             ],
             format: ["camelCase"], leadingUnderscore: "allow"
           },
-          //wrap host methods doesn"t satisfy neither camel or snake
+          //wrap host methods doesn't satisfy neither camel or snake
           {selector: ["objectLiteralMethod", "typeMethod"], filter: {regex: "^_wrap_.*", match: true}, format: null},
           //variable must be in camel or upper case
           {selector: "variable", format: ["camelCase", "UPPER_CASE"], leadingUnderscore: "allow"},

--- a/packages/js/core/src/algorithms/combine-paths.ts
+++ b/packages/js/core/src/algorithms/combine-paths.ts
@@ -1,14 +1,14 @@
 export const combinePaths = (a: string, b: string): string => {
-  // Normalize all path seperators
+  // Normalize all path separators
   a = a.replace(/\\/g, "/");
   b = b.replace(/\\/g, "/");
 
-  // Append a seperator if one doesn't exist
+  // Append a separator if one doesn't exist
   if (a[a.length - 1] !== "/") {
     a += "/";
   }
 
-  // Remove any leading seperators from
+  // Remove any leading separators from
   while (b[0] === "/" || b[0] === ".") {
     b = b.substring(1);
   }

--- a/packages/js/os/src/file.ts
+++ b/packages/js/os/src/file.ts
@@ -20,6 +20,6 @@ export function normalizeLineEndings(
   return data.replace(/\r\n|\r|\n/g, eol);
 }
 
-export function normalizePath(data: string, seperator = "/"): string {
-  return data.replace(/\\|\//g, seperator);
+export function normalizePath(data: string, separator = "/"): string {
+  return data.replace(/\\|\//g, separator);
 }

--- a/packages/schema/parse/src/__tests__/validate-types.spec.ts
+++ b/packages/schema/parse/src/__tests__/validate-types.spec.ts
@@ -329,7 +329,7 @@ describe("Polywrap Schema Type Validation", () => {
     //Should allow circular references on nullable fields
     expect(exec(circularTypes6)).not.toThrow()
 
-    //Should allow recursive referece on nullable fields
+    //Should allow recursive reference on nullable fields
     expect(exec(circularTypes7)).not.toThrow()
 
     //Should allow array of recursive references

--- a/packages/wasm/as/assembly/msgpack/ReadDecoder.ts
+++ b/packages/wasm/as/assembly/msgpack/ReadDecoder.ts
@@ -346,7 +346,7 @@ export class ReadDecoder extends Read {
         );
     }
 
-    // Consule the leadByte
+    // Consume the leadByte
     this._view.getUint8();
 
     // Get the extension type


### PR DESCRIPTION
As I was walking through the codebase, I noticed a couple typos.