### PR TITLE
fix: imported optional Map type bindings in Rust

### DIFF
--- a/packages/schema/bind/src/bindings/rust/functions.ts
+++ b/packages/schema/bind/src/bindings/rust/functions.ts
@@ -164,7 +164,7 @@ export const toWasmInit: MustacheFunction = () => {
         .substring(openBracketIdx + 1, closeBracketIdx)
         .split(",")
         .map((x) => toWasm()(x.trim(), render));
-      return `Map::<${key}, ${value}>::new()`;
+      return optionalModifier(`Map::<${key}, ${value}>::new()`);
     }
 
     switch (type) {

--- a/packages/schema/bind/src/bindings/rust/wasm/templates/imported/object-type/serialization-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/wasm/templates/imported/object-type/serialization-rs.mustache
@@ -133,7 +133,7 @@ pub fn read_{{#toLower}}{{type}}{{/toLower}}<R: Read>(reader: &mut R) -> Result<
                 {{/array}}
                 {{#map}}
                 _{{#toLower}}{{name}}{{/toLower}} = reader.read_{{#toLower}}{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}{{/toLower}}(|reader| {
-                    reader.read_{{#key}}{{#toLower}}{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}{{/toLower}}{{/key}}()?
+                    reader.read_{{#key}}{{#toLower}}{{#toMsgPack}}{{toGraphQLType}}{{/toMsgPack}}{{/toLower}}{{/key}}()
                 }, |reader| {
                     {{#value}}
                     {{> deserialize_map_value_nobox}}

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/env/mod.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/env/mod.rs
@@ -29,7 +29,7 @@ impl Env {
         Env {
             prop: String::new(),
             opt_prop: None,
-            opt_map: Map::<String, Option<i32>>::new(),
+            opt_map: None,
         }
     }
 

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/env/serialization.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/env/serialization.rs
@@ -56,7 +56,7 @@ pub fn read_env<R: Read>(reader: &mut R) -> Result<Env, DecodeError> {
     let mut _prop: String = String::new();
     let mut _prop_set = false;
     let mut _opt_prop: Option<String> = None;
-    let mut _opt_map: Option<Map<String, Option<i32>>> = Map::<String, Option<i32>>::new();
+    let mut _opt_map: Option<Map<String, Option<i32>>> = None;
 
     while num_of_fields > 0 {
         num_of_fields -= 1;


### PR DESCRIPTION
There are two issues affecting imported Map type bindings from compiling in Rust.

**First**
```rust
// expected type option, got map
let mut _headers: Option<Map<String, String>> = Map::<String, String>::new();
let mut _url_params: Option<Map<String, String>> = Map::<String, String>::new();
```

**Second**
In the object serialization logic for optional Map type, we are trying to pass a String instead of a Result<String, Error>. Example:
```
"headers" => {
                reader.context().push(&field, "Option<Map<String, String>>", "type found, reading property");
                _headers = reader.read_optional_ext_generic_map(|reader| {
                    reader.read_string()? //  <---- This `?` should not be here!
                }, |reader| {
                    reader.read_string()
                })?; 
                reader.context().pop();
            }
```