### PR TITLE
Fix (CLI): Generated build files permissions 

### DIFF
--- a/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
+++ b/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
@@ -163,7 +163,7 @@ export class DockerVMBuildStrategy extends BuildStrategy<void> {
         fse.writeFileSync(buildScriptPath, scriptContent);
 
         const { stderr } = await runCommand(
-          `docker run --rm --user $(id -u):$(id -g) -v ${path.resolve(
+          `docker run --rm -v ${path.resolve(
             this._volumePaths.project
           )}:/project -v ${path.resolve(
             this._volumePaths.linkedPackages
@@ -172,9 +172,19 @@ export class DockerVMBuildStrategy extends BuildStrategy<void> {
           }:latest /bin/bash -c "${scriptContent}"`
         );
 
+        await runCommand(
+          `docker run --rm -v ${path.resolve(
+            this._volumePaths.project
+          )}:/project -v ${path.resolve(
+            this._volumePaths.linkedPackages
+          )}:/linked-packages ${
+            CONFIGS[language].baseImage
+          }:latest /bin/bash -c "chmod -R 777 /project && chmod -R 777 /linked-packages"`
+        );
+
         if (
           stderr &&
-          !fse.existsSync(path.join(this._volumePaths.project, "build"))
+          !fse.existsSync(path.join(this._volumePaths.project, "build", "wrap.wasm"))
         ) {
           throw new Error(stderr);
         }

--- a/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
+++ b/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
@@ -192,7 +192,7 @@ export class DockerVMBuildStrategy extends BuildStrategy<void> {
             this._volumePaths.linkedPackages
           )}:/linked-packages ${
             CONFIGS[language].baseImage
-          }:latest /bin/bash -c "chmod -R g+wX ."`
+          }:latest /bin/bash -c "chmod 777 ."`
         );
 
         if (buildError) {

--- a/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
+++ b/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
@@ -184,7 +184,9 @@ export class DockerVMBuildStrategy extends BuildStrategy<void> {
 
         if (
           stderr &&
-          !fse.existsSync(path.join(this._volumePaths.project, "build", "wrap.wasm"))
+          !fse.existsSync(
+            path.join(this._volumePaths.project, "build", "wrap.wasm")
+          )
         ) {
           throw new Error(stderr);
         }

--- a/packages/cli/src/lib/defaults/build-strategies/wasm/assemblyscript/vm/vm-script.mustache
+++ b/packages/cli/src/lib/defaults/build-strategies/wasm/assemblyscript/vm/vm-script.mustache
@@ -3,7 +3,6 @@ json -I -f package.json -e 'this.dependencies[\"{{name}}\"]=\"../linked-packages
 {{/polywrap_linked_packages}}
 {{#polywrap_module}}
 yarn
-chmod -R g+wX .
 asc {{dir}}/wrap/entry.ts \
     --path ./node_modules \
     --outFile ./build/wrap.wasm \
@@ -11,6 +10,4 @@ asc {{dir}}/wrap/entry.ts \
     --optimize --importMemory \
     --runtime stub \
     --runPasses asyncify
-
-chmod -R g+wX .
 {{/polywrap_module}}

--- a/packages/cli/src/lib/defaults/build-strategies/wasm/rust/vm/vm-script.mustache
+++ b/packages/cli/src/lib/defaults/build-strategies/wasm/rust/vm/vm-script.mustache
@@ -32,6 +32,4 @@ rm -rf ./build/bg_module.wasm
 
 wasm-opt --asyncify -Os ./build/snipped_module.wasm -o ./build/wrap.wasm
 rm -rf ./build/snipped_module.wasm
-
-chmod -R g+wX .
 {{/polywrap_module}}


### PR DESCRIPTION
With the latest changes of Docker VM PR, there was a bug where files generated from share volume can not be deleted with normal permissions, only with sudo.