### PR TITLE
fix: ethereum plugin now tries to obtain signer from provider if signer.connect fails

### DIFF
--- a/packages/js/plugins/ethereum/src/Connection.ts
+++ b/packages/js/plugins/ethereum/src/Connection.ts
@@ -134,7 +134,11 @@ export class Connection {
       try {
         this._config.signer = signer.connect(this._client);
       } catch (e) {
-        this._config.signer = this._client.getSigner();
+        if (this._client.getSigner) {
+          this._config.signer = this._client.getSigner();
+        } else {
+          throw e;
+        }
       }
     } else {
       this._config.signer = signer;


### PR DESCRIPTION
Signers produced by some wallets, such as Metamask, do not support changing providers. Ethers can throw an exception when calling `signer.connect`:
> Sub-classes must implement this, however they may simply throw an error if changing providers is not supported.

This creates a situation where explicitly providing a signer to the Ethereum plugin config can cause unexpected issues:
```typescript
// this will throw an exception and fail when changing networks
mainnet:  {
  provider: library,
  signer: library.getSigner()
 },
 
 // this will work without issue
mainnet:  {
  provider: library,
 },
```

This is preventable by allowing the provider to provide a signer if signer.connect fails.

I tested this by using yarn link in a react app.

After implementing this fix, I wonder if it makes more sense to instead leave the responsibility of handling this correctly to the user. Thoughts?