### PR TITLE
Use map instead of array of pair http plugin

### DIFF
--- a/packages/js/plugins/http/src/__tests__/e2e/e2e.spec.ts
+++ b/packages/js/plugins/http/src/__tests__/e2e/e2e.spec.ts
@@ -1,15 +1,15 @@
 import { httpPlugin } from "../..";
 import { Response } from "../../wrap";
 
-import { PolywrapClient } from "@polywrap/client-js"
+import { PolywrapClient } from "@polywrap/client-js";
 import nock from "nock";
 
-jest.setTimeout(360000)
+jest.setTimeout(360000);
 
 const defaultReplyHeaders = {
-  'access-control-allow-origin': '*',
-  'access-control-allow-credentials': 'true'
-}
+  "access-control-allow-origin": "*",
+  "access-control-allow-credentials": "true",
+};
 
 describe("e2e tests for HttpPlugin", () => {
   let polywrapClient: PolywrapClient;
@@ -19,19 +19,18 @@ describe("e2e tests for HttpPlugin", () => {
       plugins: [
         {
           uri: "wrap://ens/http.polywrap.eth",
-          plugin: httpPlugin({ }),
+          plugin: httpPlugin({}),
         },
-      ]
+      ],
     });
   });
 
   describe("get method", () => {
-
     test("successful request with response type as TEXT", async () => {
       nock("http://www.example.com")
         .defaultReplyHeaders(defaultReplyHeaders)
         .get("/api")
-        .reply(200, '{data: "test-response"}')
+        .reply(200, '{data: "test-response"}');
 
       const response = await polywrapClient.query<{ get: Response }>({
         uri: "wrap://ens/http.polywrap.eth",
@@ -44,22 +43,22 @@ describe("e2e tests for HttpPlugin", () => {
               }
             )
           }
-        `
-      })
+        `,
+      });
 
-      expect(response.data).toBeDefined()
-      expect(response.errors).toBeUndefined()
-      expect(response.data?.get.status).toBe(200)
+      expect(response.data).toBeDefined();
+      expect(response.errors).toBeUndefined();
+      expect(response.data?.get.status).toBe(200);
       // expect(response.data?.get.statusText).toBe("OK")
-      expect(response.data?.get.body).toBe('{data: "test-response"}')
-      expect(response.data?.get.headers?.length).toEqual(2) // default reply headers
+      expect(response.data?.get.body).toBe('{data: "test-response"}');
+      expect(response.data?.get.headers?.length).toEqual(2); // default reply headers
     });
 
     test("successful request with response type as BINARY", async () => {
       nock("http://www.example.com")
         .defaultReplyHeaders(defaultReplyHeaders)
         .get("/api")
-        .reply(200, '{data: "test-response"}')
+        .reply(200, '{data: "test-response"}');
 
       const response = await polywrapClient.query<{ get: Response }>({
         uri: "wrap://ens/http.polywrap.eth",
@@ -72,57 +71,59 @@ describe("e2e tests for HttpPlugin", () => {
               }
             )
           }
-        `
-      })
+        `,
+      });
 
-      expect(response.data).toBeDefined()
-      expect(response.errors).toBeUndefined()
-      expect(response.data?.get.status).toBe(200)
+      expect(response.data).toBeDefined();
+      expect(response.errors).toBeUndefined();
+      expect(response.data?.get.status).toBe(200);
       // expect(response.data?.get.statusText).toBe("OK")
-      expect(response.data?.get.body).toBe(Buffer.from('{data: "test-response"}').toString('base64'))
-      expect(response.data?.get.headers?.length).toEqual(2) // default reply headers
+      expect(response.data?.get.body).toBe(
+        Buffer.from('{data: "test-response"}').toString("base64")
+      );
+      expect(response.data?.get.headers?.length).toEqual(2); // default reply headers
     });
 
     test("successful request with query params and request headers", async () => {
-      nock("http://www.example.com", { reqheaders: { 'X-Request-Header': "req-foo" } })
+      nock("http://www.example.com", {
+        reqheaders: { "X-Request-Header": "req-foo" },
+      })
         .defaultReplyHeaders(defaultReplyHeaders)
         .get("/api")
         .query({ query: "foo" })
-        .reply(200, '{data: "test-response"}', { 'X-Response-Header': "resp-foo" })
+        .reply(200, '{data: "test-response"}', {
+          "X-Response-Header": "resp-foo",
+        });
 
-      const response = await polywrapClient.query<{ get: Response }>({
+      const response = await polywrapClient.invoke<Response>({
         uri: "wrap://ens/http.polywrap.eth",
-        query: `
-          query {
-            get(
-              url: "http://www.example.com/api"
-              request: {
-                responseType: TEXT
-                urlParams: [{key: "query", value: "foo"}]
-                headers: [{key: "X-Request-Header", value: "req-foo"}]
-              }
-            )
-          }
-        `
-      })
+        method: "get",
+        args: {
+          url: "http://www.example.com/api",
+          request: {
+            responseType: "TEXT",
+            urlParams: new Map([["query", "foo"]]),
+            headers: [{ key: "X-Request-Header", value: "req-foo" }],
+          },
+        },
+      });
 
-      expect(response.data).toBeDefined()
-      expect(response.errors).toBeUndefined()
-      expect(response.data?.get.status).toBe(200)
-      // expect(response.data?.get.statusText).toBe("OK")
-      expect(response.data?.get.body).toBe('{data: "test-response"}')
-      expect(response.data?.get.headers).toEqual([
+      expect(response.data).toBeDefined();
+      expect(response.error).toBeUndefined();
+      expect(response.data?.status).toBe(200);
+      expect(response.data?.body).toBe('{data: "test-response"}');
+      expect(response.data?.headers).toEqual([
         { key: "x-response-header", value: "resp-foo" },
         { key: "access-control-allow-origin", value: "*" },
-        { key: "access-control-allow-credentials", value: "true" }
-      ])
+        { key: "access-control-allow-credentials", value: "true" },
+      ]);
     });
 
     test("failed request", async () => {
       nock("http://www.example.com")
         .defaultReplyHeaders(defaultReplyHeaders)
         .get("/api")
-        .reply(404)
+        .reply(404);
 
       const response = await polywrapClient.query<{ get: Response }>({
         uri: "wrap://ens/http.polywrap.eth",
@@ -135,32 +136,30 @@ describe("e2e tests for HttpPlugin", () => {
               }
             )
           }
-        `
-      })
+        `,
+      });
 
-      expect(response.data?.get).toBeUndefined()
-      expect(response.errors).toBeDefined()
+      expect(response.data?.get).toBeUndefined();
+      expect(response.errors).toBeDefined();
     });
