### PR TITLE
increased minor version of as-bignumber for bug fix

### DIFF
--- a/packages/wasm/as/package.json
+++ b/packages/wasm/as/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@web3api/assemblyscript-json": "1.2.0",
     "as-bigint": "0.5.3",
-    "as-bignumber": "0.2.0",
+    "as-bignumber": "0.2.1",
     "as-container": "0.6.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4590,10 +4590,10 @@ as-bigint@0.5.3, as-bigint@^0.5.1:
   resolved "https://registry.yarnpkg.com/as-bigint/-/as-bigint-0.5.3.tgz#a0647d0b7ce835077aca33115e71eb26a83df8be"
   integrity sha512-tg9iTO/vPeovOM5CSk1WxYcsfBd/cd3twhBW5PrpcGUfiSEXlPB69eOxFKvSbZnpuDxBAyQ4YBgEkfnYL89Czw==
 
-as-bignumber@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/as-bignumber/-/as-bignumber-0.2.0.tgz#13feb2e5054c8a2d557618de2e507af39cfb7532"
-  integrity sha512-Y12DyJoO1fqzc/KdosQIw/ri7NgHPZNIKoIaQ775sh/vZ/dlg50tu0GQP5npu0LJdSXzpuzqKkOfAPhdhh07QA==
+as-bignumber@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/as-bignumber/-/as-bignumber-0.2.1.tgz#6479caca7f24f784b10b3d2633cde457ef9cbc22"
+  integrity sha512-udKOlFYKSZyuHK7upTczRR8lcXkyPS0DR6NOtP+c3bhM4B2B0VqMBTzqa0hdYG4Zss94zA6UmqpjreEbzNUo4g==
   dependencies:
     as-bigint "^0.5.1"
 


### PR DESCRIPTION
Increased minor version of as-bignumber. The new version has a bug fix for the toFixed method. The bug caused toFixed to print numbers incorrectly when a decimal number was rounded to an integer.