### PR TITLE
fix: improve docker verbose output

### DIFF
--- a/packages/cli/src/lib/system/docker.ts
+++ b/packages/cli/src/lib/system/docker.ts
@@ -187,8 +187,7 @@ export async function createBuildImage(
   };
 
   if (quiet) {
-    return await run();
-  } else {
+    // Show spinner with helpful messages
     const args = {
       image: imageName,
       dockerfile: displayPath(dockerfile),
@@ -202,6 +201,9 @@ export async function createBuildImage(
         return await run();
       }
     )) as string;
+  } else {
+    // Verbose output will be emitted within run()
+    return await run();
   }
 }
 


### PR DESCRIPTION
I was dissatisfied with how the `polywrap build -v` command was printing its output, this helps make it cleaner.