### PR TITLE
Fix: Maps with custom values rust binding

### DIFF
--- a/packages/schema/bind/src/bindings/rust/types.ts
+++ b/packages/schema/bind/src/bindings/rust/types.ts
@@ -34,7 +34,7 @@ export type BuiltInTypes = typeof builtInTypes;
 export type BuiltInType = keyof BuiltInTypes;
 
 export function isBuiltInType(type: string): type is BuiltInType {
-  return type in builtInTypes || type.startsWith("Map<");
+  return type in builtInTypes;
 }
 
 const keywords = {

--- a/packages/schema/bind/src/bindings/rust/wasm/transforms/propertyDeps.ts
+++ b/packages/schema/bind/src/bindings/rust/wasm/transforms/propertyDeps.ts
@@ -61,14 +61,6 @@ export function propertyDeps(): AbiTransforms {
             typeName = typeName.replace(/\[|\]|\!|\?/g, "");
           }
 
-          if (
-            isBaseType(typeName) ||
-            isBuiltInType(typeName) ||
-            typeName === rootType
-          ) {
-            return array;
-          }
-
           const appendUnique = (item: PropertyDep) => {
             if (
               array.findIndex(
@@ -78,6 +70,30 @@ export function propertyDeps(): AbiTransforms {
               array.push(item);
             }
           };
+
+          const isKnownType = (name: string) =>
+            isBaseType(name) || isBuiltInType(name) || name === rootType;
+
+          // if type is map and the value is custom,
+          // we need to add it into property dependency
+          if (typeName.startsWith("Map<")) {
+            const valueName = def.map?.object?.type;
+            if (valueName && !isKnownType(valueName)) {
+              appendUnique({
+                crate: "crate",
+                type: valueName,
+                isEnum: false,
+              });
+
+              return array;
+            }
+
+            return array;
+          }
+
+          if (isKnownType(typeName)) {
+            return array;
+          }
 
           appendUnique({
             crate: "crate",

--- a/packages/test-cases/cases/bind/sanity/input/schema.graphql
+++ b/packages/test-cases/cases/bind/sanity/input/schema.graphql
@@ -123,6 +123,7 @@ type CustomType {
   mapOfArr: Map! @annotate(type: "Map<String!, [Int!]!>!")
   mapOfObj: Map! @annotate(type: "Map<String!, AnotherType!>!")
   mapOfArrOfObj: Map! @annotate(type: "Map<String!, [AnotherType!]!>!")
+  mapCustomValue: Map! @annotate(type: "Map<String!, CustomMapValue>!")
 }
 
 type AnotherType {
@@ -134,6 +135,10 @@ type AnotherType {
 enum CustomEnum {
   STRING
   BYTES
+}
+
+type CustomMapValue {
+  foo: String!
 }
 
 ### Imported Modules START ###

--- a/packages/test-cases/cases/bind/sanity/output/app-ts/schema.ts
+++ b/packages/test-cases/cases/bind/sanity/output/app-ts/schema.ts
@@ -123,6 +123,7 @@ type CustomType {
   mapOfArr: Map! @annotate(type: "Map<String!, [Int!]!>!")
   mapOfObj: Map! @annotate(type: "Map<String!, AnotherType!>!")
   mapOfArrOfObj: Map! @annotate(type: "Map<String!, [AnotherType!]!>!")
+  mapCustomValue: Map! @annotate(type: "Map<String!, CustomMapValue>!")
 }
 
 type AnotherType {
@@ -134,6 +135,10 @@ type AnotherType {
 enum CustomEnum {
   STRING
   BYTES
+}
+
+type CustomMapValue {
+  foo: String!
 }
 
 ### Imported Modules START ###

--- a/packages/test-cases/cases/bind/sanity/output/app-ts/types.ts
+++ b/packages/test-cases/cases/bind/sanity/output/app-ts/types.ts
@@ -64,12 +64,17 @@ export interface CustomType {
   mapOfArr: Map<Types.String, Array<Types.Int>>;
   mapOfObj: Map<Types.String, Types.AnotherType>;
   mapOfArrOfObj: Map<Types.String, Array<Types.AnotherType>>;
+  mapCustomValue: Map<Types.String, Types.CustomMapValue | undefined>;
 }
 
 export interface AnotherType {
   prop?: Types.String | null;
   circular?: Types.CustomType | null;
   const?: Types.String | null;
+}
+
+export interface CustomMapValue {
+  foo: Types.String;
 }
 
 export enum CustomEnumEnum {

--- a/packages/test-cases/cases/bind/sanity/output/plugin-ts/schema.ts
+++ b/packages/test-cases/cases/bind/sanity/output/plugin-ts/schema.ts
@@ -126,6 +126,7 @@ type CustomType {
   mapOfArr: Map! @annotate(type: "Map<String!, [Int!]!>!")
   mapOfObj: Map! @annotate(type: "Map<String!, AnotherType!>!")
   mapOfArrOfObj: Map! @annotate(type: "Map<String!, [AnotherType!]!>!")
+  mapCustomValue: Map! @annotate(type: "Map<String!, CustomMapValue>!")
 }
 
 type AnotherType {
@@ -137,6 +138,10 @@ type AnotherType {
 enum CustomEnum {
   STRING
   BYTES
+}
+
+type CustomMapValue {
+  foo: String!
 }
 
 ### Imported Modules START ###

--- a/packages/test-cases/cases/bind/sanity/output/plugin-ts/types.ts
+++ b/packages/test-cases/cases/bind/sanity/output/plugin-ts/types.ts
@@ -76,12 +76,17 @@ export interface CustomType {
   mapOfArr: Map<Types.String, Array<Types.Int>>;
   mapOfObj: Map<Types.String, Types.AnotherType>;
   mapOfArrOfObj: Map<Types.String, Array<Types.AnotherType>>;
+  mapCustomValue: Map<Types.String, Types.CustomMapValue | undefined>;
 }
 
 export interface AnotherType {
   prop?: Types.String | null;
   circular?: Types.CustomType | null;
   const?: Types.String | null;
+}
+
+export interface CustomMapValue {
+  foo: Types.String;
 }
 
 /// Objects END ///

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/CustomMapValue/index.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/CustomMapValue/index.ts
@@ -1,0 +1,35 @@
+import {
+  Read,
+  Write,
+  Option,
+  BigInt,
+  BigNumber,
+  JSON
+} from "@polywrap/wasm-as";
+import {
+  serializeCustomMapValue,
+  deserializeCustomMapValue,
+  writeCustomMapValue,
+  readCustomMapValue
+} from "./serialization";
+import * as Types from "..";
+
+export class CustomMapValue {
+  foo: string;
+
+  static toBuffer(type: CustomMapValue): ArrayBuffer {
+    return serializeCustomMapValue(type);
+  }
+
+  static fromBuffer(buffer: ArrayBuffer): CustomMapValue {
+    return deserializeCustomMapValue(buffer);
+  }
+
+  static write(writer: Write, type: CustomMapValue): void {
+    writeCustomMapValue(writer, type);
+  }
+
+  static read(reader: Read): CustomMapValue {
+    return readCustomMapValue(reader);
+  }
+}

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/CustomMapValue/serialization.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/CustomMapValue/serialization.ts
@@ -1,0 +1,68 @@
+import {
+  Read,
+  ReadDecoder,
+  Write,
+  WriteSizer,
+  WriteEncoder,
+  Option,
+  BigInt,
+  BigNumber,
+  JSON,
+  Context
+} from "@polywrap/wasm-as";
+import { CustomMapValue } from "./";
+import * as Types from "..";
+
+export function serializeCustomMapValue(type: CustomMapValue): ArrayBuffer {
+  const sizerContext: Context = new Context("Serializing (sizing) object-type: CustomMapValue");
+  const sizer = new WriteSizer(sizerContext);
+  writeCustomMapValue(sizer, type);
+  const buffer = new ArrayBuffer(sizer.length);
+  const encoderContext: Context = new Context("Serializing (encoding) object-type: CustomMapValue");
+  const encoder = new WriteEncoder(buffer, sizer, encoderContext);
+  writeCustomMapValue(encoder, type);
+  return buffer;
+}
+
+export function writeCustomMapValue(writer: Write, type: CustomMapValue): void {
+  writer.writeMapLength(1);
+  writer.context().push("foo", "string", "writing property");
+  writer.writeString("foo");
+  writer.writeString(type.foo);
+  writer.context().pop();
+}
+
+export function deserializeCustomMapValue(buffer: ArrayBuffer): CustomMapValue {
+  const context: Context = new Context("Deserializing object-type CustomMapValue");
+  const reader = new ReadDecoder(buffer, context);
+  return readCustomMapValue(reader);
+}
+
+export function readCustomMapValue(reader: Read): CustomMapValue {
+  let numFields = reader.readMapLength();
+
+  let _foo: string = "";
+  let _fooSet: bool = false;
+
+  while (numFields > 0) {
+    numFields--;
+    const field = reader.readString();
+
+    reader.context().push(field, "unknown", "searching for property type");
+    if (field == "foo") {
+      reader.context().push(field, "string", "type found, reading property");
+      _foo = reader.readString();
+      _fooSet = true;
+      reader.context().pop();
+    }
+    reader.context().pop();
+  }
+
+  if (!_fooSet) {
+    throw new Error(reader.context().printWithContext("Missing required property: 'foo: String'"));
+  }
+
+  return {
+    foo: _foo
+  };
+}

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/CustomType/index.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/CustomType/index.ts
@@ -56,6 +56,7 @@ export class CustomType {
   mapOfArr: Map<string, Array<i32>>;
   mapOfObj: Map<string, Types.AnotherType>;
   mapOfArrOfObj: Map<string, Array<Types.AnotherType>>;
+  mapCustomValue: Map<string, Types.CustomMapValue | null>;
 
   static toBuffer(type: CustomType): ArrayBuffer {
     return serializeCustomType(type);

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/index.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/index.ts
@@ -10,6 +10,7 @@ export {
 };
 export { CustomType } from "./CustomType";
 export { AnotherType } from "./AnotherType";
+export { CustomMapValue } from "./CustomMapValue";
 export {
   CustomEnum,
   getCustomEnumKey,

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/custom_map_value/mod.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/custom_map_value/mod.rs
@@ -1,0 +1,48 @@
+use serde::{Serialize, Deserialize};
+pub mod serialization;
+use polywrap_wasm_rs::{
+    BigInt,
+    BigNumber,
+    Map,
+    DecodeError,
+    EncodeError,
+    Read,
+    Write,
+    JSON,
+};
+pub use serialization::{
+    deserialize_custom_map_value,
+    read_custom_map_value,
+    serialize_custom_map_value,
+    write_custom_map_value
+};
+
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CustomMapValue {
+    pub foo: String,
+}
+
+impl CustomMapValue {
+    pub fn new() -> CustomMapValue {
+        CustomMapValue {
+            foo: String::new(),
+        }
+    }
+
+    pub fn to_buffer(args: &CustomMapValue) -> Result<Vec<u8>, EncodeError> {
+        serialize_custom_map_value(args).map_err(|e| EncodeError::TypeWriteError(e.to_string()))
+    }
+
+    pub fn from_buffer(args: &[u8]) -> Result<CustomMapValue, DecodeError> {
+        deserialize_custom_map_value(args).map_err(|e| DecodeError::TypeReadError(e.to_string()))
+    }
+
+    pub fn write<W: Write>(args: &CustomMapValue, writer: &mut W) -> Result<(), EncodeError> {
+        write_custom_map_value(args, writer).map_err(|e| EncodeError::TypeWriteError(e.to_string()))
+    }
+
+    pub fn read<R: Read>(reader: &mut R) -> Result<CustomMapValue, DecodeError> {
+        read_custom_map_value(reader).map_err(|e| DecodeError::TypeReadError(e.to_string()))
+    }
+}

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/custom_map_value/serialization.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/custom_map_value/serialization.rs
@@ -1,0 +1,68 @@
+use std::convert::TryFrom;
+use polywrap_wasm_rs::{
+    BigInt,
+    BigNumber,
+    Map,
+    Context,
+    DecodeError,
+    EncodeError,
+    Read,
+    ReadDecoder,
+    Write,
+    WriteEncoder,
+    JSON,
+};
+use crate::CustomMapValue;
+
+pub fn serialize_custom_map_value(args: &CustomMapValue) -> Result<Vec<u8>, EncodeError> {
+    let mut encoder_context = Context::new();
+    encoder_context.description = "Serializing (encoding) object-type: CustomMapValue".to_string();
+    let mut encoder = WriteEncoder::new(&[], encoder_context);
+    write_custom_map_value(args, &mut encoder)?;
+    Ok(encoder.get_buffer())
+}
+
+pub fn write_custom_map_value<W: Write>(args: &CustomMapValue, writer: &mut W) -> Result<(), EncodeError> {
+    writer.write_map_length(&1)?;
+    writer.context().push("foo", "String", "writing property");
+    writer.write_string("foo")?;
+    writer.write_string(&args.foo)?;
+    writer.context().pop();
+    Ok(())
+}
+
+pub fn deserialize_custom_map_value(args: &[u8]) -> Result<CustomMapValue, DecodeError> {
+    let mut context = Context::new();
+    context.description = "Deserializing object-type: CustomMapValue".to_string();
+    let mut reader = ReadDecoder::new(args, context);
+    read_custom_map_value(&mut reader)
+}
+
+pub fn read_custom_map_value<R: Read>(reader: &mut R) -> Result<CustomMapValue, DecodeError> {
+    let mut num_of_fields = reader.read_map_length()?;
+
+    let mut _foo: String = String::new();
+    let mut _foo_set = false;
+
+    while num_of_fields > 0 {
+        num_of_fields -= 1;
+        let field = reader.read_string()?;
+
+        match field.as_str() {
+            "foo" => {
+                reader.context().push(&field, "String", "type found, reading property");
+                _foo = reader.read_string()?;
+                _foo_set = true;
+                reader.context().pop();
+            }
+            err => return Err(DecodeError::UnknownFieldName(err.to_string())),
+        }
+    }
+    if !_foo_set {
+        return Err(DecodeError::MissingField("foo: String.".to_string()));
+    }
+
+    Ok(CustomMapValue {
+        foo: _foo,
+    })
+}

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/custom_type/mod.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/custom_type/mod.rs
@@ -19,6 +19,7 @@ pub use serialization::{
 
 use crate::AnotherType;
 use crate::CustomEnum;
+use crate::CustomMapValue;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CustomType {
@@ -63,6 +64,7 @@ pub struct CustomType {
     pub map_of_arr: Map<String, Vec<i32>>,
     pub map_of_obj: Map<String, AnotherType>,
     pub map_of_arr_of_obj: Map<String, Vec<AnotherType>>,
+    pub map_custom_value: Map<String, Option<CustomMapValue>>,
 }
 
 impl CustomType {
@@ -109,6 +111,7 @@ impl CustomType {
             map_of_arr: Map::<String, Vec<i32>>::new(),
             map_of_obj: Map::<String, AnotherType>::new(),
             map_of_arr_of_obj: Map::<String, Vec<AnotherType>>::new(),
+            map_custom_value: Map::<String, Option<CustomMapValue>>::new(),
         }
     }
 

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/mod.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/mod.rs
@@ -3,6 +3,8 @@ pub mod custom_type;
 pub use custom_type::CustomType;
 pub mod another_type;
 pub use another_type::AnotherType;
+pub mod custom_map_value;
+pub use custom_map_value::CustomMapValue;
 pub mod custom_enum;
 pub use custom_enum::{
     get_custom_enum_key,


### PR DESCRIPTION
Currently in rust wrappers, if a developer creates a custom type and it is **only** being used as value of `Map`, the codegen will fail. The reason is that currently, the bind script doesn't add the custom value as a dependency of the map type

For example:
```graphql
type ExchangeRates {
    rates: Map! @annotate(type: "Map<String!, ExchangeRateData!>!")
}

type ExchangeRateData {
    name: String!
    unit: String!
    value: BigNumber!
    type: String!
}
```

This PR aims to fix this + tests