### PR TITLE
Make config props read only

### DIFF
--- a/packages/cli/src/lib/helpers/validate-client-config.ts
+++ b/packages/cli/src/lib/helpers/validate-client-config.ts
@@ -12,7 +12,7 @@ import {
 
 export function validateRedirects<
   TUri extends PluginPackage<unknown> | Uri | string
->(redirects: UriRedirect<TUri>[]): void {
+>(redirects: readonly UriRedirect<TUri>[]): void {
   if (!Array.isArray(redirects)) {
     throw new Error(intlMsg.commands_run_error_redirectsExportNotArray());
   }
@@ -44,7 +44,7 @@ export function validateRedirects<
 }
 
 export function validatePlugins<TUri extends Uri | string = string>(
-  plugins: PluginRegistration<TUri>[]
+  plugins: readonly PluginRegistration<TUri>[]
 ): void {
   if (!Array.isArray(plugins)) {
     throw new Error(intlMsg.commands_run_error_pluginsExportNotArray());
@@ -88,7 +88,7 @@ export function validatePlugins<TUri extends Uri | string = string>(
 }
 
 export function validateInterfaces<TUri extends Uri | string = string>(
-  interfaces: InterfaceImplementations<TUri>[]
+  interfaces: readonly InterfaceImplementations<TUri>[]
 ): void {
   if (!Array.isArray(interfaces)) {
     throw new Error(intlMsg.commands_run_error_interfacesExportNotArray());
@@ -138,7 +138,7 @@ export function validateInterfaces<TUri extends Uri | string = string>(
 }
 
 export function validateEnvs<TUri extends Uri | string = string>(
-  envs: Env<TUri>[]
+  envs: readonly Env<TUri>[]
 ): void {
   if (!Array.isArray(envs)) {
     throw new Error(intlMsg.commands_run_error_envsExportNotArray());

--- a/packages/js/client/src/PolywrapClient.ts
+++ b/packages/js/client/src/PolywrapClient.ts
@@ -43,11 +43,14 @@ import { Tracer, TracerConfig, TracingLevel } from "@polywrap/tracing-js";
 import { ClientConfigBuilder } from "@polywrap/client-config-builder-js";
 import { Result, ResultErr, ResultOk } from "@polywrap/result";
 
-export interface PolywrapClientConfig<TUri extends Uri | string = string>
+interface PolywrapClientConfigInternal<TUri extends Uri | string = string>
   extends ClientConfig<TUri> {
-  tracerConfig: Partial<TracerConfig>;
-  wrapperCache?: IWrapperCache;
+  tracerConfig: Readonly<Partial<TracerConfig>>;
+  wrapperCache?: Readonly<IWrapperCache>;
 }
+
+export interface PolywrapClientConfig<TUri extends Uri | string = string>
+  extends Readonly<PolywrapClientConfigInternal<TUri>> {}
 
 export class PolywrapClient implements Client {
   private _config: PolywrapClientConfig<Uri> = ({
@@ -111,7 +114,10 @@ export class PolywrapClient implements Client {
     } else {
       Tracer.disableTracing();
     }
-    this._config.tracerConfig = tracerConfig ?? {};
+    this._config = {
+      ...this._config,
+      tracerConfig: tracerConfig ?? {},
+    };
   }
 
   @Tracer.traceMethod("PolywrapClient: getRedirects")

--- a/packages/js/client/src/PolywrapClient.ts
+++ b/packages/js/client/src/PolywrapClient.ts
@@ -43,16 +43,13 @@ import { Tracer, TracerConfig, TracingLevel } from "@polywrap/tracing-js";
 import { ClientConfigBuilder } from "@polywrap/client-config-builder-js";
 import { Result, ResultErr, ResultOk } from "@polywrap/result";
 
-type PolywrapClientConfigInternal<
+export type PolywrapClientConfig<
   TUri extends Uri | string = string
-> = ClientConfig<TUri> & {
-  tracerConfig: Readonly<Partial<TracerConfig>>;
-  wrapperCache?: Readonly<IWrapperCache>;
-};
-
-export type PolywrapClientConfig<TUri extends Uri | string = string> = Readonly<
-  PolywrapClientConfigInternal<TUri>
->;
+> = ClientConfig<TUri> &
+  Readonly<{
+    tracerConfig: Readonly<Partial<TracerConfig>>;
+    wrapperCache?: Readonly<IWrapperCache>;
+  }>;
 
 export class PolywrapClient implements Client {
   private _config: PolywrapClientConfig<Uri> = ({

--- a/packages/js/client/src/PolywrapClient.ts
+++ b/packages/js/client/src/PolywrapClient.ts
@@ -43,11 +43,12 @@ import { Tracer, TracerConfig, TracingLevel } from "@polywrap/tracing-js";
 import { ClientConfigBuilder } from "@polywrap/client-config-builder-js";
 import { Result, ResultErr, ResultOk } from "@polywrap/result";
 
-interface PolywrapClientConfigInternal<TUri extends Uri | string = string>
-  extends ClientConfig<TUri> {
+type PolywrapClientConfigInternal<
+  TUri extends Uri | string = string
+> = ClientConfig<TUri> & {
   tracerConfig: Readonly<Partial<TracerConfig>>;
   wrapperCache?: Readonly<IWrapperCache>;
-}
+};
 
 export type PolywrapClientConfig<TUri extends Uri | string = string> = Readonly<
   PolywrapClientConfigInternal<TUri>

--- a/packages/js/client/src/PolywrapClient.ts
+++ b/packages/js/client/src/PolywrapClient.ts
@@ -49,8 +49,9 @@ interface PolywrapClientConfigInternal<TUri extends Uri | string = string>
   wrapperCache?: Readonly<IWrapperCache>;
 }
 
-export interface PolywrapClientConfig<TUri extends Uri | string = string>
-  extends Readonly<PolywrapClientConfigInternal<TUri>> {}
+export type PolywrapClientConfig<TUri extends Uri | string = string> = Readonly<
+  PolywrapClientConfigInternal<TUri>
+>;
 
 export class PolywrapClient implements Client {
   private _config: PolywrapClientConfig<Uri> = ({

--- a/packages/js/client/src/PolywrapClient.ts
+++ b/packages/js/client/src/PolywrapClient.ts
@@ -43,13 +43,11 @@ import { Tracer, TracerConfig, TracingLevel } from "@polywrap/tracing-js";
 import { ClientConfigBuilder } from "@polywrap/client-config-builder-js";
 import { Result, ResultErr, ResultOk } from "@polywrap/result";
 
-export type PolywrapClientConfig<
-  TUri extends Uri | string = string
-> = ClientConfig<TUri> &
-  Readonly<{
-    tracerConfig: Readonly<Partial<TracerConfig>>;
-    wrapperCache?: Readonly<IWrapperCache>;
-  }>;
+export interface PolywrapClientConfig<TUri extends Uri | string = string>
+  extends ClientConfig<TUri> {
+  readonly tracerConfig: Readonly<Partial<TracerConfig>>;
+  readonly wrapperCache?: Readonly<IWrapperCache>;
+}
 
 export class PolywrapClient implements Client {
   private _config: PolywrapClientConfig<Uri> = ({

--- a/packages/js/core/src/types/Client.ts
+++ b/packages/js/core/src/types/Client.ts
@@ -23,8 +23,9 @@ interface ClientConfigInternal<TUri extends Uri | string = string> {
   resolver: Readonly<IUriResolver<unknown>>;
 }
 
-export interface ClientConfig<TUri extends Uri | string = string>
-  extends Readonly<ClientConfigInternal<TUri>> {}
+export type ClientConfig<TUri extends Uri | string = string> = Readonly<
+  ClientConfigInternal<TUri>
+>;
 
 export interface GetManifestOptions {
   noValidate?: boolean;

--- a/packages/js/core/src/types/Client.ts
+++ b/packages/js/core/src/types/Client.ts
@@ -15,13 +15,16 @@ import { UriResolverHandler } from "./UriResolver";
 import { WrapManifest } from "@polywrap/wrap-manifest-types-js";
 import { Result } from "@polywrap/result";
 
-export interface ClientConfig<TUri extends Uri | string = string> {
-  redirects: UriRedirect<TUri>[];
-  plugins: PluginRegistration<TUri>[];
-  interfaces: InterfaceImplementations<TUri>[];
-  envs: Env<TUri>[];
-  resolver: IUriResolver<unknown>;
+interface ClientConfigInternal<TUri extends Uri | string = string> {
+  redirects: readonly UriRedirect<TUri>[];
+  plugins: readonly PluginRegistration<TUri>[];
+  interfaces: readonly InterfaceImplementations<TUri>[];
+  envs: readonly Env<TUri>[];
+  resolver: Readonly<IUriResolver<unknown>>;
 }
+
+export interface ClientConfig<TUri extends Uri | string = string>
+  extends Readonly<ClientConfigInternal<TUri>> {}
 
 export interface GetManifestOptions {
   noValidate?: boolean;

--- a/packages/js/core/src/types/Client.ts
+++ b/packages/js/core/src/types/Client.ts
@@ -15,13 +15,13 @@ import { UriResolverHandler } from "./UriResolver";
 import { WrapManifest } from "@polywrap/wrap-manifest-types-js";
 import { Result } from "@polywrap/result";
 
-interface ClientConfigInternal<TUri extends Uri | string = string> {
+type ClientConfigInternal<TUri extends Uri | string = string> = {
   redirects: readonly UriRedirect<TUri>[];
   plugins: readonly PluginRegistration<TUri>[];
   interfaces: readonly InterfaceImplementations<TUri>[];
   envs: readonly Env<TUri>[];
   resolver: Readonly<IUriResolver<unknown>>;
-}
+};
 
 export type ClientConfig<TUri extends Uri | string = string> = Readonly<
   ClientConfigInternal<TUri>

--- a/packages/js/core/src/types/Client.ts
+++ b/packages/js/core/src/types/Client.ts
@@ -15,17 +15,13 @@ import { UriResolverHandler } from "./UriResolver";
 import { WrapManifest } from "@polywrap/wrap-manifest-types-js";
 import { Result } from "@polywrap/result";
 
-type ClientConfigInternal<TUri extends Uri | string = string> = {
+export type ClientConfig<TUri extends Uri | string = string> = Readonly<{
   redirects: readonly UriRedirect<TUri>[];
   plugins: readonly PluginRegistration<TUri>[];
   interfaces: readonly InterfaceImplementations<TUri>[];
   envs: readonly Env<TUri>[];
   resolver: Readonly<IUriResolver<unknown>>;
-};
-
-export type ClientConfig<TUri extends Uri | string = string> = Readonly<
-  ClientConfigInternal<TUri>
->;
+}>;
 
 export interface GetManifestOptions {
   noValidate?: boolean;

--- a/packages/js/core/src/types/Client.ts
+++ b/packages/js/core/src/types/Client.ts
@@ -15,13 +15,13 @@ import { UriResolverHandler } from "./UriResolver";
 import { WrapManifest } from "@polywrap/wrap-manifest-types-js";
 import { Result } from "@polywrap/result";
 
-export type ClientConfig<TUri extends Uri | string = string> = Readonly<{
-  redirects: readonly UriRedirect<TUri>[];
-  plugins: readonly PluginRegistration<TUri>[];
-  interfaces: readonly InterfaceImplementations<TUri>[];
-  envs: readonly Env<TUri>[];
-  resolver: Readonly<IUriResolver<unknown>>;
-}>;
+export interface ClientConfig<TUri extends Uri | string = string> {
+  readonly redirects: Readonly<UriRedirect<TUri>[]>;
+  readonly plugins: Readonly<PluginRegistration<TUri>[]>;
+  readonly interfaces: Readonly<InterfaceImplementations<TUri>[]>;
+  readonly envs: Readonly<Env<TUri>[]>;
+  readonly resolver: Readonly<IUriResolver<unknown>>;
+}
 
 export interface GetManifestOptions {
   noValidate?: boolean;


### PR DESCRIPTION
This PR resolves #1282 

Both ClientConfig and PolywrapClientConfig are now `readonly` with all their properties also being marked as `readonly`.

This essentially naively prevents users from modifying the client config.