### PR TITLE
Remove `wrap-invoke` Rust Feature

### DIFF
--- a/packages/cli/src/lib/defaults/build-images/wasm/rust/Dockerfile.mustache
+++ b/packages/cli/src/lib/defaults/build-images/wasm/rust/Dockerfile.mustache
@@ -64,12 +64,6 @@ RUN rm -rf {{dir}}/Cargo.lock
 # Ensure the Wasm module is configured to use imported memory
 ENV RUSTFLAGS="-C link-arg=-z -C link-arg=stack-size=65536 -C link-arg=--import-memory"
 
-# Enable the wrap-invoke feature for the {{dir}} module
-RUN toml set ./{{dir}}/Cargo.toml features.wrap-invoke [] > ./{{dir}}/Cargo-local.toml && \
-    rm -rf ./{{dir}}/Cargo.toml && \
-    mv ./{{dir}}/Cargo-local.toml ./{{dir}}/Cargo.toml && \
-    true
-
 # Cleanup an artifact left by the toml CLI program ("[]" -> [])
 RUN sed -i 's/"\[\]"/\[\]/g' ./{{dir}}/Cargo.toml
 
@@ -84,7 +78,7 @@ RUN sed -i 's/"\[cdylib,rlib\]"/\["cdylib","rlib"\]/g' ./{{dir}}/Cargo.toml
 
 # Build the module at {{dir}}
 RUN cargo +nightly build --manifest-path ./{{dir}}/Cargo.toml \
-    --target wasm32-unknown-unknown --release --features "wrap-invoke"
+    --target wasm32-unknown-unknown --release
 
 # Make the build directory
 RUN rm -rf ./build

--- a/packages/schema/bind/src/bindings/rust/wasm-rs/templates/entry-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/wasm-rs/templates/entry-rs.mustache
@@ -13,7 +13,6 @@ use polywrap_wasm_rs::{
     InvokeArgs,
 };
 
-#[cfg(feature = "wrap-invoke")]
 #[no_mangle]
 pub extern "C" fn _wrap_invoke(method_size: u32, args_size: u32) -> bool {
     // Ensure the abort handler is properly setup

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/entry.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/entry.rs
@@ -8,7 +8,6 @@ use polywrap_wasm_rs::{
     InvokeArgs,
 };
 
-#[cfg(feature = "wrap-invoke")]
 #[no_mangle]
 pub extern "C" fn _wrap_invoke(method_size: u32, args_size: u32) -> bool {
     // Ensure the abort handler is properly setup


### PR DESCRIPTION
This feature used to be necessary when we supported importing code from different modules (i.e. query -> mutation), but is no longer needed.