### PR TITLE
Hotfix CLI hanging behavior

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,5 +11,6 @@ export const run = async (argv: string[]): Promise<void> => {
     }
   }
 
-  program.parse(argv);
+  await program.parseAsync(argv);
+  process.exit();
 };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,5 +12,4 @@ export const run = async (argv: string[]): Promise<void> => {
   }
 
   await program.parseAsync(argv);
-  process.exit();
 };

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -184,8 +184,7 @@ async function run(options: BuildCommandOptions) {
     const result = await execute();
 
     if (!result) {
-      process.exitCode = 1;
-      return;
+      process.exit(1);
     }
   } else {
     // Execute
@@ -239,5 +238,5 @@ async function run(options: BuildCommandOptions) {
     });
   }
 
-  process.exitCode = 0;
+  process.exit(0);
 }

--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -110,8 +110,6 @@ async function run(options: CodegenCommandOptions) {
 
   const projectType = await project.getManifestLanguage();
 
-  let result = false;
-
   const schemaComposer = new SchemaComposer({
     project,
     client,
@@ -131,7 +129,7 @@ async function run(options: CodegenCommandOptions) {
         project,
       });
 
-  result = await codeGenerator.generate();
+  const result = await codeGenerator.generate();
 
   // HACK: Codegen outputs wrap.info into a build directory for plugins, needs to be moved into a build command?
   if (isPluginManifestLanguage(projectType)) {
@@ -153,8 +151,8 @@ async function run(options: CodegenCommandOptions) {
 
   if (result) {
     logger.info(`🔥 ${intlMsg.commands_codegen_success()} 🔥`);
-    process.exitCode = 0;
+    process.exit(0);
   } else {
-    process.exitCode = 1;
+    process.exit(1);
   }
 }

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -136,7 +136,7 @@ async function run(
     }
   }
 
-  generateProjectTemplate(command, lang, projectDir)
+  await generateProjectTemplate(command, lang, projectDir)
     .then(() => {
       let readyMessage;
       if (command === "wasm") {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -154,7 +154,7 @@ async function run(options: DeployCommandOptions): Promise<void> {
         );
     }
   }
-  return;
+  process.exit(0);
 }
 
 function sanitizePackages(packages: string[]) {

--- a/packages/cli/src/commands/docgen.ts
+++ b/packages/cli/src/commands/docgen.ts
@@ -127,8 +127,7 @@ async function run(command: DocType, options: DocgenCommandOptions) {
       })
     );
 
-    process.exitCode = 1;
-    return;
+    process.exit(1);
   }
 
   await project.validate();
@@ -154,8 +153,8 @@ async function run(command: DocType, options: DocgenCommandOptions) {
 
   if (await codeGenerator.generate()) {
     logger.info(`🔥 ${intlMsg.commands_docgen_success()} 🔥`);
-    process.exitCode = 0;
+    process.exit(0);
   } else {
-    process.exitCode = 1;
+    process.exit(1);
   }
 }

--- a/packages/cli/src/commands/infra.ts
+++ b/packages/cli/src/commands/infra.ts
@@ -176,4 +176,5 @@ async function run(
     default:
       throw Error(intlMsg.commands_infra_error_never());
   }
+  process.exit(0);
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -96,7 +96,7 @@ const _run = async (options: WorkflowCommandOptions) => {
     const { data, error, status } = jobResult;
 
     if (error !== undefined) {
-      process.exitCode = 1;
+      process.exit(1);
     }
 
     const output: WorkflowOutput = { id, status, data, error };


### PR DESCRIPTION
After the removal of our spinner, if a CLI command didn't explicitly call `process.exit()`, I have encountered a behavior where the CLI would just hang (simply not exit) after it completed the command.

This PR fixes this behaviour, and should probably be hotfixed into the latest release of Polywrap, as it's a behavior reproducible on `0.9.0`.

To reproduce the faulty behavior,  `polywrap create` the `wasm-as` template with the current `0.9.0` release of Polywrap, and then try either `polywrap codegen` or `polywrap build`.