### PR TITLE
Fix: correctly handle error in getImplementations algorithm

### DIFF
--- a/packages/js/core/src/algorithms/get-implementations.ts
+++ b/packages/js/core/src/algorithms/get-implementations.ts
@@ -32,7 +32,7 @@ export const getImplementations = Tracer.traceFunc(
             redirects
           );
           if (!redirectsResult.ok) {
-            throw redirectsResult.error;
+            return redirectsResult;
           }
           fullyResolvedUri = redirectsResult.value;
         } else {

--- a/packages/js/core/src/algorithms/get-implementations.ts
+++ b/packages/js/core/src/algorithms/get-implementations.ts
@@ -23,7 +23,7 @@ export const getImplementations = Tracer.traceFunc(
     const addAllImplementationsFromImplementationsArray = (
       implementationsArray: readonly InterfaceImplementations<Uri>[],
       wrapperInterfaceUri: Uri
-    ) => {
+    ): Result<true, Error> => {
       for (const interfaceImplementations of implementationsArray) {
         let fullyResolvedUri: Uri;
         if (redirects) {
@@ -32,7 +32,7 @@ export const getImplementations = Tracer.traceFunc(
             redirects
           );
           if (!redirectsResult.ok) {
-            continue;
+            throw redirectsResult.error;
           }
           fullyResolvedUri = redirectsResult.value;
         } else {
@@ -45,6 +45,7 @@ export const getImplementations = Tracer.traceFunc(
           }
         }
       }
+      return ResultOk(true);
     };
 
     let finalUri = wrapperInterfaceUri;
@@ -57,8 +58,11 @@ export const getImplementations = Tracer.traceFunc(
       finalUri = redirectsResult.value;
     }
 
-    addAllImplementationsFromImplementationsArray(interfaces, finalUri);
+    const addAllImp = addAllImplementationsFromImplementationsArray(
+      interfaces,
+      finalUri
+    );
 
-    return ResultOk(result);
+    return addAllImp.ok ? ResultOk(result) : addAllImp;
   }
 );

--- a/packages/js/core/src/algorithms/get-implementations.ts
+++ b/packages/js/core/src/algorithms/get-implementations.ts
@@ -23,7 +23,7 @@ export const getImplementations = Tracer.traceFunc(
     const addAllImplementationsFromImplementationsArray = (
       implementationsArray: readonly InterfaceImplementations<Uri>[],
       wrapperInterfaceUri: Uri
-    ): Result<true, Error> => {
+    ): Result<undefined, Error> => {
       for (const interfaceImplementations of implementationsArray) {
         let fullyResolvedUri: Uri;
         if (redirects) {
@@ -45,7 +45,7 @@ export const getImplementations = Tracer.traceFunc(
           }
         }
       }
-      return ResultOk(true);
+      return ResultOk(undefined);
     };
 
     let finalUri = wrapperInterfaceUri;


### PR DESCRIPTION
Reverts an accidentally change to the behavior of getImplementations in https://github.com/polywrap/toolchain/pull/1277, where an error that was previous thrown instead became ignored