-
   });
 
   describe("post method", () => {
-
     test("successful request with request type as application/json", async () => {
       const reqPayload = {
         data: "test-request",
       };
       const reqPayloadStringified = JSON.stringify(reqPayload);
-      
+
       const resPayload = {
-        data: "test-response"
+        data: "test-response",
       };
       const resPayloadStringfified = JSON.stringify(resPayload);
 
       nock("http://www.example.com")
-          .defaultReplyHeaders(defaultReplyHeaders)
-          .post("/api", reqPayloadStringified)
-          .reply(200, resPayloadStringfified)
+        .defaultReplyHeaders(defaultReplyHeaders)
+        .post("/api", reqPayloadStringified)
+        .reply(200, resPayloadStringfified);
 
       const response = await polywrapClient.query<{ post: Response }>({
         uri: "wrap://ens/http.polywrap.eth",
@@ -177,22 +176,22 @@ describe("e2e tests for HttpPlugin", () => {
               }
             )
           }
-        `
-      })
+        `,
+      });
 
-      expect(response.data).toBeDefined()
-      expect(response.errors).toBeUndefined()
-      expect(response.data?.post.status).toBe(200)
+      expect(response.data).toBeDefined();
+      expect(response.errors).toBeUndefined();
+      expect(response.data?.post.status).toBe(200);
       // expect(response.data?.get.statusText).toBe("OK")
-      expect(response.data?.post.body).toBe(resPayloadStringfified)
-      expect(response.data?.post.headers?.length).toEqual(2) // default reply headers
+      expect(response.data?.post.body).toBe(resPayloadStringfified);
+      expect(response.data?.post.headers?.length).toEqual(2); // default reply headers
     });
 
     test("successful request with response type as TEXT", async () => {
       nock("http://www.example.com")
         .defaultReplyHeaders(defaultReplyHeaders)
         .post("/api", "{data: 'test-request'}")
-        .reply(200, '{data: "test-response"}')
+        .reply(200, '{data: "test-response"}');
 
       const response = await polywrapClient.query<{ post: Response }>({
         uri: "wrap://ens/http.polywrap.eth",
@@ -206,22 +205,22 @@ describe("e2e tests for HttpPlugin", () => {
               }
             )
           }
-        `
-      })
+        `,
+      });
 
-      expect(response.data).toBeDefined()
-      expect(response.errors).toBeUndefined()
-      expect(response.data?.post.status).toBe(200)
+      expect(response.data).toBeDefined();
+      expect(response.errors).toBeUndefined();
+      expect(response.data?.post.status).toBe(200);
       // expect(response.data?.get.statusText).toBe("OK")
-      expect(response.data?.post.body).toBe('{data: "test-response"}')
-      expect(response.data?.post.headers?.length).toEqual(2) // default reply headers
+      expect(response.data?.post.body).toBe('{data: "test-response"}');
+      expect(response.data?.post.headers?.length).toEqual(2); // default reply headers
     });
 
     test("successful request with response type as BINARY", async () => {
       nock("http://www.example.com")
         .defaultReplyHeaders(defaultReplyHeaders)
         .post("/api", "{data: 'test-request'}")
-        .reply(200, '{data: "test-response"}')
+        .reply(200, '{data: "test-response"}');
 
       const response = await polywrapClient.query<{ post: Response }>({
         uri: "wrap://ens/http.polywrap.eth",
@@ -235,58 +234,60 @@ describe("e2e tests for HttpPlugin", () => {
               }
             )
           }
-        `
-      })
+        `,
+      });
 
-      expect(response.data).toBeDefined()
-      expect(response.errors).toBeUndefined()
-      expect(response.data?.post.status).toBe(200)
+      expect(response.data).toBeDefined();
+      expect(response.errors).toBeUndefined();
+      expect(response.data?.post.status).toBe(200);
       // expect(response.data?.get.statusText).toBe("OK")
-      expect(response.data?.post.body).toBe(Buffer.from('{data: "test-response"}').toString('base64'))
-      expect(response.data?.post.headers?.length).toEqual(2) // default reply headers
+      expect(response.data?.post.body).toBe(
+        Buffer.from('{data: "test-response"}').toString("base64")
+      );
+      expect(response.data?.post.headers?.length).toEqual(2); // default reply headers
     });
 
     test("successful request with query params and request headers", async () => {
-      nock("http://www.example.com", { reqheaders: { 'X-Request-Header': "req-foo" } })
+      nock("http://www.example.com", {
+        reqheaders: { "X-Request-Header": "req-foo" },
+      })
         .defaultReplyHeaders(defaultReplyHeaders)
         .post("/api", "{data: 'test-request'}")
         .query({ query: "foo" })
-        .reply(200, '{data: "test-response"}', { 'X-Response-Header': "resp-foo" })
+        .reply(200, '{data: "test-response"}', {
+          "X-Response-Header": "resp-foo",
+        });
 
-      const response = await polywrapClient.query<{ post: Response }>({
+      const response = await polywrapClient.invoke<Response>({
         uri: "wrap://ens/http.polywrap.eth",
-        query: `
-          query {
-            post(
-              url: "http://www.example.com/api"
-              request: {
-                responseType: TEXT
-                body: "{data: 'test-request'}"
-                urlParams: [{key: "query", value: "foo"}]
-                headers: [{key: "X-Request-Header", value: "req-foo"}]
-              }
-            )
-          }
-        `
-      })
+        method: "post",
+        args: {
+          url: "http://www.example.com/api",
+          request: {
+            responseType: "TEXT",
+            body: "{data: 'test-request'}",
+            urlParams: new Map([["query", "foo"]]),
+            headers: [{ key: "X-Request-Header", value: "req-foo" }],
+          },
+        },
+      });
 
-      expect(response.data).toBeDefined()
-      expect(response.errors).toBeUndefined()
-      expect(response.data?.post.status).toBe(200)
-      // expect(response.data?.get.statusText).toBe("OK")
-      expect(response.data?.post.body).toBe('{data: "test-response"}')
-      expect(response.data?.post.headers).toEqual([
+      expect(response.data).toBeDefined();
+      expect(response.error).toBeUndefined();
+      expect(response.data?.status).toBe(200);
+      expect(response.data?.body).toBe('{data: "test-response"}');
+      expect(response.data?.headers).toEqual([
         { key: "x-response-header", value: "resp-foo" },
         { key: "access-control-allow-origin", value: "*" },
-        { key: "access-control-allow-credentials", value: "true" }
-      ])
+        { key: "access-control-allow-credentials", value: "true" },
+      ]);
     });
 
     test("failed request", async () => {
       nock("http://www.example.com")
         .defaultReplyHeaders(defaultReplyHeaders)
         .post("/api")
-        .reply(404)
+        .reply(404);
 
       const response = await polywrapClient.query<{ get: Response }>({
         uri: "wrap://ens/http.polywrap.eth",
@@ -299,12 +300,11 @@ describe("e2e tests for HttpPlugin", () => {
               }
             )
           }
-        `
-      })
+        `,
+      });
 
-      expect(response.data?.get).toBeUndefined()
-      expect(response.errors).toBeDefined()
+      expect(response.data?.get).toBeUndefined();
+      expect(response.errors).toBeDefined();
     });
