### PR TITLE
CLI Reference section

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -115,7 +115,6 @@ This command generates types and bindings for your project based on your project
 - `-s, --script <path>`
   Path to a custom generation script (JavaScript | TypeScript).
   This script is run in place of the standard codegen script if provided.
-  **TODO: Add details about the custom codegen script**
 
 - `-c, --client-config <config-path>`
   Use a custom Polywrap Client configuration.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -78,7 +78,6 @@ This outputs the project's ABI schema (Wasm and Interface) and binary package (W
 
 - `-c, --client-config <config-path>`
   Use a custom Polywrap Client configuration.
-  See [The `-c, --client-config` option](#the--c,---client-config-option) for details
 
 - `-n, --no-codegen`
   Don't perform codegen before building.
@@ -119,7 +118,6 @@ This command generates types and bindings for your project based on your project
 
 - `-c, --client-config <config-path>`
   Use a custom Polywrap Client configuration.
-  See [The `-c, --client-config` option](#the--c,---client-config-option) for details
 
 #### Special note
 
@@ -270,7 +268,6 @@ polywrap test [options]
 
 - `-c, --client-config <config-path>`
   Use a custom Polywrap Client configuration.
-  See [The `-c, --client-config` option](#the--c,---client-config-option) for details
 
 - `-o, --output-file <output-file-path>`
   Specify the output file path for the workflow result
@@ -428,7 +425,6 @@ polywrap docgen <action>
 
 - `-c, --client-config <config-path>`
   Use a custom Polywrap Client configuration.
-  See [The `-c, --client-config` option](#the--c,---client-config-option) for details
 
 - `-i, --imports`
   Generate docs for your project's dependencies as well.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,9 +64,34 @@ polywrap create --help
 
 ### `build | b`
 
-Build Polywrap projects.
+Build Wasm and Interface Polywrap projects.
+This outputs the project's ABI schema (Wasm and Interface) and binary package (Wasm) into the `./build` directory.
 
-**TODO: Add documentation**
+#### Options
+- `-m, --manifest-file <path>`
+  Specify your project's manifest file.
+  By default, `build` searches for `polywrap.yaml`.
+
+- `-o, --output-dir <path>`
+  Specify an alternative directory for build output.
+  The default codegen output directory is `./build`.
+
+- `-c, --client-config <config-path>`
+  Use a custom Polywrap Client configuration.
+
+- `-n, --no-codegen`
+  Don't perform codegen before building.
+  By default, `build` performs a `codegen` step before building your Project. This option skips this step. This is especially useful when you are testing manual changes to your types/bindings.
+
+- `-s, --strategy <strategy>`
+  Specify which build strategy to use. By default, the `vm` build strategy is used.
+  Available strategies:
+  - `vm`: Uses Docker only for the source building part of the build process. At build time, it pulls a pre-built image with all necessary system dependencies, env vars and runtime; and it instantiates a Docker container with it. The Docker container instantiates bind-mounts (volumes) to copy the sources and dependencies from the host, build the sources inside the container, and copy the build artifacts back to the host machine. This approach ensures that the sources will be built in a reproducible environment but it doesn't use Docker for anything else and no image is built at runtime.
+  - `image`: Implies building a Docker image at runtime, where dependencies are installed and sources are copied and built as Dockerfile instructions. On subsequent builds, Docker tries to reuse cached image layers and rebuild accordingly. This approach is notably slow but the complete process happens in Docker, and can be reproduced, examined and audited layer by layer (from dependency installation to build artifacts output).
+  - `local` - does not use Docker at all. It simply executes a .sh file that contains the necessary instructions to install dependencies and build sources. While this is the fastest way of building, it requires you, the user, to have all prerequisite system dependencies installed. In addition, given that sources are built on the host machine and not a reproducible docker environment, reproducibility isn't guaranteed.
+
+- `-w, --watch`
+  Watch the Project's files and automatically rebuild when a file is changed.
 
 ### `codegen | g`
 
@@ -105,7 +130,7 @@ Create a Polywrap project.
 
 This command sets up a basic Polywrap-enabled project based on a pre-defined template.
 
-#### Subcommands:
+#### Subcommands
 
 `polywrap create wasm <language> <name>`
 
@@ -179,7 +204,7 @@ Generate wrapper documentation for your project.
 polywrap docgen <action>
 ```
 
-#### Arguments:
+#### Arguments
 
 - `action` (required)
   Specifies the kind of documentation generated.
@@ -191,7 +216,7 @@ polywrap docgen <action>
   - `jsdoc`
     Generates JSDoc markdown for your project.
 
-#### Options:
+#### Options
 - `-m, --manifest-file <path>`
   Specify your project's manifest file.
   By default, `docgen` searches for `polywrap.yaml`.
@@ -210,7 +235,7 @@ polywrap docgen <action>
 
 Inspect and migrate Polywrap manifests.
 
-#### Subcommands:
+#### Subcommands
 
 #### `schema | s`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,6 +5,7 @@
 </a>
 
 <br/>
+<br/>
 
 A command-line interface for building and deploying Polywrap projects.
 
@@ -25,7 +26,7 @@ You can install Cue by following the instructions found [here](https://cuelang.o
 
 ## Installation
 
-Within one project:
+Within a single project:
 
 ```bash
 npm install --save-dev polywrap
@@ -40,7 +41,7 @@ npm install -g polywrap
 Alternatively, `polywrap` can be run without installation:
 
 ```bash
-npx polywrap -v
+npx polywrap
 ```
 
 ## Commands
@@ -81,17 +82,50 @@ This command sets up a basic Polywrap-enabled project based on a pre-defined tem
 
 #### Subcommands:
 
-#### `wasm`
+`polywrap create wasm <language> <name>`
 
 Set up a Polywrap WASM Wrapper or Interface project.
 
-#### `app`
+`polywrap create app <language> <name>`
 
 Set up a NodeJS or React application which uses the Polywrap Client to invoke wrappers.
 
-#### `plugin`
+`polywrap create plugin <language> <name>`
 
 Set up a Polywrap Plugin project used to provide the Polywrap Cient with additional functionality.
+
+#### Arguments
+
+All subcommands share the following arguments:
+
+- `language` (required)
+  The type/language of the created project
+
+- `name` (required)
+  The project name.
+
+#### Options
+
+All subcommands share the following options:
+
+- `-o, --output-dir <path>`
+  Specifies a custom output directory for the created project.
+
+#### Sample usage
+
+```bash
+# Create a wrapper project using assemblyscript called "my-wrapper"
+polywrap create wasm assemblyscript my-wrapper
+
+# Create an interface project using assemblyscript called "my-project"
+polywrap create wasm interface my-interface
+
+# Create a React app project using Typescript called "my-react-app"
+polywrap create app typescript-react my-react-app
+
+# Create a Plugin wrapper project using Typescript called "my-plugin"
+polywrap create plugin typescript my-plugin
+```
 
 ### `deploy | d`
 
@@ -186,7 +220,21 @@ polywrap manifest migrate
   polywrap m m -m custom-manifest.yaml
   ```
 
+## Logging
 
+By default, the Polywrap CLI outputs all of its messages to the console.
+Different levels of output verbosity are supported by using the following options:
+
+- `-v, --verbose`
+  Enables logging of informational messages in addition to standard output.
+
+- `-q, --quiet`
+  Disables ALL logging. Overrides the `--verbose` option.
+
+
+### 
+
+### `-q`
 
 https://docs.polywrap.io/reference/cli/polywrap-cli
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -148,9 +148,39 @@ Run Workflows
 
 ### `docgen | o`
 
-Generate wrapper documentation
+Generate wrapper documentation for your project.
 
-**TODO: Add documentation**
+```bash
+polywrap docgen <action>
+```
+
+#### Arguments:
+
+- `action` (required)
+  Specifies the kind of documentation generated.
+  Values:
+  - `schema`
+    Generates GraphQL-like schema for your project.
+  - `docusaurus`
+    Generates Docusaurus markdown for your project.
+  - `jsdoc`
+    Generates JSDoc markdown for your project.
+
+#### Options:
+- `-m, --manifest-file <path>`
+  Specify your project's manifest file.
+  By default, `docgen` searches for `polywrap.yaml`.
+
+- `-g, --docgen-dir <path>`
+  Specify the output directory for generated docs.
+  By default, `./docs` is used.
+
+- `-c, --client-config <config-path>`
+  Specify a custom Polywrap Client configuration to be used.
+  The Polywrap Client is used to build your project's schema for which the docs will be generated.
+
+- `-i, --imports`
+  Generate docs for your project's dependencies as well.
 
 ### `manifest | m`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,11 +1,197 @@
-# The Polywrap CLI (polywrap)
+# The Polywrap CLI (`polywrap`)
+
+<a href="https://www.npmjs.com/package/polywrap" target="_blank" rel="noopener noreferrer">
+<img src="https://img.shields.io/npm/v/polywrap.svg" alt="npm"/>
+</a>
+
+<br/>
 
 A command-line interface for building and deploying Polywrap projects.
 
-## Documentation
+
+## Prerequisites
+
+### Docker
+
+[Docker](https://www.docker.com/) is required to perform some tasks, including to `build` Wasm wrappers.
+Linux users will also need to install [Docker Compose](https://docs.docker.com/compose/install/).
+Docker is free for personal use. Once Docker is installed and enabled, you're ready to go!
+
+### Cue
+
+The `polywrap run` command can validate runs by examining `stdout` output using **Cue**. If you need to run workflow validations, you will have to install Cue.
+
+You can install Cue by following the instructions found [here](https://cuelang.org/docs/install/).
+
+## Installation
+
+Within one project:
+
+```bash
+npm install --save-dev polywrap
+```
+
+Globally:
+
+```bash
+npm install -g polywrap
+```
+
+Alternatively, `polywrap` can be run without installation:
+
+```bash
+npx polywrap -v
+```
+
+## Commands
+
+### `help` command and `--help` option
+
+To list available commands, use the `help` command or the `-h, --help` option:
+
+```bash
+polywrap help
+polywrap --help
+```
+
+Alternatively, you can use the help command or option within any command to get a full list of available subcommands, arguments and options.
+
+```bash
+polywrap create help
+polywrap create --help
+```
+
+### `build | b`
+
+Build Polywrap projects.
+
+**TODO: Add documentation**
+
+### `codegen | g`
+
+Generate code bindings for Polywrap projects.
+
+**TODO: Add documentation**
+
+### `create | c`
+
+Create a Polywrap project.
+
+This command sets up a basic Polywrap-enabled project based on a pre-defined template.
+
+#### Subcommands:
+
+#### `wasm`
+
+Set up a Polywrap WASM Wrapper or Interface project.
+
+#### `app`
+
+Set up a NodeJS or React application which uses the Polywrap Client to invoke wrappers.
+
+#### `plugin`
+
+Set up a Polywrap Plugin project used to provide the Polywrap Cient with additional functionality.
+
+### `deploy | d`
+
+Deploy Polywrap projects.
+
+**TODO: Add documentation**
+
+
+### `infra | i`
+
+Modular Infrastructure-As-Code Orchestrator
+
+**TODO: Add documentation**
+
+### `run | r`
+
+Run Workflows
+
+**TODO: Add documentation**
+
+### `docgen | o`
+
+Generate wrapper documentation
+
+**TODO: Add documentation**
+
+### `manifest | m`
+
+Inspect and migrate Polywrap manifests.
+
+#### Subcommands:
+
+#### `schema | s`
+
+Output the schema for any of your Project or Extension manifests. 
+
+Usage:
+```bash
+# Output schema for the current project manifest (polywrap.yaml)
+polywrap manifest schema
+```
+
+##### Arguments
+
+- `type`
+  The type of the manifest file. The default value for `type` is `project`.
+  
+##### Options
+
+- `-r, --raw`
+  Output the full JSON Schema for the given manifest.
+  
+- `-m, --manifest-file <path>`
+  The manifest file for which the schema will be rendered. The `type` argument determines the default manifest file used.
+  For example, `polywrap manifest schema build` will use `polywrap.build.yaml` as its default manifest file.
+
+#### `migrate | m`
+
+Migrate a Project or Extension manifest file to the the latest version, or a version specified.
+
+Usage:
+```bash
+# Migrate the current project manifest (polywrap.yaml)
+polywrap manifest migrate
+```
+##### Arguments
+
+- `type`
+  The type of the manifest file. The default value for `type` is `project`.
+
+##### Options
+- `-f, --format <format>`
+  Migrate to a specific format instead of the latest.
+  
+  Example:
+  ```bash
+  # Migrate the current project manfiest to format 0.2.0
+  polywrap manifest migrate -f 0.2.0
+  # or
+  polywrap m m -f 0.2.0
+  ```
+
+- `-m, --manifest-file <path>`
+  The manifest file for which the schema will be rendered. The `type` argument determines the default manifest file used.
+  For example, `polywrap manifest migrate build` will use `polywrap.build.yaml` as its default manifest file.
+  
+  Example:
+  ```bash
+  # Migrate "custom-manifest.yaml" to the latest format
+  polywrap manifest migrate -m custom-manifest.yaml
+  # or
+  polywrap m m -m custom-manifest.yaml
+  ```
+
+
+
 https://docs.polywrap.io/reference/cli/polywrap-cli
 
 ## Examples
+
 Demos:  
 https://github.com/polywrap/demos
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -78,6 +78,7 @@ This outputs the project's ABI schema (Wasm and Interface) and binary package (W
 
 - `-c, --client-config <config-path>`
   Use a custom Polywrap Client configuration.
+  See [The `-c, --client-config` option](#the--c,---client-config-option) for details
 
 - `-n, --no-codegen`
   Don't perform codegen before building.
@@ -118,6 +119,7 @@ This command generates types and bindings for your project based on your project
 
 - `-c, --client-config <config-path>`
   Use a custom Polywrap Client configuration.
+  See [The `-c, --client-config` option](#the--c,---client-config-option) for details
 
 #### Special note
 
@@ -242,7 +244,13 @@ The default infrastructure module defines a docker container with:
 - A Ganache Ethereum test network at http://localhost:8545
 - An IPFS node at http://localhost:5001
 
-It also sets up ENS smart contracts at initialization, so you can build wrappers and deploy them to an ENS registry on your locally hosted testnet. The Ethereum address of the ENS registry is 0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab.
+It also sets up ENS smart contracts at initialization, so you can build wrappers and deploy them to an ENS registry on your locally hosted testnet.
+
+Addresses for the components of ENS:
+- Registry: `0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab`
+- Resolver: `0x5b1869D9A4C187F2EAa108f3062412ecf0526b24`
+- Registrar: `0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb`
+- Reverse Registrar: `0xe982E462b094850F12AF94d21D470e21bE9D0E9C`
 
 ### `test | t`
 
@@ -252,7 +260,7 @@ The `test` command executes a series of Wrapper invocations called **steps** org
 All steps within a job are run in series, while jobs are run in parallel.
 
 ```bash
-polywrap run [options]
+polywrap test [options]
 ```
 
 #### Options
@@ -262,6 +270,7 @@ polywrap run [options]
 
 - `-c, --client-config <config-path>`
   Use a custom Polywrap Client configuration.
+  See [The `-c, --client-config` option](#the--c,---client-config-option) for details
 
 - `-o, --output-file <output-file-path>`
   Specify the output file path for the workflow result
@@ -419,6 +428,7 @@ polywrap docgen <action>
 
 - `-c, --client-config <config-path>`
   Use a custom Polywrap Client configuration.
+  See [The `-c, --client-config` option](#the--c,---client-config-option) for details
 
 - `-i, --imports`
   Generate docs for your project's dependencies as well.
@@ -490,6 +500,24 @@ polywrap manifest migrate
   # or
   polywrap m m -m custom-manifest.yaml
   ```
+
+### The `-c, --client-config` option
+
+The `build`, `codegen`, `docgen` and `test` commands allow the user to configure the Polywrap Client via the `-c, --client-config <config-path>` option.
+
+You can supply a path to a Javascript or Typescript module which exports a function named `getClientConfig`:
+
+```typescript
+// asynchronous option
+export async function getClientConfig(
+  defaultConfigs: Partial<PolywrapClientConfig>
+): Promise<Partial<PolywrapClientConfig>>
+
+// synchronous option
+export function getClientConfig(
+  defaultConfigs: Partial<PolywrapClientConfig>
+): Partial<PolywrapClientConfig>
+```
 
 ## Logging
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,7 +72,32 @@ Build Polywrap projects.
 
 Generate code bindings for Polywrap projects.
 
-**TODO: Add documentation**
+This command generates types and bindings for your project based on your project's schema (found in `schema.graphql`).
+
+#### Options
+- `-m, --manifest-file <path>`
+  Specify your project's manifest file.
+  By default, `docgen` searches for `polywrap.yaml`.
+  
+- `-g, --codegen-dir <path>`
+  Specify an alternative directory for codegen output.
+  The default codegen output directory is `./wrap`.
+  
+- `-p, --publish-dir <path>`
+  Output path for the built schema and manifest (default: `./build`)
+  This only applies when running `codegen` for Plugin Projects.
+
+- `-s, --script <path>`
+  Path to a custom generation script (JavaScript | TypeScript).
+  This script is run in place of the standard codegen script if provided.
+  **TODO: Add details about the custom codegen script**
+
+- `-c, --client-config <config-path>`
+  Use a custom Polywrap Client configuration.
+
+#### Special note
+
+When running `codegen` for Plugin Projects, the Polywrap CLI will also output an ABI schema for your plugin into the `./build` directory. You can override this output directory by specifying `-p, --publish-dir <path>`.
 
 ### `create | c`
 
@@ -176,8 +201,7 @@ polywrap docgen <action>
   By default, `./docs` is used.
 
 - `-c, --client-config <config-path>`
-  Specify a custom Polywrap Client configuration to be used.
-  The Polywrap Client is used to build your project's schema for which the docs will be generated.
+  Use a custom Polywrap Client configuration.
 
 - `-i, --imports`
   Generate docs for your project's dependencies as well.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -88,7 +88,7 @@ This outputs the project's ABI schema (Wasm and Interface) and binary package (W
   Available strategies:
   - `vm`: Uses Docker only for the source building part of the build process. At build time, it pulls a pre-built image with all necessary system dependencies, env vars and runtime; and it instantiates a Docker container with it. The Docker container instantiates bind-mounts (volumes) to copy the sources and dependencies from the host, build the sources inside the container, and copy the build artifacts back to the host machine. This approach ensures that the sources will be built in a reproducible environment but it doesn't use Docker for anything else and no image is built at runtime.
   - `image`: Implies building a Docker image at runtime, where dependencies are installed and sources are copied and built as Dockerfile instructions. On subsequent builds, Docker tries to reuse cached image layers and rebuild accordingly. This approach is notably slow but the complete process happens in Docker, and can be reproduced, examined and audited layer by layer (from dependency installation to build artifacts output).
-  - `local` - does not use Docker at all. It simply executes a .sh file that contains the necessary instructions to install dependencies and build sources. While this is the fastest way of building, it requires you, the user, to have all prerequisite system dependencies installed. In addition, given that sources are built on the host machine and not a reproducible docker environment, reproducibility isn't guaranteed.
+  - `local` - Does not use Docker at all. It simply executes a .sh file that contains the necessary instructions to install dependencies and build sources. While this is the fastest way of building, it requires you, the user, to have all prerequisite system dependencies installed. In addition, given that sources are built on the host machine and not a reproducible docker environment, reproducibility isn't guaranteed.
 
 - `-w, --watch`
   Watch the Project's files and automatically rebuild when a file is changed.
@@ -181,6 +181,14 @@ polywrap create plugin typescript my-plugin
 
 Deploy Polywrap projects.
 
+```bash
+polywrap deploy
+```
+
+`deploy` reads the Deploy manifest (`polywrap.deploy.yaml` by default) and executes the jobs and steps listed inside.
+
+For more information on the Deploy command and the Deploy manifest, see [Configure Polywrap deployment pipeline](https://docs.polywrap.io/quick-start/build-and-deploy-wasm-wrappers/deploy-pipeline).
+
 #### Options
 - `-m, --manifest-file <path>`
   Specify your project's manifest file.
@@ -188,9 +196,6 @@ Deploy Polywrap projects.
 
 - `-o, --output-file <path>`
   Output file path for the deploy result
-  
-**TODO: Extend documentation with examples, more information**
-
 
 ### `infra | i`
 
@@ -199,6 +204,10 @@ Modular Infrastructure-As-Code Orchestrator
 ```bash
 polywrap infra <action> [options]
 ```
+
+The `infra` command is used to set up infrastructure to test and deploy your wrappers locally.
+
+For more information on the `infra` command and how to create your own Infra modules, see [Configure Polywrap infrastructure pipeline](https://docs.polywrap.io/quick-start/test-wasm-wrappers/infra-pipeline)
 
 #### Arguments
 - `action` (required)
@@ -220,7 +229,21 @@ polywrap infra <action> [options]
 - `-o, --modules <module, module>`
   Use only specified modules
 
-**TODO: Extend documentation with examples, more information**
+#### Defaults
+
+Polywrap comes with a default `eth-ens-ipfs` module which can be used to test your wrappers locally:
+
+```
+polywrap infra up --modules=eth-ens-ipfs
+```
+
+The default infrastructure module defines a docker container with:
+
+- A test server at http://localhost:4040
+- A Ganache Ethereum test network at http://localhost:8545
+- An IPFS node at http://localhost:5001
+
+It also sets up ENS smart contracts at initialization, so you can build wrappers and deploy them to an ENS registry on your locally hosted testnet. The Ethereum address of the ENS registry is 0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab.
 
 ### `test | t`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -55,11 +55,11 @@ polywrap help
 polywrap --help
 ```
 
-Alternatively, you can use the help command or option within any command to get a full list of available subcommands, arguments and options.
+Alternatively, you can use the `-h, --help` option within any command to get a full list of available subcommands, arguments and options.
 
 ```bash
-polywrap create help
 polywrap create --help
+polywrap codegen --help
 ```
 
 ### `build | b`
@@ -181,20 +181,71 @@ polywrap create plugin typescript my-plugin
 
 Deploy Polywrap projects.
 
-**TODO: Add documentation**
+#### Options
+- `-m, --manifest-file <path>`
+  Specify your project's manifest file.
+  By default, `deploy` searches for `polywrap.yaml`.
+
+- `-o, --output-file <path>`
+  Output file path for the deploy result
+  
+**TODO: Extend documentation with examples, more information**
 
 
 ### `infra | i`
 
 Modular Infrastructure-As-Code Orchestrator
 
-**TODO: Add documentation**
+```bash
+polywrap infra <action> [options]
+```
+
+#### Arguments
+- `action` (required)
+  Infra allows you to execute the following actions:
+  - `up`
+    Start Polywrap infrastructure
+  - `down`
+    Stop Polywrap infrastructure
+  - `config`
+    Validate and display Polywrap infrastructure's bundled docker-compose manifest
+  - `vars`
+    Show Polywrap infrastructure's required .env variables
+
+#### Options
+- `-m, --manifest-file <path>`
+  Specify the `infra` extension manifest file.
+  By default, `infra` searches for `polywrap.infra.yaml`.
+
+- `-o, --modules <module, module>`
+  Use only specified modules
+
+**TODO: Extend documentation with examples, more information**
 
 ### `run | r`
 
 Run Workflows
 
-**TODO: Add documentation**
+```bash
+polywrap run [options]
+```
+
+#### Options
+- `-m, --manifest-file <path>`
+  Specify the Workflow extension manifest file.
+  By default, `run` searches for `polywrap.test.yaml`.
+
+- `-c, --client-config <config-path>`
+  Use a custom Polywrap Client configuration.
+
+- `-o, --output-file <output-file-path>`
+  Specify the output file path for the workflow result
+
+- `-j, --jobs <jobs...>`
+  Specify ids of jobs that you want to run
+
+
+**TODO: Extend documentation with examples, more information**
 
 ### `docgen | o`
 
@@ -302,6 +353,8 @@ polywrap manifest migrate
 ## Logging
 
 By default, the Polywrap CLI outputs all of its messages to the console.
+
+### Logging levels
 Different levels of output verbosity are supported by using the following options:
 
 - `-v, --verbose`
@@ -310,17 +363,19 @@ Different levels of output verbosity are supported by using the following option
 - `-q, --quiet`
   Disables ALL logging. Overrides the `--verbose` option.
 
+### Logging to a file
+You can also tell the Polywrap CLI to save its output to a logfile using the `-l, --log-file [path]` option.
 
-### 
+Specifying the `-l` option without a `path` parameter will create a log file within the `./.polywrap/logs` directory.
 
-### `-q`
+```bash
+# Output will be saved to the "./.polywrap/logs" directory
+polywrap codegen -l
+```
 
-https://docs.polywrap.io/reference/cli/polywrap-cli
+Alternatively, you can specify your own log file path.
 
-## Examples
-
-Demos:  
-https://github.com/polywrap/demos
-
-Integrations:  
-https://github.com/polywrap/integrations
+```bash
+# Output will be saved to "my-log-file.log"
+polywrap codegen -l my-log-file.log
+```


### PR DESCRIPTION
Remaining work:

- [x] expand `run` command / get feedback from owner ( @Niraj-Kamdar )
- [x] expand `infra` command / get feedback from owner
- [x] expand `deploy` command / get feedback from owner
- [x] ~~expand on `codegen`'s `-s, --script` option~~ Seems relatively unused and not documented elsewhere - can do as a separate PR if need be.
- [x] ~~generally expand on the `-c, --client-config` option~~ Wherever it’s needed, has links to the explanation