### PR TITLE
schema.graphql should be replaced with wrap.info in the polywrap.app.yaml migrator

### DIFF
--- a/packages/js/manifests/polywrap/src/__tests__/manifest/polywrap/migrations/polywrap-0.1.0.yaml
+++ b/packages/js/manifests/polywrap/src/__tests__/manifest/polywrap/migrations/polywrap-0.1.0.yaml
@@ -8,4 +8,4 @@ meta: ./polywrap.meta.yaml
 deploy: ./polywrap.deploy.yaml
 import_redirects:
   - uri: "ens/ipfs.polywrap.eth"
-    schema: ../../../../../../../../interfaces/ipfs/build/schema.graphql
+    schema: ../../schema.graphql

--- a/packages/js/manifests/polywrap/src/__tests__/manifest/polywrap/migrations/polywrap-0.2.0.yaml
+++ b/packages/js/manifests/polywrap/src/__tests__/manifest/polywrap/migrations/polywrap-0.2.0.yaml
@@ -7,7 +7,7 @@ source:
   module: ../index.ts
   import_abis:
     - uri: "ens/ipfs.polywrap.eth"
-      abi: ../../../../../../../../interfaces/ipfs/build/schema.graphql
+      abi: ../../wrap.info
 extensions:
   build: ./polywrap.build.yaml
   meta: ./polywrap.meta.yaml

--- a/packages/js/manifests/polywrap/src/formats/polywrap.app/migrators/0.1.0_to_0.2.0.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.app/migrators/0.1.0_to_0.2.0.ts
@@ -1,6 +1,8 @@
 import { AppManifest as OldManifest } from "../0.1.0";
 import { AppManifest as NewManifest } from "../0.2.0";
 
+import path from "path";
+
 export function migrate(manifest: OldManifest): NewManifest {
   return {
     format: "0.2.0",
@@ -13,10 +15,10 @@ export function migrate(manifest: OldManifest): NewManifest {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       import_abis: manifest.import_redirects?.map((x) => ({
         uri: x.uri,
-        abi: x.schema,
+        abi: path.join(path.dirname(x.schema), "wrap.info"),
       })),
     },
     // eslint-disable-next-line @typescript-eslint/naming-convention
     __type: "AppManifest",
   };
-};
+}

--- a/packages/js/manifests/polywrap/src/formats/polywrap.plugin/migrators/0.1.0_to_0.2.0.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.plugin/migrators/0.1.0_to_0.2.0.ts
@@ -1,6 +1,8 @@
 import { PluginManifest as OldManifest } from "../0.1.0";
 import { PluginManifest as NewManifest } from "../0.2.0";
 
+import path from "path";
+
 export function migrate(manifest: OldManifest): NewManifest {
   return {
     format: "0.2.0",
@@ -14,10 +16,10 @@ export function migrate(manifest: OldManifest): NewManifest {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       import_abis: manifest.import_redirects?.map((x) => ({
         uri: x.uri,
-        abi: x.schema,
+        abi: path.join(path.dirname(x.schema), "wrap.info"),
       })),
     },
     // eslint-disable-next-line @typescript-eslint/naming-convention
     __type: "PluginManifest",
   };
-};
+}

--- a/packages/js/manifests/polywrap/src/formats/polywrap/migrators/0.1.0_to_0.2.0.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap/migrators/0.1.0_to_0.2.0.ts
@@ -1,6 +1,8 @@
 import { PolywrapManifest as OldManifest } from "../0.1.0";
 import { PolywrapManifest as NewManifest } from "../0.2.0";
 
+import path from "path";
+
 export function migrate(manifest: OldManifest): NewManifest {
   const shouldHaveExtensions =
     manifest.build || manifest.deploy || manifest.meta;
@@ -23,11 +25,11 @@ export function migrate(manifest: OldManifest): NewManifest {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       import_abis: manifest.import_redirects?.map((x) => ({
         uri: x.uri,
-        abi: x.schema,
+        abi: path.join(path.dirname(x.schema), "wrap.info"),
       })),
     },
     extensions: shouldHaveExtensions ? maybeExtensions : undefined,
     // eslint-disable-next-line @typescript-eslint/naming-convention
     __type: "PolywrapManifest",
   };
-};
+}


### PR DESCRIPTION
Resolves #1185 

We might want to consider checking for the existence of `schema.graphql` before blindly migrating the `import_redirects` to `wrap.info`. This would require the migrator to "know" about the manifest's path.

Here's some context to my reasoning for this (copied from Discord):

> This is an interesting edge-case here, as the redirects work under the assumption that the file will always exist, which clearly isn't the case when we point to a file within the build folder.
> 
> So the migrator assumes that schema.graphql exists when migrating  import_redirects to import_abis, and I believe that to be the correct 1st step. 
> 
> What should probably happen in the case of that bug would be that the migrator searches for wrap.info within the same folder if the original file could not be found.
> 
> I'd need a bit more context on WHEN we use import_redirects, as my assumption was that we point it to a local file (and that file doesn't necessarily have to be part of a build output).
> 
> In any case I believe this solution would allow for flexibility in this case where we had 2 significant changes happen accross the repo (1st migration to manifest format 0.2, 2nd the introduction of wrap.info and depreciation of schema.graphql for build outputs)

Thoughts? @dOrgJelli @namesty @fetsorn ?