### PR TITLE
Feat: Add '--no-codegen' option to CLI build command

### DIFF
--- a/packages/cli/lang/en.json
+++ b/packages/cli/lang/en.json
@@ -13,6 +13,7 @@
   "commands_build_options_o_path": "path",
   "commands_build_options_options": "options",
   "commands_build_options_t": "Use the development server's ENS instance",
+  "commands_build_options_n": "Skip code generation",
   "commands_build_options_w": "Automatically rebuild when changes are made (default: false)",
   "commands_build_options_v": "Verbose output (default: false)",
   "commands_infra_description": "Modular Infrastructure-As-Code Orchestrator",

--- a/packages/cli/lang/es.json
+++ b/packages/cli/lang/es.json
@@ -13,6 +13,7 @@
   "commands_build_options_o_path": "path",
   "commands_build_options_options": "options",
   "commands_build_options_t": "Use the development server's ENS instance",
+  "commands_build_options_n": "Skip code generation",
   "commands_build_options_w": "Automatically rebuild when changes are made (default: false)",
   "commands_build_options_v": "Verbose output (default: false)",
   "commands_infra_description": "Modular Infrastructure-As-Code Orchestrator",

--- a/packages/cli/src/__tests__/e2e/build.spec.ts
+++ b/packages/cli/src/__tests__/e2e/build.spec.ts
@@ -18,6 +18,7 @@ Options:
                                      (default: ./build)
   -c, --client-config <config-path>  Add custom configuration to the
                                      PolywrapClient
+  -n, --no-codegen                   Skip code generation
   -w, --watch                        Automatically rebuild when changes are
                                      made (default: false)
   -v, --verbose                      Verbose output (default: false)

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -28,6 +28,7 @@ type BuildCommandOptions = {
   manifestFile: string;
   outputDir: string;
   clientConfig: Partial<PolywrapClientConfig>;
+  codegen: boolean; // defaults to true
   watch?: boolean;
   verbose?: boolean;
 };
@@ -54,6 +55,7 @@ export const build: Command = {
         `-c, --client-config <${intlMsg.commands_common_options_configPath()}>`,
         `${intlMsg.commands_common_options_config()}`
       )
+      .option(`-n, --no-codegen`, `${intlMsg.commands_build_options_n()}`)
       .option(`-w, --watch`, `${intlMsg.commands_build_options_w()}`)
       .option(`-v, --verbose`, `${intlMsg.commands_build_options_v()}`)
       .action(async (options) => {
@@ -68,7 +70,14 @@ export const build: Command = {
 };
 
 async function run(options: BuildCommandOptions) {
-  const { watch, verbose, manifestFile, outputDir, clientConfig } = options;
+  const {
+    watch,
+    verbose,
+    manifestFile,
+    outputDir,
+    clientConfig,
+    codegen,
+  } = options;
 
   // Get Client
   const client = new PolywrapClient(clientConfig);
@@ -100,6 +109,7 @@ async function run(options: BuildCommandOptions) {
     project,
     outputDir,
     schemaComposer,
+    codegen,
   });
 
   const execute = async (): Promise<boolean> => {

--- a/packages/cli/src/lib/Compiler.ts
+++ b/packages/cli/src/lib/Compiler.ts
@@ -41,6 +41,7 @@ export interface CompilerConfig {
   outputDir: string;
   project: PolywrapProject;
   schemaComposer: SchemaComposer;
+  codegen: boolean;
 }
 
 export class Compiler {
@@ -99,9 +100,10 @@ export class Compiler {
       await this._outputWrapManifest(state);
 
       if (!(await this._isInterface())) {
-        // Generate the bindings
-        await this._generateCode(state);
-
+        if (this._config.codegen) {
+          // Generate the bindings
+          await this._generateCode(state);
+        }
         // Compile the Wrapper
         await this._buildModules();
       }

--- a/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/cmd.json
+++ b/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/cmd.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--no-codegen"]
+}

--- a/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/expected/stdout.json
+++ b/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/expected/stdout.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    "Failed to compile Polywrap",
+    "File 'src/wrap/entry.ts' not found"
+  ],
+  "exitCode": 1
+}

--- a/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/package.json
+++ b/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@polywrap/test-project",
+  "version": "0.1.0",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "build": "polywrap build"
+  },
+  "dependencies": {
+    "@polywrap/wasm-as": "0.3.0"
+  },
+  "devDependencies": {
+    "assemblyscript": "0.19.5"
+  }
+}

--- a/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/polywrap.build.yaml
+++ b/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/polywrap.build.yaml
@@ -1,0 +1,6 @@
+format: 0.1.0
+config:
+  node_version: "14.16.0"
+linked_packages:
+  - name: "@polywrap/wasm-as"
+    path: ../../../../../../wasm/as

--- a/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/polywrap.yaml
+++ b/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/polywrap.yaml
@@ -1,0 +1,9 @@
+format: 0.2.0
+project:
+  name: test-project
+  type: wasm/assemblyscript
+source:
+  module: ./src/index.ts
+  schema: ./src/schema.graphql
+extensions:
+  build: ./polywrap.build.yaml

--- a/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/src/index.ts
+++ b/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/src/index.ts
@@ -1,0 +1,5 @@
+import { Args_method } from "./wrap";
+
+export function method(args: Args_method): string {
+  return args.arg;
+}

--- a/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/src/schema.graphql
+++ b/packages/test-cases/cases/cli/wasm/build-cmd/012-no-codegen/src/schema.graphql
@@ -1,0 +1,5 @@
+type Module {
+  method(
+    arg: String!
+  ): String!
+}


### PR DESCRIPTION
This PR adds a `--no-codegen` option to the CLI's build command. When the flag is present, bindings are not generated during the build process. Users are expected to generate bindings with the `codegen` command. Bindings should be located at `src/wrap`, where the compiler will look for them.

```bash
polywrap build --no-codegen
polywrap build -n
```

**Questions**
- Should this feature be added or moved to the build manifest?
- Should users be able to specify a path to their bindings directory other than `src/wrap`?

Closes https://github.com/polywrap/toolchain/issues/796