### PR TITLE
Update wasm/rust Dockerfile

### DIFF
--- a/packages/cli/src/lib/defaults/build-images/wasm/rust/Dockerfile.mustache
+++ b/packages/cli/src/lib/defaults/build-images/wasm/rust/Dockerfile.mustache
@@ -1,4 +1,4 @@
-FROM rustlang/rust:nightly-slim as base
+FROM rust:1.60.0 as base
 
 # Install the wasm32 rust build target
 RUN rustup target add wasm32-unknown-unknown
@@ -7,7 +7,7 @@ WORKDIR /build-deps
 
 # Install curl
 RUN apt-get update
-RUN apt-get -y install curl
+RUN apt-get -y install curl clang llvm build-essential
 
 # Install wasm-opt
 RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-linux.tar.gz | tar -xz \
@@ -16,10 +16,13 @@ RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_10
     && rm -rf binary-version_101
 
 # Install the toml-cli
-RUN cargo install toml-cli
+RUN cargo install -f toml-cli
 
 # Install wasm-snip
-RUN cargo install wasm-snip
+RUN cargo install -f wasm-snip
+
+# Install wasm-bindgen
+RUN cargo install -f wasm-bindgen-cli
 
 {{#polywrap_linked_packages.length}}
 WORKDIR /linked-packages
@@ -55,38 +58,50 @@ RUN PACKAGE_NAME={{name}}; \
     {{/polywrap_module}}
     true
 {{/polywrap_linked_packages}}
+
 {{/polywrap_linked_packages.length}}
 
-# Remove any Cargo.lock files
 {{#polywrap_module}}
+# Remove any Cargo.lock files
 RUN rm -rf {{dir}}/Cargo.lock
 
 # Ensure the Wasm module is configured to use imported memory
 ENV RUSTFLAGS="-C link-arg=-z -C link-arg=stack-size=65536 -C link-arg=--import-memory"
 
-# Cleanup an artifact left by the toml CLI program ("[]" -> [])
-RUN sed -i 's/"\[\]"/\[\]/g' ./{{dir}}/Cargo.toml
-
 # Ensure the module at {{dir}} has the crate-type = ["cdylib"]
-RUN toml set ./{{dir}}/Cargo.toml lib.crate-type ["cdylib","rlib"] > ./{{dir}}/Cargo-local.toml && \
+RUN toml set ./{{dir}}/Cargo.toml lib.crate-type ["cdylib"] > ./{{dir}}/Cargo-local.toml && \
     rm -rf ./{{dir}}/Cargo.toml && \
     mv ./{{dir}}/Cargo-local.toml ./{{dir}}/Cargo.toml && \
     true
 
-# Clean up artifacts left by the toml CLI program ("["cdylib", "rlib"]" -> ["cdylib", "rlib"])
-RUN sed -i 's/"\[cdylib,rlib\]"/\["cdylib","rlib"\]/g' ./{{dir}}/Cargo.toml
+# Clean up artifacts left by the toml CLI program ("["cdylib"]" -> ["cdylib"])
+RUN sed -i 's/"\[cdylib\]"/\["cdylib"\]/g' ./{{dir}}/Cargo.toml
 
-# Build the module at {{dir}}
-RUN cargo +nightly build --manifest-path ./{{dir}}/Cargo.toml \
-    --target wasm32-unknown-unknown --release
+# Ensure the package name = "module"
+RUN toml set ./{{dir}}/Cargo.toml package.name "module" > ./{{dir}}/Cargo-local.toml && \
+    rm -rf ./{{dir}}/Cargo.toml && \
+    mv ./{{dir}}/Cargo-local.toml ./{{dir}}/Cargo.toml && \
+    true
 
 # Make the build directory
 RUN rm -rf ./build
 RUN mkdir ./build
 
+# Build the module at {{dir}}
+RUN cargo build --manifest-path ./{{dir}}/Cargo.toml \
+    --target wasm32-unknown-unknown --release
+
+# Enable the "WASM_INTERFACE_TYPES" feature, which will remove the __wbindgen_throw import.
+# See: https://github.com/rustwasm/wasm-bindgen/blob/7f4663b70bd492278bf0e7bba4eeddb3d840c868/crates/cli-support/src/lib.rs#L397-L403
+ENV WASM_INTERFACE_TYPES=1
+
+# Run wasm-bindgen over the module, replacing all placeholder __wbindgen_... imports
+RUN wasm-bindgen ./{{dir}}/target/wasm32-unknown-unknown/release/module.wasm --out-dir ./build --out-name bg_module.wasm
+
+RUN wasm-snip ./build/bg_module.wasm -o ./build/snipped_module.wasm && \
+    rm -rf ./build/bg_module.wasm
+
 # Use wasm-opt to perform the "asyncify" post-processing step over all modules
-RUN WASM_MODULE=$(ls ./{{dir}}/target/wasm32-unknown-unknown/release/*.wasm); \
-    wasm-snip $WASM_MODULE -o ./build/snipped_{{name}}.wasm && \
-    wasm-opt --asyncify -Os ./build/snipped_{{name}}.wasm -o ./build/{{name}}.wasm && \
-    rm -rf ./build/snipped_{{name}}.wasm
+RUN wasm-opt --asyncify -Os ./build/snipped_module.wasm -o ./build/module.wasm && \
+    rm -rf ./build/snipped_module.wasm
 {{/polywrap_module}}


### PR DESCRIPTION
Updates include:
- Adding commonly used system dependencies: `clang`, `llvm`, `build-essentials`
- Added steps to remove any `wasm-bindgen` imports that may have been injected (more details [here](https://github.com/polywrap/integrations/issues/71#issuecomment-1168442943))
- Created a more consistent crate naming convention, so that artifacts in the target folder are consistent.