### PR TITLE
Fix: check for fallback providers in IPFS plugin

### DIFF
--- a/packages/js/plugins/ipfs/src/index.ts
+++ b/packages/js/plugins/ipfs/src/index.ts
@@ -108,13 +108,14 @@ export class IpfsPlugin extends Module<NoConfig> {
   ): Promise<TReturn> {
     const defaultIpfsClient = createIpfsClient(this.env.provider);
 
-    if (!options) {
-      // Default behavior if no options are provided
+    if (!options?.fallbackProviders) {
+      // Default behavior if no fallback providers are provided
+      // Note that options.timeout is already set by getOptions
       return await execSimple(
         operation,
         defaultIpfsClient,
         this.config.provider,
-        0,
+        options?.timeout ?? 0,
         func
       );
     }


### PR DESCRIPTION
A test was checking if IpfsOptions was undefined, but it is always defined. The intended behavior appears to be to check for the existence of fallback providers. If they are not present, the invocation can be simplified.