### PR TITLE
fix: remove IpfsResolverPlugin's config, not needed

### DIFF
--- a/packages/js/client/src/default-client-config.ts
+++ b/packages/js/client/src/default-client-config.ts
@@ -88,10 +88,7 @@ export const getDefaultClientConfig = Tracer.traceFunc(
         },
         {
           uri: new Uri("wrap://ens/ipfs-resolver.polywrap.eth"),
-          plugin: ipfsResolverPlugin({
-            provider: defaultIpfsProviders[0],
-            fallbackProviders: defaultIpfsProviders.slice(1),
-          }),
+          plugin: ipfsResolverPlugin({}),
         },
       ],
       interfaces: [

--- a/packages/js/plugins/uri-resolvers/ipfs-resolver/src/__tests__/e2e.spec.ts
+++ b/packages/js/plugins/uri-resolvers/ipfs-resolver/src/__tests__/e2e.spec.ts
@@ -39,9 +39,7 @@ describe("IPFS Plugin", () => {
         },
         {
           uri: "wrap://ens/ipfs-uri-resolver.polywrap.eth",
-          plugin: ipfsResolverPlugin({
-            provider: providers.ipfs
-          })
+          plugin: ipfsResolverPlugin({})
         }
       ]
     });

--- a/packages/js/plugins/uri-resolvers/ipfs-resolver/src/index.ts
+++ b/packages/js/plugins/uri-resolvers/ipfs-resolver/src/index.ts
@@ -14,12 +14,9 @@ import { PluginFactory } from "@polywrap/core-js";
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const isIPFS = require("is-ipfs");
 
-export interface IpfsResolverPluginConfig extends Record<string, unknown> {
-  provider: string;
-  fallbackProviders?: string[];
-}
+type NoConfig = Record<string, never>;
 
-export class IpfsResolverPlugin extends Module<IpfsResolverPluginConfig> {
+export class IpfsResolverPlugin extends Module<NoConfig> {
   // uri-resolver.core.polywrap.eth
   public async tryResolveUri(
     args: Args_tryResolveUri,
@@ -106,11 +103,9 @@ export class IpfsResolverPlugin extends Module<IpfsResolverPluginConfig> {
   }
 }
 
-export const ipfsResolverPlugin: PluginFactory<IpfsResolverPluginConfig> = (
-  opts: IpfsResolverPluginConfig
-) => {
+export const ipfsResolverPlugin: PluginFactory<NoConfig> = () => {
   return {
-    factory: () => new IpfsResolverPlugin(opts),
+    factory: () => new IpfsResolverPlugin({}),
     manifest,
   };
 };

--- a/packages/test-cases/cases/cli/wasm/run/workflows/config.ts
+++ b/packages/test-cases/cases/cli/wasm/run/workflows/config.ts
@@ -42,9 +42,7 @@ function getPlugins(
       },
       {
         uri: "wrap://ens/ipfs-resolver.polywrap.eth",
-        plugin: ipfsResolverPlugin({
-          provider: ipfs,
-        }),
+        plugin: ipfsResolverPlugin({}),
       },
       {
         uri: "wrap://ens/ens-resolver.polywrap.eth",


### PR DESCRIPTION
The `IpfsResolverPlugin's` configuration was not being utilized, so I went ahead and removed it to avoid confusion for the user. All IPFS providers are configured through the `IpfsPlugin`.