### PR TITLE
Feat: TypeScript App/Plugin Codegen Type Safety

### DIFF
--- a/packages/schema/bind/src/bindings/typescript/app/templates/types-ts.mustache
+++ b/packages/schema/bind/src/bindings/typescript/app/templates/types-ts.mustache
@@ -88,7 +88,7 @@ export type {{#detectKeyword}}{{type}}{{/detectKeyword}} = {{type}}Enum | {{type
 {{#methods}}
 
 /* URI: "{{parent.uri}}" */
-interface {{parent.type}}_Args_{{name}} extends Record<string, unknown> {
+interface {{parent.type}}_Args_{{name}} {
   {{#arguments}}
   {{name}}{{^required}}?{{/required}}: {{#toTypescript}}{{toGraphQLType}}{{/toTypescript}};
   {{/arguments}}
@@ -106,7 +106,7 @@ export const {{type}} = {
     return client.invoke<{{#return}}{{#toTypescript}}{{toGraphQLType}}{{/toTypescript}}{{/return}}>({
       uri,
       method: "{{name}}",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   }{{^last}},{{/last}}
   {{^last}}

--- a/packages/schema/bind/src/bindings/typescript/plugin/templates/module-ts.mustache
+++ b/packages/schema/bind/src/bindings/typescript/plugin/templates/module-ts.mustache
@@ -11,7 +11,7 @@ import {
 {{#moduleType}}
 {{#methods}}
 
-export interface Args_{{name}} extends Record<string, unknown> {
+export interface Args_{{name}} {
   {{#arguments}}
   {{name}}{{^required}}?{{/required}}: {{#toTypescript}}{{toGraphQLType}}{{/toTypescript}};
   {{/arguments}}

--- a/packages/schema/bind/src/bindings/typescript/plugin/templates/types-ts.mustache
+++ b/packages/schema/bind/src/bindings/typescript/plugin/templates/types-ts.mustache
@@ -98,7 +98,7 @@ export type {{#detectKeyword}}{{type}}{{/detectKeyword}} = {{type}}Enum | {{type
 {{#importedModuleTypes}}
 {{#methods}}
 /* URI: "{{parent.uri}}" */
-interface {{parent.type}}_Args_{{name}} extends Record<string, unknown> {
+interface {{parent.type}}_Args_{{name}} {
   {{#arguments}}
   {{name}}{{^required}}?{{/required}}: {{#toTypescript}}{{toGraphQLType}}{{/toTypescript}};
   {{/arguments}}
@@ -116,7 +116,7 @@ export const {{type}} = {
     return client.invoke<{{#return}}{{#toTypescript}}{{toGraphQLType}}{{/toTypescript}}{{/return}}>({
       uri: "{{parent.uri}}",
       method: "{{name}}",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   }{{^last}},{{/last}}
   {{^last}}
@@ -141,7 +141,7 @@ export class {{#detectKeyword}}{{type}}{{/detectKeyword}} {
     return client.invoke<{{#return}}{{#toTypescript}}{{toGraphQLType}}{{/toTypescript}}{{/return}}>({
       uri: this.uri,
       method: "{{name}}",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   }
   {{^last}}

--- a/packages/test-cases/cases/bind/sanity/output/app-ts/types.ts
+++ b/packages/test-cases/cases/bind/sanity/output/app-ts/types.ts
@@ -143,7 +143,7 @@ export type TestImport_Enum = TestImport_EnumEnum | TestImport_EnumString;
 /// Imported Modules START ///
 
 /* URI: "testimport.uri.eth" */
-interface TestImport_Module_Args_importedMethod extends Record<string, unknown> {
+interface TestImport_Module_Args_importedMethod {
   str: Types.String;
   optStr?: Types.String | null;
   u: Types.UInt;
@@ -160,7 +160,7 @@ interface TestImport_Module_Args_importedMethod extends Record<string, unknown> 
 }
 
 /* URI: "testimport.uri.eth" */
-interface TestImport_Module_Args_anotherMethod extends Record<string, unknown> {
+interface TestImport_Module_Args_anotherMethod {
   arg: Array<Types.String>;
 }
 
@@ -174,7 +174,7 @@ export const TestImport_Module = {
     return client.invoke<Types.TestImport_Object | null>({
       uri,
       method: "importedMethod",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -186,7 +186,7 @@ export const TestImport_Module = {
     return client.invoke<Types.Int32>({
       uri,
       method: "anotherMethod",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   }
 }

--- a/packages/test-cases/cases/bind/sanity/output/plugin-ts/module.ts
+++ b/packages/test-cases/cases/bind/sanity/output/plugin-ts/module.ts
@@ -9,7 +9,7 @@ import {
   MaybeAsync
 } from "@polywrap/core-js";
 
-export interface Args_moduleMethod extends Record<string, unknown> {
+export interface Args_moduleMethod {
   str: Types.String;
   optStr?: Types.String | null;
   en: Types.CustomEnum;
@@ -23,21 +23,21 @@ export interface Args_moduleMethod extends Record<string, unknown> {
   mapOfArrOfObj: Map<Types.String, Array<Types.AnotherType>>;
 }
 
-export interface Args_objectMethod extends Record<string, unknown> {
+export interface Args_objectMethod {
   object: Types.AnotherType;
   optObject?: Types.AnotherType | null;
   objectArray: Array<Types.AnotherType>;
   optObjectArray?: Array<Types.AnotherType | null> | null;
 }
 
-export interface Args_optionalEnvMethod extends Record<string, unknown> {
+export interface Args_optionalEnvMethod {
   object: Types.AnotherType;
   optObject?: Types.AnotherType | null;
   objectArray: Array<Types.AnotherType>;
   optObjectArray?: Array<Types.AnotherType | null> | null;
 }
 
-export interface Args_if extends Record<string, unknown> {
+export interface Args_if {
   if: Types._else;
 }
 

--- a/packages/test-cases/cases/bind/sanity/output/plugin-ts/types.ts
+++ b/packages/test-cases/cases/bind/sanity/output/plugin-ts/types.ts
@@ -156,7 +156,7 @@ export type TestImport_Enum = TestImport_EnumEnum | TestImport_EnumString;
 /// Imported Modules START ///
 
 /* URI: "testimport.uri.eth" */
-interface TestImport_Module_Args_importedMethod extends Record<string, unknown> {
+interface TestImport_Module_Args_importedMethod {
   str: Types.String;
   optStr?: Types.String | null;
   u: Types.UInt;
@@ -173,7 +173,7 @@ interface TestImport_Module_Args_importedMethod extends Record<string, unknown> 
 }
 
 /* URI: "testimport.uri.eth" */
-interface TestImport_Module_Args_anotherMethod extends Record<string, unknown> {
+interface TestImport_Module_Args_anotherMethod {
   arg: Array<Types.String>;
 }
 
@@ -191,7 +191,7 @@ export class TestImport_Module {
     return client.invoke<Types.TestImport_Object | null>({
       uri: this.uri,
       method: "importedMethod",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   }
 
@@ -202,7 +202,7 @@ export class TestImport_Module {
     return client.invoke<Types.Int32>({
       uri: this.uri,
       method: "anotherMethod",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   }
 }

--- a/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/module.ts
@@ -9,12 +9,12 @@ import {
   MaybeAsync
 } from "@polywrap/core-js";
 
-export interface Args_methodOne extends Record<string, unknown> {
+export interface Args_methodOne {
   str: Types.String;
   optStr?: Types.String | null;
 }
 
-export interface Args_methodTwo extends Record<string, unknown> {
+export interface Args_methodTwo {
   arg: Types.UInt32;
 }
 

--- a/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/types.ts
@@ -159,7 +159,7 @@ export interface Ethereum_Access {
 /// Imported Modules START ///
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractView extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractView {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -167,7 +167,7 @@ interface Ethereum_Module_Args_callContractView extends Record<string, unknown> 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractStatic extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractStatic {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -176,72 +176,72 @@ interface Ethereum_Module_Args_callContractStatic extends Record<string, unknown
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getBalance extends Record<string, unknown> {
+interface Ethereum_Module_Args_getBalance {
   address: Types.String;
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeParams extends Record<string, unknown> {
+interface Ethereum_Module_Args_encodeParams {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeFunction extends Record<string, unknown> {
+interface Ethereum_Module_Args_encodeFunction {
   method: Types.String;
   args?: Array<Types.String> | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityPack extends Record<string, unknown> {
+interface Ethereum_Module_Args_solidityPack {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityKeccak256 extends Record<string, unknown> {
+interface Ethereum_Module_Args_solidityKeccak256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_soliditySha256 extends Record<string, unknown> {
+interface Ethereum_Module_Args_soliditySha256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerAddress extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerAddress {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerBalance extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerBalance {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerTransactionCount extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerTransactionCount {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getGasPrice extends Record<string, unknown> {
+interface Ethereum_Module_Args_getGasPrice {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateTransactionGas extends Record<string, unknown> {
+interface Ethereum_Module_Args_estimateTransactionGas {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateContractCallGas extends Record<string, unknown> {
+interface Ethereum_Module_Args_estimateContractCallGas {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -250,22 +250,22 @@ interface Ethereum_Module_Args_estimateContractCallGas extends Record<string, un
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_checkAddress extends Record<string, unknown> {
+interface Ethereum_Module_Args_checkAddress {
   address: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toWei extends Record<string, unknown> {
+interface Ethereum_Module_Args_toWei {
   eth: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toEth extends Record<string, unknown> {
+interface Ethereum_Module_Args_toEth {
   wei: Types.BigInt;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_awaitTransaction extends Record<string, unknown> {
+interface Ethereum_Module_Args_awaitTransaction {
   txHash: Types.String;
   confirmations: Types.UInt32;
   timeout: Types.UInt32;
@@ -273,7 +273,7 @@ interface Ethereum_Module_Args_awaitTransaction extends Record<string, unknown> 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_waitForEvent extends Record<string, unknown> {
+interface Ethereum_Module_Args_waitForEvent {
   address: Types.String;
   event: Types.String;
   args?: Array<Types.String> | null;
@@ -282,17 +282,17 @@ interface Ethereum_Module_Args_waitForEvent extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getNetwork extends Record<string, unknown> {
+interface Ethereum_Module_Args_getNetwork {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_requestAccounts extends Record<string, unknown> {
+interface Ethereum_Module_Args_requestAccounts {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractMethod {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -301,7 +301,7 @@ interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethodAndWait extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractMethodAndWait {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -310,19 +310,19 @@ interface Ethereum_Module_Args_callContractMethodAndWait extends Record<string, 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransaction extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendTransaction {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransactionAndWait extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendTransactionAndWait {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_deployContract extends Record<string, unknown> {
+interface Ethereum_Module_Args_deployContract {
   abi: Types.String;
   bytecode: Types.String;
   args?: Array<Types.String> | null;
@@ -330,13 +330,13 @@ interface Ethereum_Module_Args_deployContract extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessage extends Record<string, unknown> {
+interface Ethereum_Module_Args_signMessage {
   message: Types.String;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendRPC extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendRPC {
   method: Types.String;
   params: Array<Types.String>;
   connection?: Types.Ethereum_Connection | null;
@@ -351,7 +351,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractView",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -362,7 +362,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_StaticTxResult>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractStatic",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -373,7 +373,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getBalance",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -384,7 +384,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "encodeParams",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -395,7 +395,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "encodeFunction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -406,7 +406,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "solidityPack",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -417,7 +417,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "solidityKeccak256",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -428,7 +428,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "soliditySha256",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -439,7 +439,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerAddress",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -450,7 +450,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerBalance",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -461,7 +461,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerTransactionCount",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -472,7 +472,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getGasPrice",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -483,7 +483,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "estimateTransactionGas",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -494,7 +494,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "estimateContractCallGas",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -505,7 +505,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Boolean>({
       uri: "ens/ethereum.polywrap.eth",
       method: "checkAddress",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -516,7 +516,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "toWei",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -527,7 +527,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "toEth",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -538,7 +538,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "awaitTransaction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -549,7 +549,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_EventNotification>({
       uri: "ens/ethereum.polywrap.eth",
       method: "waitForEvent",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -560,7 +560,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_Network>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getNetwork",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -571,7 +571,7 @@ export const Ethereum_Module = {
     return client.invoke<Array<Types.String>>({
       uri: "ens/ethereum.polywrap.eth",
       method: "requestAccounts",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -582,7 +582,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxResponse>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractMethod",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -593,7 +593,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractMethodAndWait",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -604,7 +604,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxResponse>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendTransaction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -615,7 +615,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendTransactionAndWait",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -626,7 +626,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "deployContract",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -637,7 +637,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "signMessage",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -648,7 +648,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String | null>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendRPC",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   }
 }

--- a/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/module.ts
@@ -9,7 +9,7 @@ import {
   MaybeAsync
 } from "@polywrap/core-js";
 
-export interface Args_method extends Record<string, unknown> {
+export interface Args_method {
   str: Types.String;
   optStr?: Types.String | null;
 }

--- a/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/types.ts
@@ -159,7 +159,7 @@ export interface Ethereum_Access {
 /// Imported Modules START ///
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractView extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractView {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -167,7 +167,7 @@ interface Ethereum_Module_Args_callContractView extends Record<string, unknown> 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractStatic extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractStatic {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -176,72 +176,72 @@ interface Ethereum_Module_Args_callContractStatic extends Record<string, unknown
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getBalance extends Record<string, unknown> {
+interface Ethereum_Module_Args_getBalance {
   address: Types.String;
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeParams extends Record<string, unknown> {
+interface Ethereum_Module_Args_encodeParams {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeFunction extends Record<string, unknown> {
+interface Ethereum_Module_Args_encodeFunction {
   method: Types.String;
   args?: Array<Types.String> | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityPack extends Record<string, unknown> {
+interface Ethereum_Module_Args_solidityPack {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityKeccak256 extends Record<string, unknown> {
+interface Ethereum_Module_Args_solidityKeccak256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_soliditySha256 extends Record<string, unknown> {
+interface Ethereum_Module_Args_soliditySha256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerAddress extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerAddress {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerBalance extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerBalance {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerTransactionCount extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerTransactionCount {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getGasPrice extends Record<string, unknown> {
+interface Ethereum_Module_Args_getGasPrice {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateTransactionGas extends Record<string, unknown> {
+interface Ethereum_Module_Args_estimateTransactionGas {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateContractCallGas extends Record<string, unknown> {
+interface Ethereum_Module_Args_estimateContractCallGas {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -250,22 +250,22 @@ interface Ethereum_Module_Args_estimateContractCallGas extends Record<string, un
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_checkAddress extends Record<string, unknown> {
+interface Ethereum_Module_Args_checkAddress {
   address: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toWei extends Record<string, unknown> {
+interface Ethereum_Module_Args_toWei {
   eth: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toEth extends Record<string, unknown> {
+interface Ethereum_Module_Args_toEth {
   wei: Types.BigInt;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_awaitTransaction extends Record<string, unknown> {
+interface Ethereum_Module_Args_awaitTransaction {
   txHash: Types.String;
   confirmations: Types.UInt32;
   timeout: Types.UInt32;
@@ -273,7 +273,7 @@ interface Ethereum_Module_Args_awaitTransaction extends Record<string, unknown> 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_waitForEvent extends Record<string, unknown> {
+interface Ethereum_Module_Args_waitForEvent {
   address: Types.String;
   event: Types.String;
   args?: Array<Types.String> | null;
@@ -282,17 +282,17 @@ interface Ethereum_Module_Args_waitForEvent extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getNetwork extends Record<string, unknown> {
+interface Ethereum_Module_Args_getNetwork {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_requestAccounts extends Record<string, unknown> {
+interface Ethereum_Module_Args_requestAccounts {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractMethod {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -301,7 +301,7 @@ interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethodAndWait extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractMethodAndWait {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -310,19 +310,19 @@ interface Ethereum_Module_Args_callContractMethodAndWait extends Record<string, 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransaction extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendTransaction {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransactionAndWait extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendTransactionAndWait {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_deployContract extends Record<string, unknown> {
+interface Ethereum_Module_Args_deployContract {
   abi: Types.String;
   bytecode: Types.String;
   args?: Array<Types.String> | null;
@@ -330,13 +330,13 @@ interface Ethereum_Module_Args_deployContract extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessage extends Record<string, unknown> {
+interface Ethereum_Module_Args_signMessage {
   message: Types.String;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendRPC extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendRPC {
   method: Types.String;
   params: Array<Types.String>;
   connection?: Types.Ethereum_Connection | null;
@@ -351,7 +351,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractView",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -362,7 +362,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_StaticTxResult>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractStatic",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -373,7 +373,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getBalance",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -384,7 +384,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "encodeParams",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -395,7 +395,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "encodeFunction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -406,7 +406,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "solidityPack",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -417,7 +417,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "solidityKeccak256",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -428,7 +428,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "soliditySha256",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -439,7 +439,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerAddress",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -450,7 +450,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerBalance",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -461,7 +461,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerTransactionCount",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -472,7 +472,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getGasPrice",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -483,7 +483,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "estimateTransactionGas",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -494,7 +494,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "estimateContractCallGas",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -505,7 +505,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Boolean>({
       uri: "ens/ethereum.polywrap.eth",
       method: "checkAddress",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -516,7 +516,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "toWei",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -527,7 +527,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "toEth",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -538,7 +538,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "awaitTransaction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -549,7 +549,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_EventNotification>({
       uri: "ens/ethereum.polywrap.eth",
       method: "waitForEvent",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -560,7 +560,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_Network>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getNetwork",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -571,7 +571,7 @@ export const Ethereum_Module = {
     return client.invoke<Array<Types.String>>({
       uri: "ens/ethereum.polywrap.eth",
       method: "requestAccounts",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -582,7 +582,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxResponse>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractMethod",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -593,7 +593,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractMethodAndWait",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -604,7 +604,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxResponse>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendTransaction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -615,7 +615,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendTransactionAndWait",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -626,7 +626,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "deployContract",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -637,7 +637,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "signMessage",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -648,7 +648,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String | null>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendRPC",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   }
 }

--- a/packages/test-cases/cases/cli/plugin/codegen/003-env/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/003-env/expected/wrap/module.ts
@@ -9,7 +9,7 @@ import {
   MaybeAsync
 } from "@polywrap/core-js";
 
-export interface Args_method extends Record<string, unknown> {
+export interface Args_method {
   str: Types.String;
 }
 

--- a/packages/test-cases/cases/cli/plugin/codegen/004-env-sanitization/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/004-env-sanitization/expected/wrap/module.ts
@@ -9,7 +9,7 @@ import {
   MaybeAsync
 } from "@polywrap/core-js";
 
-export interface Args_method extends Record<string, unknown> {
+export interface Args_method {
   str: Types.String;
 }
 

--- a/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/module.ts
@@ -9,12 +9,12 @@ import {
   MaybeAsync
 } from "@polywrap/core-js";
 
-export interface Args_methodOne extends Record<string, unknown> {
+export interface Args_methodOne {
   str: Types.String;
   optStr?: Types.String | null;
 }
 
-export interface Args_methodTwo extends Record<string, unknown> {
+export interface Args_methodTwo {
   arg: Types.UInt32;
 }
 

--- a/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/types.ts
@@ -159,7 +159,7 @@ export interface Ethereum_Access {
 /// Imported Modules START ///
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractView extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractView {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -167,7 +167,7 @@ interface Ethereum_Module_Args_callContractView extends Record<string, unknown> 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractStatic extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractStatic {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -176,72 +176,72 @@ interface Ethereum_Module_Args_callContractStatic extends Record<string, unknown
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getBalance extends Record<string, unknown> {
+interface Ethereum_Module_Args_getBalance {
   address: Types.String;
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeParams extends Record<string, unknown> {
+interface Ethereum_Module_Args_encodeParams {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeFunction extends Record<string, unknown> {
+interface Ethereum_Module_Args_encodeFunction {
   method: Types.String;
   args?: Array<Types.String> | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityPack extends Record<string, unknown> {
+interface Ethereum_Module_Args_solidityPack {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityKeccak256 extends Record<string, unknown> {
+interface Ethereum_Module_Args_solidityKeccak256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_soliditySha256 extends Record<string, unknown> {
+interface Ethereum_Module_Args_soliditySha256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerAddress extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerAddress {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerBalance extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerBalance {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerTransactionCount extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerTransactionCount {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getGasPrice extends Record<string, unknown> {
+interface Ethereum_Module_Args_getGasPrice {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateTransactionGas extends Record<string, unknown> {
+interface Ethereum_Module_Args_estimateTransactionGas {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateContractCallGas extends Record<string, unknown> {
+interface Ethereum_Module_Args_estimateContractCallGas {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -250,22 +250,22 @@ interface Ethereum_Module_Args_estimateContractCallGas extends Record<string, un
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_checkAddress extends Record<string, unknown> {
+interface Ethereum_Module_Args_checkAddress {
   address: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toWei extends Record<string, unknown> {
+interface Ethereum_Module_Args_toWei {
   eth: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toEth extends Record<string, unknown> {
+interface Ethereum_Module_Args_toEth {
   wei: Types.BigInt;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_awaitTransaction extends Record<string, unknown> {
+interface Ethereum_Module_Args_awaitTransaction {
   txHash: Types.String;
   confirmations: Types.UInt32;
   timeout: Types.UInt32;
@@ -273,7 +273,7 @@ interface Ethereum_Module_Args_awaitTransaction extends Record<string, unknown> 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_waitForEvent extends Record<string, unknown> {
+interface Ethereum_Module_Args_waitForEvent {
   address: Types.String;
   event: Types.String;
   args?: Array<Types.String> | null;
@@ -282,17 +282,17 @@ interface Ethereum_Module_Args_waitForEvent extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getNetwork extends Record<string, unknown> {
+interface Ethereum_Module_Args_getNetwork {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_requestAccounts extends Record<string, unknown> {
+interface Ethereum_Module_Args_requestAccounts {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractMethod {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -301,7 +301,7 @@ interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethodAndWait extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractMethodAndWait {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -310,19 +310,19 @@ interface Ethereum_Module_Args_callContractMethodAndWait extends Record<string, 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransaction extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendTransaction {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransactionAndWait extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendTransactionAndWait {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_deployContract extends Record<string, unknown> {
+interface Ethereum_Module_Args_deployContract {
   abi: Types.String;
   bytecode: Types.String;
   args?: Array<Types.String> | null;
@@ -330,13 +330,13 @@ interface Ethereum_Module_Args_deployContract extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessage extends Record<string, unknown> {
+interface Ethereum_Module_Args_signMessage {
   message: Types.String;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendRPC extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendRPC {
   method: Types.String;
   params: Array<Types.String>;
   connection?: Types.Ethereum_Connection | null;
@@ -351,7 +351,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractView",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -362,7 +362,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_StaticTxResult>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractStatic",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -373,7 +373,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getBalance",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -384,7 +384,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "encodeParams",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -395,7 +395,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "encodeFunction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -406,7 +406,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "solidityPack",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -417,7 +417,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "solidityKeccak256",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -428,7 +428,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "soliditySha256",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -439,7 +439,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerAddress",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -450,7 +450,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerBalance",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -461,7 +461,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerTransactionCount",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -472,7 +472,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getGasPrice",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -483,7 +483,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "estimateTransactionGas",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -494,7 +494,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "estimateContractCallGas",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -505,7 +505,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Boolean>({
       uri: "ens/ethereum.polywrap.eth",
       method: "checkAddress",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -516,7 +516,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "toWei",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -527,7 +527,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "toEth",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -538,7 +538,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "awaitTransaction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -549,7 +549,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_EventNotification>({
       uri: "ens/ethereum.polywrap.eth",
       method: "waitForEvent",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -560,7 +560,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_Network>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getNetwork",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -571,7 +571,7 @@ export const Ethereum_Module = {
     return client.invoke<Array<Types.String>>({
       uri: "ens/ethereum.polywrap.eth",
       method: "requestAccounts",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -582,7 +582,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxResponse>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractMethod",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -593,7 +593,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractMethodAndWait",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -604,7 +604,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxResponse>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendTransaction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -615,7 +615,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendTransactionAndWait",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -626,7 +626,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "deployContract",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -637,7 +637,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "signMessage",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -648,7 +648,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String | null>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendRPC",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   }
 }

--- a/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/module.ts
@@ -9,12 +9,12 @@ import {
   MaybeAsync
 } from "@polywrap/core-js";
 
-export interface Args_methodOne extends Record<string, unknown> {
+export interface Args_methodOne {
   str: Types.String;
   optStr?: Types.String | null;
 }
 
-export interface Args_methodTwo extends Record<string, unknown> {
+export interface Args_methodTwo {
   arg: Types.UInt32;
 }
 

--- a/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/types.ts
@@ -159,7 +159,7 @@ export interface Ethereum_Access {
 /// Imported Modules START ///
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractView extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractView {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -167,7 +167,7 @@ interface Ethereum_Module_Args_callContractView extends Record<string, unknown> 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractStatic extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractStatic {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -176,72 +176,72 @@ interface Ethereum_Module_Args_callContractStatic extends Record<string, unknown
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getBalance extends Record<string, unknown> {
+interface Ethereum_Module_Args_getBalance {
   address: Types.String;
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeParams extends Record<string, unknown> {
+interface Ethereum_Module_Args_encodeParams {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeFunction extends Record<string, unknown> {
+interface Ethereum_Module_Args_encodeFunction {
   method: Types.String;
   args?: Array<Types.String> | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityPack extends Record<string, unknown> {
+interface Ethereum_Module_Args_solidityPack {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityKeccak256 extends Record<string, unknown> {
+interface Ethereum_Module_Args_solidityKeccak256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_soliditySha256 extends Record<string, unknown> {
+interface Ethereum_Module_Args_soliditySha256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerAddress extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerAddress {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerBalance extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerBalance {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerTransactionCount extends Record<string, unknown> {
+interface Ethereum_Module_Args_getSignerTransactionCount {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getGasPrice extends Record<string, unknown> {
+interface Ethereum_Module_Args_getGasPrice {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateTransactionGas extends Record<string, unknown> {
+interface Ethereum_Module_Args_estimateTransactionGas {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateContractCallGas extends Record<string, unknown> {
+interface Ethereum_Module_Args_estimateContractCallGas {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -250,22 +250,22 @@ interface Ethereum_Module_Args_estimateContractCallGas extends Record<string, un
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_checkAddress extends Record<string, unknown> {
+interface Ethereum_Module_Args_checkAddress {
   address: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toWei extends Record<string, unknown> {
+interface Ethereum_Module_Args_toWei {
   eth: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toEth extends Record<string, unknown> {
+interface Ethereum_Module_Args_toEth {
   wei: Types.BigInt;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_awaitTransaction extends Record<string, unknown> {
+interface Ethereum_Module_Args_awaitTransaction {
   txHash: Types.String;
   confirmations: Types.UInt32;
   timeout: Types.UInt32;
@@ -273,7 +273,7 @@ interface Ethereum_Module_Args_awaitTransaction extends Record<string, unknown> 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_waitForEvent extends Record<string, unknown> {
+interface Ethereum_Module_Args_waitForEvent {
   address: Types.String;
   event: Types.String;
   args?: Array<Types.String> | null;
@@ -282,17 +282,17 @@ interface Ethereum_Module_Args_waitForEvent extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getNetwork extends Record<string, unknown> {
+interface Ethereum_Module_Args_getNetwork {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_requestAccounts extends Record<string, unknown> {
+interface Ethereum_Module_Args_requestAccounts {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractMethod {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -301,7 +301,7 @@ interface Ethereum_Module_Args_callContractMethod extends Record<string, unknown
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethodAndWait extends Record<string, unknown> {
+interface Ethereum_Module_Args_callContractMethodAndWait {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -310,19 +310,19 @@ interface Ethereum_Module_Args_callContractMethodAndWait extends Record<string, 
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransaction extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendTransaction {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransactionAndWait extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendTransactionAndWait {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_deployContract extends Record<string, unknown> {
+interface Ethereum_Module_Args_deployContract {
   abi: Types.String;
   bytecode: Types.String;
   args?: Array<Types.String> | null;
@@ -330,13 +330,13 @@ interface Ethereum_Module_Args_deployContract extends Record<string, unknown> {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessage extends Record<string, unknown> {
+interface Ethereum_Module_Args_signMessage {
   message: Types.String;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendRPC extends Record<string, unknown> {
+interface Ethereum_Module_Args_sendRPC {
   method: Types.String;
   params: Array<Types.String>;
   connection?: Types.Ethereum_Connection | null;
@@ -351,7 +351,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractView",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -362,7 +362,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_StaticTxResult>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractStatic",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -373,7 +373,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getBalance",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -384,7 +384,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "encodeParams",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -395,7 +395,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "encodeFunction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -406,7 +406,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "solidityPack",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -417,7 +417,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "solidityKeccak256",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -428,7 +428,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "soliditySha256",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -439,7 +439,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerAddress",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -450,7 +450,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerBalance",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -461,7 +461,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getSignerTransactionCount",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -472,7 +472,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getGasPrice",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -483,7 +483,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "estimateTransactionGas",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -494,7 +494,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "estimateContractCallGas",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -505,7 +505,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Boolean>({
       uri: "ens/ethereum.polywrap.eth",
       method: "checkAddress",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -516,7 +516,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.BigInt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "toWei",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -527,7 +527,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "toEth",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -538,7 +538,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "awaitTransaction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -549,7 +549,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_EventNotification>({
       uri: "ens/ethereum.polywrap.eth",
       method: "waitForEvent",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -560,7 +560,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_Network>({
       uri: "ens/ethereum.polywrap.eth",
       method: "getNetwork",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -571,7 +571,7 @@ export const Ethereum_Module = {
     return client.invoke<Array<Types.String>>({
       uri: "ens/ethereum.polywrap.eth",
       method: "requestAccounts",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -582,7 +582,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxResponse>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractMethod",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -593,7 +593,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "callContractMethodAndWait",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -604,7 +604,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxResponse>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendTransaction",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -615,7 +615,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.Ethereum_TxReceipt>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendTransactionAndWait",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -626,7 +626,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "deployContract",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -637,7 +637,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String>({
       uri: "ens/ethereum.polywrap.eth",
       method: "signMessage",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   },
 
@@ -648,7 +648,7 @@ export const Ethereum_Module = {
     return client.invoke<Types.String | null>({
       uri: "ens/ethereum.polywrap.eth",
       method: "sendRPC",
-      args
+      args: args as unknown as Record<string, unknown>
     });
   }
 }


### PR DESCRIPTION
This PR enforces type safety for generated TypeScript code. Instead of extending `Record<string, unknown>`, generated object and arg types are cast to `Record<string, unknown>` just before invocations are called in the generated `Module` type. Generated arg types must be typecast to `Record<string, unknown>` because the client's `invoke` method expects a `Record<string, unknown> | UInt8Array | undefined`.

The TypeScript interface for the generated `Env` type still extends `Record<string, unknown>` to ensure it conforms to the generic parameter restriction set by the `PluginModule` definition in `@polywrap/core-js`.

Closes https://github.com/polywrap/toolchain/issues/897