### PR TITLE
Write deploy output to file

### DIFF
--- a/packages/cli/lang/en.json
+++ b/packages/cli/lang/en.json
@@ -60,7 +60,7 @@
   "commands_deploy_options_o_string": "string",
   "commands_deploy_options_h": "Show usage information",
   "commands_deploy_options_m": "Path to the Polywrap Deploy manifest file (default: {default})",
-  "commands_deploy_options_o": "Output file path for the workflow result",
+  "commands_deploy_options_o": "Output file path for the deploy result",
   "commands_deploy_options_n": "Name of the deployment to execute",
   "commands_deploy_options_c": "Argument for deployment's publish step, in case deploy step is absent",
   "commands_deploy_options_v": "Verbose output (default: false)",

--- a/packages/cli/lang/en.json
+++ b/packages/cli/lang/en.json
@@ -60,6 +60,7 @@
   "commands_deploy_options_o_string": "string",
   "commands_deploy_options_h": "Show usage information",
   "commands_deploy_options_m": "Path to the Polywrap Deploy manifest file (default: {default})",
+  "commands_deploy_options_o": "Output file path for the workflow result",
   "commands_deploy_options_n": "Name of the deployment to execute",
   "commands_deploy_options_c": "Argument for deployment's publish step, in case deploy step is absent",
   "commands_deploy_options_v": "Verbose output (default: false)",

--- a/packages/cli/lang/es.json
+++ b/packages/cli/lang/es.json
@@ -60,6 +60,7 @@
   "commands_deploy_options_o_string": "string",
   "commands_deploy_options_h": "Show usage information",
   "commands_deploy_options_m": "Path to the Polywrap Deploy manifest file (default: {default})",
+  "commands_deploy_options_o": "Output file path for the deploy result",
   "commands_deploy_options_n": "Name of the deployment to execute",
   "commands_deploy_options_c": "Argument for deployment's publish step, in case deploy step is absent",
   "commands_deploy_options_v": "Verbose output (default: false)",

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -41,7 +41,7 @@ export const deploy: Command = {
       )
       .option(
         `-o, --output-file <${pathStr}>`,
-        `${intlMsg.commands_deploy_options_o}`
+        `${intlMsg.commands_deploy_options_o()}`
       )
       .option(`-v, --verbose`, `${intlMsg.commands_deploy_options_v()}`)
       .action(async (options) => {


### PR DESCRIPTION
Taking inspiration from the workflows `run` command, this PR aims to enable the possibility of writing the result of the `deploy` command to a file, that could be a `yaml` or `json` file.

The output follows the following structure:

```typescript
interface Output {
  id: string;
  name: string;
  input: {
    uri: string;
    config: unknown;
  };
  result: string;
}[]
```

Where the `id` is, similarly to the workflows output, the name of the step preceded by all of its previous stage's names (of the same deployment chain). Example:

`polywrap.deploy.yaml`:
```yaml
format: 0.1.0
stages:
  ipfs_deploy:
    package: ipfs
    uri: fs/./build
  from_deploy:
    package: ens
    depends_on: ipfs_deploy
    config:
      domainName: test1.eth
      provider: 'http://localhost:8545'
      ensRegistryAddress: 0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab
  from_deploy2:
    package: ens
    depends_on: ipfs_deploy
    config:
      domainName: test2.eth
      provider: 'http://localhost:8545'
      ensRegistryAddress: 0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab
  from_uri:
    package: ens
    uri: ipfs/QmVdDR6QtigTt38Xwpj2Ki73X1AyZn5WRCreBCJq1CEtpF
    config:
      domainName: test3.eth
      provider: 'http://localhost:8545'
      ensRegistryAddress: 0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab
```

Results in:

`output.json`:

```json
[
   {
      "id":"ipfs_deploy",
      "name":"ipfs_deploy",
      "input":{
         "uri":"wrap://fs/./build"
      },
      "result":"wrap://ipfs/QmRkysP47QawrzfyDSgbaukryjcXMxFnJgqswaeKBcziYF"
   },
   {
      "id":"ipfs_deploy.from_deploy",
      "name":"from_deploy",
      "input":{
         "uri":"wrap://ipfs/QmRkysP47QawrzfyDSgbaukryjcXMxFnJgqswaeKBcziYF",
         "config":{
            "domainName":"test1.eth",
            "provider":"http://localhost:8545",
            "ensRegistryAddress":"0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab"
         }
      },
      "result":"wrap://ens/test1.eth"
   },
   {
      "id":"ipfs_deploy.from_deploy2",
      "name":"from_deploy2",
      "input":{
         "uri":"wrap://ipfs/QmRkysP47QawrzfyDSgbaukryjcXMxFnJgqswaeKBcziYF",
         "config":{
            "domainName":"test2.eth",
            "provider":"http://localhost:8545",
            "ensRegistryAddress":"0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab"
         }
      },
      "result":"wrap://ens/test2.eth"
   },
   {
      "id":"from_uri",
      "name":"from_uri",
      "input":{
         "uri":"wrap://ipfs/QmVdDR6QtigTt38Xwpj2Ki73X1AyZn5WRCreBCJq1CEtpF",
         "config":{
            "domainName":"test3.eth",
            "provider":"http://localhost:8545",
            "ensRegistryAddress":"0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab"
         }
      },
      "result":"wrap://ens/test3.eth"
   }
]
```