### PR TITLE
feat: add requestAccounts method to ethereum plugin

### DIFF
--- a/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
+++ b/packages/js/plugins/ethereum/src/__tests__/e2e.spec.ts
@@ -798,6 +798,21 @@ describe("Ethereum Plugin", () => {
       expect(polygonNetwork.data?.getNetwork.chainId).toBe("137");
       expect(polygonNetwork.data?.getNetwork.name).toBe("matic");
     });
+
+    it("requestAccounts", async () => {
+      const { error } = await client.invoke<string[]>({
+        uri,
+        method: "requestAccounts",
+      })
+
+      // eth_requestAccounts is not supported by Ganache
+      // this RPC error indicates that the method call was attempted
+      expect(error?.message.indexOf("Method eth_requestAccounts not supported")).toBeGreaterThanOrEqual(0);
+
+      // expect(error).toBeFalsy();
+      // expect(data).toBeTruthy();
+      // expect(data?.length).toBeGreaterThan(0);
+    });
   });
 
   describe("Mutation", () => {

--- a/packages/js/plugins/ethereum/src/__tests__/integration/src/index.ts
+++ b/packages/js/plugins/ethereum/src/__tests__/integration/src/index.ts
@@ -31,7 +31,7 @@ import {
   Args_sendRPC,
   Args_sendTransaction,
   Args_sendTransactionAndWait,
-  Args_signMessage
+  Args_signMessage, Args_requestAccounts,
 } from "./wrap";
 import { BigInt } from "@polywrap/wasm-as";
 
@@ -219,6 +219,14 @@ export function getNetwork(
   args: Args_getNetwork
 ): Ethereum_Network {
   return Ethereum_Module.getNetwork({
+    connection: args.connection
+  }).unwrap();
+}
+
+export function requestAccounts(
+  args: Args_requestAccounts
+): string[] {
+  return Ethereum_Module.requestAccounts({
     connection: args.connection
   }).unwrap();
 }

--- a/packages/js/plugins/ethereum/src/__tests__/integration/src/schema.graphql
+++ b/packages/js/plugins/ethereum/src/__tests__/integration/src/schema.graphql
@@ -109,6 +109,10 @@ type Module {
         connection: Ethereum_Connection
     ): Ethereum_Network!
 
+    requestAccounts(
+        connection: Ethereum_Connection
+    ): [String!]!
+
     callContractMethod(
         address: String!
         method: String!

--- a/packages/js/plugins/ethereum/src/index.ts
+++ b/packages/js/plugins/ethereum/src/index.ts
@@ -21,6 +21,7 @@ import {
   Args_waitForEvent,
   Args_awaitTransaction,
   Args_getNetwork,
+  Args_requestAccounts,
   Args_callContractMethod,
   Args_callContractMethodAndWait,
   Args_deployContract,
@@ -323,6 +324,15 @@ export class EthereumPlugin extends Module<EthereumPluginConfig> {
       chainId: network.chainId.toString(),
       ensAddress: network.ensAddress,
     };
+  }
+
+  async requestAccounts(
+    args: Args_requestAccounts,
+    _client: Client
+  ): Promise<string[]> {
+    const connection = await this._getConnection(args.connection);
+    const provider = connection.getProvider();
+    return provider.send("eth_requestAccounts", []);
   }
 
   public async callContractMethod(

--- a/packages/js/plugins/ethereum/src/schema.graphql
+++ b/packages/js/plugins/ethereum/src/schema.graphql
@@ -204,6 +204,8 @@ type Module {
 
     getNetwork(connection: Connection): Network!
 
+    requestAccounts(connection: Connection): [String!]!
+
     callContractMethod(
         address: String!
         method: String!

--- a/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/build-artifacts/schema.graphql
+++ b/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/build-artifacts/schema.graphql
@@ -187,6 +187,10 @@ type Ethereum_Module @imported(
     connection: Ethereum_Connection
   ): Ethereum_Network!
 
+  requestAccounts(
+    connection: Ethereum_Connection
+  ): [String!]!
+
   callContractMethod(
     address: String!
     method: String!

--- a/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/schema.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/schema.ts
@@ -190,6 +190,10 @@ type Ethereum_Module @imported(
     connection: Ethereum_Connection
   ): Ethereum_Network!
 
+  requestAccounts(
+    connection: Ethereum_Connection
+  ): [String!]!
+
   callContractMethod(
     address: String!
     method: String!

--- a/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/types.ts
@@ -287,6 +287,11 @@ interface Ethereum_Module_Args_getNetwork extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
+interface Ethereum_Module_Args_requestAccounts extends Record<string, unknown> {
+  connection?: Types.Ethereum_Connection | null;
+}
+
+/* URI: "ens/ethereum.polywrap.eth" */
 interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown> {
   address: Types.String;
   method: Types.String;
@@ -555,6 +560,17 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_Network>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getNetwork",
+      args
+    });
+  },
+
+  requestAccounts: async (
+    args: Ethereum_Module_Args_requestAccounts,
+    client: Client
+  ): Promise<InvokeResult<Array<Types.String>>> => {
+    return client.invoke<Array<Types.String>>({
+      uri: "ens/ethereum.polywrap.eth",
+      method: "requestAccounts",
       args
     });
   },

--- a/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/build-artifacts/schema.graphql
+++ b/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/build-artifacts/schema.graphql
@@ -183,6 +183,10 @@ type Ethereum_Module @imported(
     connection: Ethereum_Connection
   ): Ethereum_Network!
 
+  requestAccounts(
+    connection: Ethereum_Connection
+  ): [String!]!
+
   callContractMethod(
     address: String!
     method: String!

--- a/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/schema.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/schema.ts
@@ -186,6 +186,10 @@ type Ethereum_Module @imported(
     connection: Ethereum_Connection
   ): Ethereum_Network!
 
+  requestAccounts(
+    connection: Ethereum_Connection
+  ): [String!]!
+
   callContractMethod(
     address: String!
     method: String!

--- a/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/types.ts
@@ -287,6 +287,11 @@ interface Ethereum_Module_Args_getNetwork extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
+interface Ethereum_Module_Args_requestAccounts extends Record<string, unknown> {
+  connection?: Types.Ethereum_Connection | null;
+}
+
+/* URI: "ens/ethereum.polywrap.eth" */
 interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown> {
   address: Types.String;
   method: Types.String;
@@ -555,6 +560,17 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_Network>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getNetwork",
+      args
+    });
+  },
+
+  requestAccounts: async (
+    args: Ethereum_Module_Args_requestAccounts,
+    client: Client
+  ): Promise<InvokeResult<Array<Types.String>>> => {
+    return client.invoke<Array<Types.String>>({
+      uri: "ens/ethereum.polywrap.eth",
+      method: "requestAccounts",
       args
     });
   },

--- a/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/build-artifacts/schema.graphql
+++ b/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/build-artifacts/schema.graphql
@@ -187,6 +187,10 @@ type Ethereum_Module @imported(
     connection: Ethereum_Connection
   ): Ethereum_Network!
 
+  requestAccounts(
+    connection: Ethereum_Connection
+  ): [String!]!
+
   callContractMethod(
     address: String!
     method: String!

--- a/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/schema.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/schema.ts
@@ -190,6 +190,10 @@ type Ethereum_Module @imported(
     connection: Ethereum_Connection
   ): Ethereum_Network!
 
+  requestAccounts(
+    connection: Ethereum_Connection
+  ): [String!]!
+
   callContractMethod(
     address: String!
     method: String!

--- a/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/types.ts
@@ -287,6 +287,11 @@ interface Ethereum_Module_Args_getNetwork extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
+interface Ethereum_Module_Args_requestAccounts extends Record<string, unknown> {
+  connection?: Types.Ethereum_Connection | null;
+}
+
+/* URI: "ens/ethereum.polywrap.eth" */
 interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown> {
   address: Types.String;
   method: Types.String;
@@ -555,6 +560,17 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_Network>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getNetwork",
+      args
+    });
+  },
+
+  requestAccounts: async (
+    args: Ethereum_Module_Args_requestAccounts,
+    client: Client
+  ): Promise<InvokeResult<Array<Types.String>>> => {
+    return client.invoke<Array<Types.String>>({
+      uri: "ens/ethereum.polywrap.eth",
+      method: "requestAccounts",
       args
     });
   },

--- a/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/build-artifacts/schema.graphql
+++ b/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/build-artifacts/schema.graphql
@@ -187,6 +187,10 @@ type Ethereum_Module @imported(
     connection: Ethereum_Connection
   ): Ethereum_Network!
 
+  requestAccounts(
+    connection: Ethereum_Connection
+  ): [String!]!
+
   callContractMethod(
     address: String!
     method: String!

--- a/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/schema.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/schema.ts
@@ -190,6 +190,10 @@ type Ethereum_Module @imported(
     connection: Ethereum_Connection
   ): Ethereum_Network!
 
+  requestAccounts(
+    connection: Ethereum_Connection
+  ): [String!]!
+
   callContractMethod(
     address: String!
     method: String!

--- a/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/types.ts
@@ -287,6 +287,11 @@ interface Ethereum_Module_Args_getNetwork extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
+interface Ethereum_Module_Args_requestAccounts extends Record<string, unknown> {
+  connection?: Types.Ethereum_Connection | null;
+}
+
+/* URI: "ens/ethereum.polywrap.eth" */
 interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown> {
   address: Types.String;
   method: Types.String;
@@ -555,6 +560,17 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_Network>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getNetwork",
+      args
+    });
+  },
+
+  requestAccounts: async (
+    args: Ethereum_Module_Args_requestAccounts,
+    client: Client
+  ): Promise<InvokeResult<Array<Types.String>>> => {
+    return client.invoke<Array<Types.String>>({
+      uri: "ens/ethereum.polywrap.eth",
+      method: "requestAccounts",
       args
     });
   },


### PR DESCRIPTION
the requestAccounts method in the ethereum plugin calls "eth_requestAccounts", which is required to initiate metamask.

Closes #1066.