-
   });
 });

--- a/packages/js/plugins/http/src/__tests__/e2e/integration.spec.ts
+++ b/packages/js/plugins/http/src/__tests__/e2e/integration.spec.ts
@@ -51,13 +51,13 @@ describe("e2e tests for HttpPlugin", () => {
           request: {
             responseType: "TEXT",
             urlParams: new Map([["query", "foo"]]),
-            headers: [{ key: "X-Request-Header", value: "req-foo" }],
+            headers: new Map([["X-Request-Header", "req-foo"]]),
           },
         },
       });
 
-      expect(response.data).toBeDefined();
       expect(response.error).toBeUndefined();
+      expect(response.data).toBeDefined();
       expect(response.data?.status).toBe(200);
     });
 
@@ -81,14 +81,13 @@ describe("e2e tests for HttpPlugin", () => {
             responseType: "TEXT",
             body: "{data: 'test-request'}",
             urlParams: { query: "foo" },
-            headers: [{ key: "X-Request-Header", value: "req-foo" }],
+            headers: new Map([["X-Request-Header", "req-foo"]]),
           },
         },
       });
 
-      expect(response.data).toBeTruthy();
       expect(response.error).toBeFalsy();
-
+      expect(response.data).toBeTruthy();
       expect(response.data?.status).toBe(200);
       expect(response.data?.body).toBeTruthy();
     });

