### PR TITLE
Fix: JavaScript minimization bug

### DIFF
--- a/packages/js/client/src/PolywrapClient.ts
+++ b/packages/js/client/src/PolywrapClient.ts
@@ -457,7 +457,7 @@ export class PolywrapClient implements Client {
     let uriResolvers = this.getUriResolvers({ contextId: contextId });
 
     if (!cacheRead) {
-      uriResolvers = uriResolvers.filter((x) => x.name !== CacheResolver.name);
+      uriResolvers = uriResolvers.filter((x) => !(x instanceof CacheResolver));
     }
     const { wrapper, uri: resolvedUri, uriHistory, error } = await resolveUri(
       this._toUri(uri),
@@ -504,7 +504,7 @@ export class PolywrapClient implements Client {
     failedUriResolvers: string[];
   }> {
     const extendableUriResolver = this.getUriResolvers().find(
-      (x) => x.name === ExtendableUriResolver.name
+      (x) => x instanceof ExtendableUriResolver
     ) as ExtendableUriResolver;
 
     if (!extendableUriResolver) {

--- a/packages/js/core/src/uri-resolution/resolvers/cache/CacheResolver.ts
+++ b/packages/js/core/src/uri-resolution/resolvers/cache/CacheResolver.ts
@@ -9,7 +9,7 @@ import { UriResolver, UriResolutionResult } from "../../core";
 
 export class CacheResolver implements UriResolver {
   public get name(): string {
-    return CacheResolver.name;
+    return "CacheResolver";
   }
 
   public async resolveUri(

--- a/packages/js/core/src/uri-resolution/resolvers/extendable/ExtendableUriResolver.ts
+++ b/packages/js/core/src/uri-resolution/resolvers/extendable/ExtendableUriResolver.ts
@@ -32,7 +32,7 @@ export class ExtendableUriResolver implements UriResolver {
   }
 
   public get name(): string {
-    return ExtendableUriResolver.name;
+    return "ExtendableUriResolver";
   }
 
   async resolveUri(
@@ -101,7 +101,7 @@ export class ExtendableUriResolver implements UriResolver {
   }> {
     const bootstrapUriResolvers = client
       .getUriResolvers({})
-      .filter((x) => x.name !== ExtendableUriResolver.name);
+      .filter((x) => x.name !== this.name);
 
     const implementationsToLoad = new Queue<Uri>();
 

--- a/packages/js/core/src/uri-resolution/resolvers/extendable/UriResolverWrapper.ts
+++ b/packages/js/core/src/uri-resolution/resolvers/extendable/UriResolverWrapper.ts
@@ -22,7 +22,7 @@ export class UriResolverWrapper implements UriResolver {
   ) {}
 
   public get name(): string {
-    return UriResolverWrapper.name;
+    return "UriResolverWrapper";
   }
 
   async resolveUri(

--- a/packages/js/core/src/uri-resolution/resolvers/plugin/PluginResolver.ts
+++ b/packages/js/core/src/uri-resolution/resolvers/plugin/PluginResolver.ts
@@ -24,7 +24,7 @@ export class PluginResolver implements UriResolver {
   ) {}
 
   public get name(): string {
-    return PluginResolver.name;
+    return "PluginResolver";
   }
 
   async resolveUri(

--- a/packages/js/core/src/uri-resolution/resolvers/redirects/RedirectsResolver.ts
+++ b/packages/js/core/src/uri-resolution/resolvers/redirects/RedirectsResolver.ts
@@ -4,7 +4,7 @@ import { UriResolver, UriResolutionResult } from "../../core";
 
 export class RedirectsResolver implements UriResolver {
   public get name(): string {
-    return RedirectsResolver.name;
+    return "RedirectsResolver";
   }
 
   async resolveUri(uri: Uri, client: Client): Promise<UriResolutionResult> {


### PR DESCRIPTION
The client has a bug that prevents url resolvers from loading correctly after JavaScript minimization (aka "minification"). The bug can be circumvented by configuring weback to keep function names. 

This PR fixes the issue so that webpack configuration is not necessary. It does so by removing the use of reflection from the client and uri resolvers. In particular, the client and uri resolvers were using `X.name` where X is the name of a uri resolver class.

I'm not sure how to write an automated test for this. I tested the fix using the Uniswap v3 front end. After linking the updated toolchain packages, the Uniswap v3 front end works without modifying the webpack configuration.

Closes https://github.com/polywrap/toolchain/issues/985.