--- a/packages/js/plugins/http/src/__tests__/e2e/integration.spec.ts
+++ b/packages/js/plugins/http/src/__tests__/e2e/integration.spec.ts
@@ -1,34 +1,30 @@
 import { httpPlugin } from "../..";
 import { Response } from "../../wrap";
 
-import { PolywrapClient } from "@polywrap/client-js"
-import {
-  buildWrapper
-} from "@polywrap/test-env-js";
+import { PolywrapClient } from "@polywrap/client-js";
+import { buildWrapper } from "@polywrap/test-env-js";
 import nock from "nock";
 
-jest.setTimeout(360000)
+jest.setTimeout(360000);
 
 const defaultReplyHeaders = {
-  'access-control-allow-origin': '*',
-  'access-control-allow-credentials': 'true'
-}
+  "access-control-allow-origin": "*",
+  "access-control-allow-credentials": "true",
+};
 
 describe("e2e tests for HttpPlugin", () => {
-
   describe("integration", () => {
-
     let client: PolywrapClient;
 
-    const wrapperPath = `${__dirname}/integration`
-    const uri = `fs/${wrapperPath}/build`
+    const wrapperPath = `${__dirname}/integration`;
+    const uri = `fs/${wrapperPath}/build`;
 
     beforeAll(async () => {
       client = new PolywrapClient({
         plugins: [
           {
             uri: "wrap://ens/http.polywrap.eth",
-            plugin: httpPlugin({ }),
+            plugin: httpPlugin({}),
           },
         ],
       });
@@ -37,58 +33,64 @@ describe("e2e tests for HttpPlugin", () => {
     });
 
     it("get", async () => {
-      nock("http://www.example.com", { reqheaders: { 'X-Request-Header': "req-foo" } })
+      nock("http://www.example.com", {
+        reqheaders: { "X-Request-Header": "req-foo" },
+      })
         .defaultReplyHeaders(defaultReplyHeaders)
         .get("/api")
         .query({ query: "foo" })
-        .reply(200, '{data: "test-response"}', { 'X-Response-Header': "resp-foo" })
+        .reply(200, '{data: "test-response"}', {
+          "X-Response-Header": "resp-foo",
+        });
 
-      const response = await client.query<{ get: Response }>({
+      const response = await client.invoke<Response>({
         uri,
-        query: `query {
-          get(
-            url: "http://www.example.com/api"
-            request: {
-              responseType: TEXT
-              urlParams: [{key: "query", value: "foo"}]
-              headers: [{key: "X-Request-Header", value: "req-foo"}]
-            }
-          )
-        }`
+        method: "get",
+        args: {
+          url: "http://www.example.com/api",
+          request: {
+            responseType: "TEXT",
+            urlParams: new Map([["query", "foo"]]),
+            headers: [{ key: "X-Request-Header", value: "req-foo" }],
+          },
+        },
       });
 
-      expect(response.data).toBeDefined()
-      expect(response.errors).toBeUndefined()
-      expect(response.data?.get.status).toBe(200)
+      expect(response.data).toBeDefined();
+      expect(response.error).toBeUndefined();
+      expect(response.data?.status).toBe(200);
     });
 
     it("post", async () => {
-      nock("http://www.example.com", { reqheaders: { 'X-Request-Header': "req-foo" } })
+      nock("http://www.example.com", {
+        reqheaders: { "X-Request-Header": "req-foo" },
+      })
         .defaultReplyHeaders(defaultReplyHeaders)
         .post("/api", "{data: 'test-request'}")
         .query({ query: "foo" })
-        .reply(200, '{data: "test-response"}', { 'X-Response-Header': "resp-foo" })
-
-        const response = await client.query<{ post: Response }>({
-          uri,
-          query: `query {
-            post(
-              url: "http://www.example.com/api"
-              request: {
-                responseType: TEXT
-                body: "{data: 'test-request'}"
-                urlParams: [{key: "query", value: "foo"}]
-                headers: [{key: "X-Request-Header", value: "req-foo"}]
-              }
-            )
-          }`
+        .reply(200, '{data: "test-response"}', {
+          "X-Response-Header": "resp-foo",
         });
-  
-        expect(response.data).toBeTruthy();
-        expect(response.errors).toBeFalsy();
-  
-        expect(response.data?.post.status).toBe(200);
-        expect(response.data?.post.body).toBeTruthy();
+
+      const response = await client.invoke<Response>({
+        uri,
+        method: "post",
+        args: {
+          url: "http://www.example.com/api",
+          request: {
+            responseType: "TEXT",
+            body: "{data: 'test-request'}",
+            urlParams: { query: "foo" },
+            headers: [{ key: "X-Request-Header", value: "req-foo" }],
+          },
+        },
+      });
+
+      expect(response.data).toBeTruthy();
+      expect(response.error).toBeFalsy();
+
+      expect(response.data?.status).toBe(200);
+      expect(response.data?.body).toBeTruthy();
     });
   });
 });

--- a/packages/js/plugins/http/src/__tests__/e2e/integration/polywrap.yaml
+++ b/packages/js/plugins/http/src/__tests__/e2e/integration/polywrap.yaml
@@ -4,3 +4,6 @@ build: ./polywrap.build.yaml
 language: wasm/assemblyscript
 schema: ./schema.graphql
 module: ./src/index.ts
+import_redirects:
+  - uri: "ens/http.polywrap.eth"
+    schema: ../../../schema.graphql

--- a/packages/js/plugins/http/src/__tests__/unit/index.test.ts
+++ b/packages/js/plugins/http/src/__tests__/unit/index.test.ts
@@ -34,10 +34,10 @@ describe("test http plugin", () => {
         {
           url: "/api/test",
           request: {
-            headers: [
-              { key: "Accept", value: "application/json" },
-              { key: "X-Test-Header", value: "test-header-value" },
-            ],
+            headers: new Map([
+              ["Accept", "application/json"],
+              ["X-Test-Header", "test-header-value"],
+            ]),
             urlParams: new Map([["q", "test-param"]]),
             responseType: ResponseTypeEnum.TEXT,
           },
@@ -56,9 +56,9 @@ describe("test http plugin", () => {
 
       expect(response?.status).toBe(200);
       expect(response?.statusText).toBe("Ok");
-      expect(response?.headers).toStrictEqual([
-        { key: "Content-Type", value: "application/json; charset=utf-8" },
-      ]);
+      expect(response?.headers).toStrictEqual(
+        new Map([["Content-Type", "application/json; charset=utf-8"]])
+      );
       expect(response?.body).toBe("{result: 1001}");
     });
 
@@ -77,10 +77,10 @@ describe("test http plugin", () => {
         {
           url: "/api/test",
           request: {
-            headers: [
-              { key: "Accept", value: "application/json" },
-              { key: "X-Test-Header", value: "test-header-value" },
-            ],
+            headers: new Map([
+              ["Accept", "application/json"],
+              ["X-Test-Header", "test-header-value"],
+            ]),
             urlParams: new Map([["q", "test-param"]]),
             responseType: "BINARY",
           },
@@ -99,9 +99,9 @@ describe("test http plugin", () => {
 
       expect(response?.status).toBe(200);
       expect(response?.statusText).toBe("Ok");
-      expect(response?.headers).toStrictEqual([
-        { key: "Content-Type", value: "application/json; charset=utf-8" },
-      ]);
+      expect(response?.headers).toStrictEqual(
+        new Map([["Content-Type", "application/json; charset=utf-8"]])
+      );
       expect(response?.body).toBeTruthy();
       if (response?.body) {
         expect(Buffer.from(response.body, "base64").toString()).toBe(
@@ -129,10 +129,10 @@ describe("test http plugin", () => {
         {
           url: "/api/test",
           request: {
-            headers: [
-              { key: "Accept", value: "application/json" },
-              { key: "X-Test-Header", value: "test-header-value" },
-            ],
+            headers: new Map([
+              ["Accept", "application/json"],
+              ["X-Test-Header", "test-header-value"],
+            ]),
             urlParams: new Map([["q", "test-param"]]),
             body: "{request: 1001}",
             responseType: "TEXT",
@@ -152,9 +152,9 @@ describe("test http plugin", () => {
 
       expect(response?.status).toBe(200);
       expect(response?.statusText).toBe("Ok");
-      expect(response?.headers).toStrictEqual([
-        { key: "Content-Type", value: "application/json; charset=utf-8" },
-      ]);
+      expect(response?.headers).toStrictEqual(
+        new Map([["Content-Type", "application/json; charset=utf-8"]])
+      );
       expect(response?.body).toBe("{response: 1001}");
     });
 
@@ -173,10 +173,10 @@ describe("test http plugin", () => {
         {
           url: "/api/test",
           request: {
-            headers: [
-              { key: "Accept", value: "application/json" },
-              { key: "X-Test-Header", value: "test-header-value" },
-            ],
+            headers: new Map([
+              ["Accept", "application/json"],
+              ["X-Test-Header", "test-header-value"],
+            ]),
             urlParams: new Map([["q", "test-param"]]),
             body: "{request: 1001}",
             responseType: "BINARY",
@@ -196,9 +196,9 @@ describe("test http plugin", () => {
 
       expect(response?.status).toBe(200);
       expect(response?.statusText).toBe("Ok");
-      expect(response?.headers).toStrictEqual([
-        { key: "Content-Type", value: "application/json; charset=utf-8" },
-      ]);
+      expect(response?.headers).toStrictEqual(
+        new Map([["Content-Type", "application/json; charset=utf-8"]])
+      );
       expect(response?.body).toBeTruthy();
       if (response?.body) {
         expect(Buffer.from(response.body, "base64").toString()).toBe(

--- a/packages/js/plugins/http/src/__tests__/unit/index.test.ts
+++ b/packages/js/plugins/http/src/__tests__/unit/index.test.ts
@@ -30,17 +30,20 @@ describe("test http plugin", () => {
         },
       } as AxiosResponse);
 
-      const response = await plugin.get({
-        url: "/api/test",
-        request: {
-          headers: [
-            { key: "Accept", value: "application/json" },
-            { key: "X-Test-Header", value: "test-header-value" },
-          ],
-          urlParams: [{ key: "q", value: "test-param" }],
-          responseType: ResponseTypeEnum.TEXT,
+      const response = await plugin.get(
+        {
+          url: "/api/test",
+          request: {
+            headers: [
+              { key: "Accept", value: "application/json" },
+              { key: "X-Test-Header", value: "test-header-value" },
+            ],
+            urlParams: new Map([["q", "test-param"]]),
+            responseType: ResponseTypeEnum.TEXT,
+          },
         },
-      }, {} as Client);
+        {} as Client
+      );
 
       expect(mockedAxios.get).lastCalledWith("/api/test", {
         headers: {
@@ -70,17 +73,20 @@ describe("test http plugin", () => {
         },
       } as AxiosResponse);
 
-      const response = await plugin.get({
-        url: "/api/test",
-        request: {
-          headers: [
-            { key: "Accept", value: "application/json" },
-            { key: "X-Test-Header", value: "test-header-value" },
-          ],
-          urlParams: [{ key: "q", value: "test-param" }],
-          responseType: "BINARY",
-        }
-      }, {} as Client);
+      const response = await plugin.get(
+        {
+          url: "/api/test",
+          request: {
+            headers: [
+              { key: "Accept", value: "application/json" },
+              { key: "X-Test-Header", value: "test-header-value" },
+            ],
+            urlParams: new Map([["q", "test-param"]]),
+            responseType: "BINARY",
+          },
+        },
+        {} as Client
+      );
 
       expect(mockedAxios.get).lastCalledWith("/api/test", {
         headers: {
@@ -98,7 +104,9 @@ describe("test http plugin", () => {
       ]);
       expect(response?.body).toBeTruthy();
       if (response?.body) {
-        expect(Buffer.from(response.body, 'base64').toString()).toBe("{result: 1001}");
+        expect(Buffer.from(response.body, "base64").toString()).toBe(
+          "{result: 1001}"
+        );
       }
     });
   });
@@ -117,18 +125,21 @@ describe("test http plugin", () => {
         },
       } as AxiosResponse);
 
-      const response = await plugin.post({
-        url: "/api/test",
-        request: {
-          headers: [
-            { key: "Accept", value: "application/json" },
-            { key: "X-Test-Header", value: "test-header-value" },
-          ],
-          urlParams: [{ key: "q", value: "test-param" }],
-          body: "{request: 1001}",
-          responseType: "TEXT",
-        }
-      }, {} as Client);
+      const response = await plugin.post(
+        {
+          url: "/api/test",
+          request: {
+            headers: [
+              { key: "Accept", value: "application/json" },
+              { key: "X-Test-Header", value: "test-header-value" },
+            ],
+            urlParams: new Map([["q", "test-param"]]),
+            body: "{request: 1001}",
+            responseType: "TEXT",
+          },
+        },
+        {} as Client
+      );
 
       expect(mockedAxios.post).lastCalledWith("/api/test", "{request: 1001}", {
         headers: {
@@ -158,18 +169,21 @@ describe("test http plugin", () => {
         },
       } as AxiosResponse);
 
-      const response = await plugin.post({
-        url: "/api/test",
-        request: {
-          headers: [
-            { key: "Accept", value: "application/json" },
-            { key: "X-Test-Header", value: "test-header-value" },
-          ],
-          urlParams: [{ key: "q", value: "test-param" }],
-          body: "{request: 1001}",
-          responseType: "BINARY",
-        }
-      }, {} as Client);
+      const response = await plugin.post(
+        {
+          url: "/api/test",
+          request: {
+            headers: [
+              { key: "Accept", value: "application/json" },
+              { key: "X-Test-Header", value: "test-header-value" },
+            ],
+            urlParams: new Map([["q", "test-param"]]),
+            body: "{request: 1001}",
+            responseType: "BINARY",
+          },
+        },
+        {} as Client
+      );
 
       expect(mockedAxios.post).lastCalledWith("/api/test", "{request: 1001}", {
         headers: {
@@ -187,7 +201,9 @@ describe("test http plugin", () => {
       ]);
       expect(response?.body).toBeTruthy();
       if (response?.body) {
-        expect(Buffer.from(response.body, 'base64').toString()).toBe("{response: 1001}");
+        expect(Buffer.from(response.body, "base64").toString()).toBe(
+          "{response: 1001}"
+        );
       }
     });
   });

--- a/packages/js/plugins/http/src/__tests__/unit/util.test.ts
+++ b/packages/js/plugins/http/src/__tests__/unit/util.test.ts
@@ -19,13 +19,17 @@ describe("converting axios response", () => {
     expect(response.statusText).toBe("Ok");
     expect(response.body).toBe("body-content");
   });
-  
+
   test("response type: text; with header as a map", () => {
     const response = fromAxiosResponse({
       status: 200,
       statusText: "Ok",
       data: "body-content",
-      headers: { ["Accept"]: "application-json", ["X-Header"]: "test-value", ["set-cookie"]: ['key=val;', 'key2=val2;'] },
+      headers: {
+        ["Accept"]: "application-json",
+        ["X-Header"]: "test-value",
+        ["set-cookie"]: ["key=val;", "key2=val2;"],
+      },
       config: { responseType: "text" },
     });
 
@@ -54,7 +58,7 @@ describe("converting axios response", () => {
     ]);
     expect(response.status).toBe(200);
     expect(response.statusText).toBe("Ok");
-    expect(response.body).toBe(Buffer.from("body-content").toString('base64'));
+    expect(response.body).toBe(Buffer.from("body-content").toString("base64"));
   });
 });
 
@@ -79,7 +83,7 @@ describe("creating axios config", () => {
 
   test("with url params", () => {
     const config = toAxiosRequestConfig({
-      urlParams: [{ key: "tag", value: "data" }],
+      urlParams: new Map([["tag", "data"]]),
       responseType: ResponseTypeEnum.BINARY,
       body: "body-content",
     });

--- a/packages/js/plugins/http/src/__tests__/unit/util.test.ts
+++ b/packages/js/plugins/http/src/__tests__/unit/util.test.ts
@@ -11,10 +11,12 @@ describe("converting axios response", () => {
       config: { responseType: "text" },
     });
 
-    expect(response.headers).toStrictEqual([
-      { key: "Accept", value: "application-json" },
-      { key: "X-Header", value: "test-value" },
-    ]);
+    expect(response.headers).toStrictEqual(
+      new Map([
+        ["Accept", "application-json"],
+        ["X-Header", "test-value"],
+      ])
+    );
     expect(response.status).toBe(200);
     expect(response.statusText).toBe("Ok");
     expect(response.body).toBe("body-content");
@@ -33,11 +35,13 @@ describe("converting axios response", () => {
       config: { responseType: "text" },
     });
 
-    expect(response.headers).toStrictEqual([
-      { key: "Accept", value: "application-json" },
-      { key: "X-Header", value: "test-value" },
-      { key: "set-cookie", value: "key=val; key2=val2;" },
-    ]);
+    expect(response.headers).toStrictEqual(
+      new Map([
+        ["Accept", "application-json"],
+        ["X-Header", "test-value"],
+        ["set-cookie", "key=val; key2=val2;"],
+      ])
+    );
     expect(response.status).toBe(200);
     expect(response.statusText).toBe("Ok");
     expect(response.body).toBe("body-content");
@@ -52,10 +56,12 @@ describe("converting axios response", () => {
       config: { responseType: "arraybuffer" },
     });
 
-    expect(response.headers).toStrictEqual([
-      { key: "Accept", value: "application-json" },
-      { key: "X-Header", value: "test-value" },
-    ]);
+    expect(response.headers).toStrictEqual(
+      new Map([
+        ["Accept", "application-json"],
+        ["X-Header", "test-value"],
+      ])
+    );
     expect(response.status).toBe(200);
     expect(response.statusText).toBe("Ok");
     expect(response.body).toBe(Buffer.from("body-content").toString("base64"));
@@ -65,10 +71,10 @@ describe("converting axios response", () => {
 describe("creating axios config", () => {
   test("with headers", () => {
     const config = toAxiosRequestConfig({
-      headers: [
-        { key: "Accept", value: "application-json" },
-        { key: "X-Header", value: "test-value" },
-      ],
+      headers: new Map([
+        ["Accept", "application-json"],
+        ["X-Header", "test-value"],
+      ]),
       responseType: "TEXT",
       body: "body-content",
     });

--- a/packages/js/plugins/http/src/schema.graphql
+++ b/packages/js/plugins/http/src/schema.graphql
@@ -3,11 +3,6 @@ type Header {
   value: String!
 }
 
-type UrlParam {
-  key: String!
-  value: String!
-}
-
 type Response {
   status: Int!
   statusText: String!

--- a/packages/js/plugins/http/src/schema.graphql
+++ b/packages/js/plugins/http/src/schema.graphql
@@ -17,7 +17,7 @@ type Response {
 
 type Request {
   headers: [Header!]
-  urlParams: [UrlParam!]
+  urlParams: Map @annotate(type: "Map<String!, String!>")
   responseType: ResponseType!
   body: String
 }

--- a/packages/js/plugins/http/src/schema.graphql
+++ b/packages/js/plugins/http/src/schema.graphql
@@ -1,17 +1,12 @@
-type Header {
-  key: String!
-  value: String!
-}
-
 type Response {
   status: Int!
   statusText: String!
-  headers: [Header!]
+  headers: Map @annotate(type: "Map<String!, String!>")
   body: String
 }
 
 type Request {
-  headers: [Header!]
+  headers: Map @annotate(type: "Map<String!, String!>")
   urlParams: Map @annotate(type: "Map<String!, String!>")
   responseType: ResponseType!
   body: String

--- a/packages/js/plugins/http/src/util.ts
+++ b/packages/js/plugins/http/src/util.ts
@@ -1,4 +1,4 @@
-import { Request, Response, ResponseTypeEnum, Header } from "./wrap";
+import { Request, Response, ResponseTypeEnum } from "./wrap";
 
 import { AxiosResponse, AxiosRequestConfig } from "axios";
 
@@ -10,14 +10,14 @@ import { AxiosResponse, AxiosRequestConfig } from "axios";
 export function fromAxiosResponse(
   axiosResponse: AxiosResponse<unknown>
 ): Response {
-  const responseHeaders: Header[] = [];
+  const responseHeaders = new Map<string, string>();
   for (const key of Object.keys(axiosResponse.headers)) {
-    responseHeaders.push({
-      key: key,
-      value: Array.isArray(axiosResponse.headers[key])
+    responseHeaders.set(
+      key,
+      Array.isArray(axiosResponse.headers[key])
         ? axiosResponse.headers[key].join(" ")
-        : axiosResponse.headers[key],
-    });
+        : axiosResponse.headers[key]
+    );
   }
 
   const response = {
@@ -62,10 +62,6 @@ export function fromAxiosResponse(
  * @param request
  */
 export function toAxiosRequestConfig(request: Request): AxiosRequestConfig {
-  const requestHeaders = request.headers?.reduce((headers, h) => {
-    return { ...headers, [h.key]: h.value };
-  }, {});
-
   let responseType: "text" | "arraybuffer" = "text";
 
   switch (request.responseType) {
@@ -82,8 +78,8 @@ export function toAxiosRequestConfig(request: Request): AxiosRequestConfig {
     config = { ...config, params: Object.fromEntries(request.urlParams) };
   }
 
-  if (requestHeaders) {
-    config = { ...config, headers: requestHeaders };
+  if (request.headers) {
+    config = { ...config, headers: Object.fromEntries(request.headers) };
   }
 
   return config;

--- a/packages/js/plugins/http/src/util.ts
+++ b/packages/js/plugins/http/src/util.ts
@@ -62,10 +62,6 @@ export function fromAxiosResponse(
  * @param request
  */
 export function toAxiosRequestConfig(request: Request): AxiosRequestConfig {
-  const urlParams = request.urlParams?.reduce((params, p) => {
-    return { ...params, [p.key]: p.value };
-  }, {});
-
   const requestHeaders = request.headers?.reduce((headers, h) => {
     return { ...headers, [h.key]: h.value };
   }, {});
@@ -82,8 +78,8 @@ export function toAxiosRequestConfig(request: Request): AxiosRequestConfig {
     responseType,
   };
 
-  if (urlParams) {
-    config = { ...config, params: urlParams };
+  if (request.urlParams) {
+    config = { ...config, params: Object.fromEntries(request.urlParams) };
   }
 
   if (requestHeaders) {

--- a/packages/wasm/as/assembly/msgpack/Write.ts
+++ b/packages/wasm/as/assembly/msgpack/Write.ts
@@ -63,7 +63,7 @@ export abstract class Write {
     value_fn: (writer: Write, value: V) => void
   ): void;
   abstract writeOptionalExtGenericMap<K, V>(
-    m: Map<K, V>,
+    m: Map<K, V> | null,
     key_fn: (writer: Write, key: K) => void,
     value_fn: (writer: Write, value: V) => void
   ): void;


### PR DESCRIPTION
Resolves #863

Additional work:

`packages/wasm/as/assembly/msgpack/Write.ts`
- Changed signature of abstract method `writeOptionalExtGenericMap` to allow for `null` maps, putting it in line with its implementations in `WriteEncoder` and `WriteSizer`

`packages/js/plugins/http/src/__tests__/e2e/integration/polywrap.yaml`
- Added `import_redirects` for HTTP plugin - codegen needs this to import the latest HTTP plugin schema.

Formatted test files in line with `.prettierrc`