### PR TITLE
Fix: In Rust bindings, enum imports are now added in serialization modules when the enum is a subtype of an array (Vec) or map

### DIFF
--- a/packages/schema/bind/src/bindings/rust/wasm/transforms/propertyDeps.ts
+++ b/packages/schema/bind/src/bindings/rust/wasm/transforms/propertyDeps.ts
@@ -77,12 +77,12 @@ export function propertyDeps(): AbiTransforms {
           // if type is map and the value is custom,
           // we need to add it into property dependency
           if (typeName.startsWith("Map<")) {
-            const valueName = def.map?.object?.type;
+            const valueName = def.map?.object?.type ?? def.map?.enum?.type;
             if (valueName && !isKnownType(valueName)) {
               appendUnique({
                 crate: "crate",
                 type: valueName,
-                isEnum: false,
+                isEnum: valueName === def.map?.enum?.type,
               });
 
               return array;
@@ -98,7 +98,7 @@ export function propertyDeps(): AbiTransforms {
           appendUnique({
             crate: "crate",
             type: typeName,
-            isEnum: !!def.enum,
+            isEnum: !!def.enum || !!def.array?.enum,
           });
 
           return array;

--- a/packages/test-cases/cases/bind/sanity/input/schema.graphql
+++ b/packages/test-cases/cases/bind/sanity/input/schema.graphql
@@ -40,7 +40,8 @@ type Module @imports(
     "TestImport_Module",
     "TestImport_Object",
     "TestImport_AnotherObject",
-    "TestImport_Enum"
+    "TestImport_Enum",
+    "TestImport_Enum_Return"
   ]
 ) @capability(
   type: "getImplementations",
@@ -181,6 +182,10 @@ type TestImport_Module @imported(
   anotherMethod(
     arg: [String!]!
   ): Int32!
+
+  returnsArrayOfEnums(
+    arg: String!
+  ): [TestImport_Enum_Return]!
 }
 
 ### Imported Modules END ###
@@ -211,6 +216,15 @@ type TestImport_AnotherObject @imported(
 }
 
 enum TestImport_Enum @imported(
+  uri: "testimport.uri.eth",
+  namespace: "TestImport",
+  nativeType: "Enum"
+) {
+  STRING
+  BYTES
+}
+
+enum TestImport_Enum_Return @imported(
   uri: "testimport.uri.eth",
   namespace: "TestImport",
   nativeType: "Enum"

--- a/packages/test-cases/cases/bind/sanity/output/app-ts/types.ts
+++ b/packages/test-cases/cases/bind/sanity/output/app-ts/types.ts
@@ -138,6 +138,18 @@ export type TestImport_EnumString =
 
 export type TestImport_Enum = TestImport_EnumEnum | TestImport_EnumString;
 
+/* URI: "testimport.uri.eth" */
+export enum TestImport_Enum_ReturnEnum {
+  STRING,
+  BYTES,
+}
+
+export type TestImport_Enum_ReturnString =
+  | "STRING"
+  | "BYTES"
+
+export type TestImport_Enum_Return = TestImport_Enum_ReturnEnum | TestImport_Enum_ReturnString;
+
 /// Imported Enums END ///
 
 /// Imported Modules START ///
@@ -165,6 +177,11 @@ interface TestImport_Module_Args_anotherMethod {
 }
 
 /* URI: "testimport.uri.eth" */
+interface TestImport_Module_Args_returnsArrayOfEnums {
+  arg: Types.String;
+}
+
+/* URI: "testimport.uri.eth" */
 export const TestImport_Module = {
   importedMethod: async (
     args: TestImport_Module_Args_importedMethod,
@@ -186,6 +203,18 @@ export const TestImport_Module = {
     return client.invoke<Types.Int32>({
       uri,
       method: "anotherMethod",
+      args: args as unknown as Record<string, unknown>
+    });
+  },
+
+  returnsArrayOfEnums: async (
+    args: TestImport_Module_Args_returnsArrayOfEnums,
+    client: Client,
+    uri: string = "testimport.uri.eth"
+  ): Promise<InvokeResult<Array<Types.TestImport_Enum_Return | null>>> => {
+    return client.invoke<Array<Types.TestImport_Enum_Return | null>>({
+      uri,
+      method: "returnsArrayOfEnums",
       args: args as unknown as Record<string, unknown>
     });
   }

--- a/packages/test-cases/cases/bind/sanity/output/plugin-ts/types.ts
+++ b/packages/test-cases/cases/bind/sanity/output/plugin-ts/types.ts
@@ -152,6 +152,18 @@ export type TestImport_EnumString =
 
 export type TestImport_Enum = TestImport_EnumEnum | TestImport_EnumString;
 
+/* URI: "testimport.uri.eth" */
+export enum TestImport_Enum_ReturnEnum {
+  STRING,
+  BYTES,
+}
+
+export type TestImport_Enum_ReturnString =
+  | "STRING"
+  | "BYTES"
+
+export type TestImport_Enum_Return = TestImport_Enum_ReturnEnum | TestImport_Enum_ReturnString;
+
 /// Imported Objects END ///
 
 /// Imported Modules START ///
@@ -179,6 +191,11 @@ interface TestImport_Module_Args_anotherMethod {
 }
 
 /* URI: "testimport.uri.eth" */
+interface TestImport_Module_Args_returnsArrayOfEnums {
+  arg: Types.String;
+}
+
+/* URI: "testimport.uri.eth" */
 export class TestImport_Module {
   public static interfaceUri: string = "testimport.uri.eth";
 
@@ -203,6 +220,17 @@ export class TestImport_Module {
     return client.invoke<Types.Int32>({
       uri: this.uri,
       method: "anotherMethod",
+      args: args as unknown as Record<string, unknown>
+    });
+  }
+
+  public async returnsArrayOfEnums (
+    args: TestImport_Module_Args_returnsArrayOfEnums,
+    client: Client
+  ): Promise<InvokeResult<Array<Types.TestImport_Enum_Return | null>>> {
+    return client.invoke<Array<Types.TestImport_Enum_Return | null>>({
+      uri: this.uri,
+      method: "returnsArrayOfEnums",
       args: args as unknown as Record<string, unknown>
     });
   }

--- a/packages/test-cases/cases/bind/sanity/output/plugin-ts/wrap.info.ts
+++ b/packages/test-cases/cases/bind/sanity/output/plugin-ts/wrap.info.ts
@@ -90,6 +90,17 @@ export const manifest: WrapManifest = {
       "nativeType": "Enum",
       "type": "TestImport_Enum",
       "uri": "testimport.uri.eth"
+    },
+    {
+      "constants": [
+        "STRING",
+        "BYTES"
+      ],
+      "kind": 520,
+      "namespace": "TestImport",
+      "nativeType": "Enum",
+      "type": "TestImport_Enum_Return",
+      "uri": "testimport.uri.eth"
     }
   ],
   "importedEnvTypes": [
@@ -402,6 +413,48 @@ export const manifest: WrapManifest = {
             "type": "Int32"
           },
           "type": "Method"
+        },
+        {
+          "arguments": [
+            {
+              "kind": 34,
+              "name": "arg",
+              "required": true,
+              "scalar": {
+                "kind": 4,
+                "name": "arg",
+                "required": true,
+                "type": "String"
+              },
+              "type": "String"
+            }
+          ],
+          "kind": 64,
+          "name": "returnsArrayOfEnums",
+          "required": true,
+          "return": {
+            "array": {
+              "enum": {
+                "kind": 16384,
+                "name": "returnsArrayOfEnums",
+                "type": "TestImport_Enum_Return"
+              },
+              "item": {
+                "kind": 16384,
+                "name": "returnsArrayOfEnums",
+                "type": "TestImport_Enum_Return"
+              },
+              "kind": 18,
+              "name": "returnsArrayOfEnums",
+              "required": true,
+              "type": "[TestImport_Enum_Return]"
+            },
+            "kind": 34,
+            "name": "returnsArrayOfEnums",
+            "required": true,
+            "type": "[TestImport_Enum_Return]"
+          },
+          "type": "Method"
         }
       ],
       "namespace": "TestImport",
@@ -601,6 +654,9 @@ export const manifest: WrapManifest = {
       },
       {
         "type": "TestImport_Enum"
+      },
+      {
+        "type": "TestImport_Enum_Return"
       }
     ],
     "kind": 128,

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/TestImport_Enum_Return/index.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/TestImport_Enum_Return/index.ts
@@ -1,0 +1,34 @@
+export enum TestImport_Enum_Return {
+  STRING,
+  BYTES,
+  _MAX_
+}
+
+export function sanitizeTestImport_Enum_ReturnValue(value: i32): void {
+  const valid = value >= 0 && value < TestImport_Enum_Return._MAX_;
+  if (!valid) {
+    throw new Error("Invalid value for enum 'TestImport_Enum_Return': " + value.toString());
+  }
+}
+
+export function getTestImport_Enum_ReturnValue(key: string): TestImport_Enum_Return {
+  if (key == "STRING") {
+    return TestImport_Enum_Return.STRING;
+  }
+  if (key == "BYTES") {
+    return TestImport_Enum_Return.BYTES;
+  }
+
+  throw new Error("Invalid key for enum 'TestImport_Enum_Return': " + key);
+}
+
+export function getTestImport_Enum_ReturnKey(value: TestImport_Enum_Return): string {
+  sanitizeTestImport_Enum_ReturnValue(value);
+
+  switch (value) {
+    case TestImport_Enum_Return.STRING: return "STRING";
+    case TestImport_Enum_Return.BYTES: return "BYTES";
+    default:
+      throw new Error("Invalid value for enum 'TestImport_Enum_Return': " + value.toString());
+  }
+}

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/TestImport_Module/index.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/TestImport_Module/index.ts
@@ -13,7 +13,10 @@ import {
   Args_importedMethod,
   serializeanotherMethodArgs,
   deserializeanotherMethodResult,
-  Args_anotherMethod
+  Args_anotherMethod,
+  serializereturnsArrayOfEnumsArgs,
+  deserializereturnsArrayOfEnumsResult,
+  Args_returnsArrayOfEnums
 } from "./serialization";
 import * as Types from "../..";
 
@@ -68,6 +71,28 @@ export class TestImport_Module {
 
     return Result.Ok<i32, string>(
       deserializeanotherMethodResult(result.unwrap())
+    );
+  }
+
+  public returnsArrayOfEnums(
+    args: Args_returnsArrayOfEnums
+  ): Result<Array<Box<Types.TestImport_Enum_Return> | null>, string> {
+    const argsBuf = serializereturnsArrayOfEnumsArgs(args);
+    const result = wrap_subinvokeImplementation(
+      "testimport.uri.eth",
+      this.uri,
+      "returnsArrayOfEnums",
+      argsBuf
+    );
+
+    if (result.isErr) {
+      return Result.Err<Array<Box<Types.TestImport_Enum_Return> | null>, string>(
+        result.unwrapErr()
+      );
+    }
+
+    return Result.Ok<Array<Box<Types.TestImport_Enum_Return> | null>, string>(
+      deserializereturnsArrayOfEnumsResult(result.unwrap())
     );
   }
 }

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/TestImport_Module/serialization.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/TestImport_Module/serialization.ts
@@ -453,3 +453,107 @@ export function deserializeanotherMethodResult(buffer: ArrayBuffer): i32 {
 
   return res;
 }
+
+export class Args_returnsArrayOfEnums {
+  arg: string;
+}
+
+export function deserializereturnsArrayOfEnumsArgs(argsBuf: ArrayBuffer): Args_returnsArrayOfEnums {
+  const context: Context = new Context("Deserializing imported module-type: returnsArrayOfEnums Args");
+  const reader = new ReadDecoder(argsBuf, context);
+  let numFields = reader.readMapLength();
+
+  let _arg: string = "";
+  let _argSet: bool = false;
+
+  while (numFields > 0) {
+    numFields--;
+    const field = reader.readString();
+
+    reader.context().push(field, "unknown", "searching for property type");
+    if (field == "arg") {
+      reader.context().push(field, "string", "type found, reading property");
+      _arg = reader.readString();
+      _argSet = true;
+      reader.context().pop();
+    }
+    reader.context().pop();
+  }
+
+  if (!_argSet) {
+    throw new Error(reader.context().printWithContext("Missing required argument: 'arg: String'"));
+  }
+
+  return {
+    arg: _arg
+  };
+}
+
+export function serializereturnsArrayOfEnumsArgs(args: Args_returnsArrayOfEnums): ArrayBuffer {
+  const sizerContext: Context = new Context("Serializing (sizing) imported module-type: returnsArrayOfEnums Args");
+  const sizer = new WriteSizer(sizerContext);
+  writereturnsArrayOfEnumsArgs(sizer, args);
+  const buffer = new ArrayBuffer(sizer.length);
+  const encoderContext: Context = new Context("Serializing (encoding) imported module-type: returnsArrayOfEnums Args");
+  const encoder = new WriteEncoder(buffer, sizer, encoderContext);
+  writereturnsArrayOfEnumsArgs(encoder, args);
+  return buffer;
+}
+
+export function writereturnsArrayOfEnumsArgs(
+  writer: Write,
+  args: Args_returnsArrayOfEnums
+): void {
+  writer.writeMapLength(1);
+  writer.context().push("arg", "string", "writing property");
+  writer.writeString("arg");
+  writer.writeString(args.arg);
+  writer.context().pop();
+}
+
+export function serializereturnsArrayOfEnumsResult(result: Array<Box<Types.TestImport_Enum_Return> | null>): ArrayBuffer {
+  const sizerContext: Context = new Context("Serializing (sizing) imported module-type: returnsArrayOfEnums Result");
+  const sizer = new WriteSizer(sizerContext);
+  writereturnsArrayOfEnumsResult(sizer, result);
+  const buffer = new ArrayBuffer(sizer.length);
+  const encoderContext: Context = new Context("Serializing (encoding) imported module-type: returnsArrayOfEnums Result");
+  const encoder = new WriteEncoder(buffer, sizer, encoderContext);
+  writereturnsArrayOfEnumsResult(encoder, result);
+  return buffer;
+}
+
+export function writereturnsArrayOfEnumsResult(writer: Write, result: Array<Box<Types.TestImport_Enum_Return> | null>): void {
+  writer.context().push("returnsArrayOfEnums", "Array<Box<Types.TestImport_Enum_Return> | null>", "writing property");
+  writer.writeArray(result, (writer: Write, item: Box<Types.TestImport_Enum_Return> | null): void => {
+    writer.writeOptionalInt32(item);
+  });
+  writer.context().pop();
+}
+
+export function deserializereturnsArrayOfEnumsResult(buffer: ArrayBuffer): Array<Box<Types.TestImport_Enum_Return> | null> {
+  const context: Context = new Context("Deserializing imported module-type: returnsArrayOfEnums Result");
+  const reader = new ReadDecoder(buffer, context);
+
+  reader.context().push("returnsArrayOfEnums", "Array<Box<Types.TestImport_Enum_Return> | null>", "reading function output");
+  const res: Array<Box<Types.TestImport_Enum_Return> | null> = reader.readArray((reader: Read): Box<Types.TestImport_Enum_Return> | null => {
+    let value: Box<Types.TestImport_Enum_Return> | null;
+    if (!reader.isNextNil()) {
+      if (reader.isNextString()) {
+        value = Box.from(
+          Types.getTestImport_Enum_ReturnValue(reader.readString())
+        );
+      } else {
+        value = Box.from(
+          reader.readInt32()
+        );
+        Types.sanitizeTestImport_Enum_ReturnValue(value.unwrap());
+      }
+    } else {
+      value = null;
+    }
+    return value;
+  });
+  reader.context().pop();
+
+  return res;
+}

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/index.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/imported/index.ts
@@ -2,4 +2,5 @@ export * from "./TestImport_Module";
 export * from "./TestImport_Object";
 export * from "./TestImport_AnotherObject";
 export * from "./TestImport_Enum";
+export * from "./TestImport_Enum_Return";
 export * from "./TestImport_Env";

--- a/packages/test-cases/cases/bind/sanity/output/wasm-as/index.ts
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-as/index.ts
@@ -36,5 +36,11 @@ export {
   getTestImport_EnumValue,
   sanitizeTestImport_EnumValue
 } from "./imported/TestImport_Enum";
+export {
+  TestImport_Enum_Return,
+  getTestImport_Enum_ReturnKey,
+  getTestImport_Enum_ReturnValue,
+  sanitizeTestImport_Enum_ReturnValue
+} from "./imported/TestImport_Enum_Return";
 export { TestImport } from "./TestImport";
 export { Env } from "./Env";

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/mod.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/mod.rs
@@ -4,6 +4,8 @@ pub mod test_import_another_object;
 pub use test_import_another_object::*;
 pub mod test_import_enum;
 pub use test_import_enum::*;
+pub mod test_import_enum_return;
+pub use test_import_enum_return::*;
 pub mod test_import_module;
 pub use test_import_module::*;
 pub mod test_import_env;

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_enum_return/mod.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_enum_return/mod.rs
@@ -1,0 +1,51 @@
+use polywrap_wasm_rs::EnumTypeError;
+use serde::{Serialize, Deserialize};
+use std::convert::TryFrom;
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum TestImportEnumReturn {
+    STRING,
+    BYTES,
+    _MAX_
+}
+
+pub fn sanitize_test_import_enum_return_value(value: i32) -> Result<(), EnumTypeError> {
+    if value < 0 && value >= TestImportEnumReturn::_MAX_ as i32 {
+        return Err(EnumTypeError::EnumProcessingError(format!("Invalid value for enum 'TestImportEnumReturn': {}", value.to_string())));
+    }
+    Ok(())
+}
+
+pub fn get_test_import_enum_return_value(key: &str) -> Result<TestImportEnumReturn, EnumTypeError> {
+    match key {
+        "STRING" => Ok(TestImportEnumReturn::STRING),
+        "BYTES" => Ok(TestImportEnumReturn::BYTES),
+        "_MAX_" => Ok(TestImportEnumReturn::_MAX_),
+        err => Err(EnumTypeError::EnumProcessingError(format!("Invalid key for enum 'TestImportEnumReturn': {}", err)))
+    }
+}
+
+pub fn get_test_import_enum_return_key(value: TestImportEnumReturn) -> Result<String, EnumTypeError> {
+    if sanitize_test_import_enum_return_value(value as i32).is_ok() {
+        match value {
+            TestImportEnumReturn::STRING => Ok("STRING".to_string()),
+            TestImportEnumReturn::BYTES => Ok("BYTES".to_string()),
+            TestImportEnumReturn::_MAX_ => Ok("_MAX_".to_string()),
+        }
+    } else {
+        Err(EnumTypeError::EnumProcessingError(format!("Invalid value for enum 'TestImportEnumReturn': {}", (value  as i32).to_string())))
+    }
+}
+
+impl TryFrom<i32> for TestImportEnumReturn {
+    type Error = EnumTypeError;
+
+    fn try_from(v: i32) -> Result<TestImportEnumReturn, Self::Error> {
+        match v {
+            x if x == TestImportEnumReturn::STRING as i32 => Ok(TestImportEnumReturn::STRING),
+            x if x == TestImportEnumReturn::BYTES as i32 => Ok(TestImportEnumReturn::BYTES),
+            x if x == TestImportEnumReturn::_MAX_ as i32 => Ok(TestImportEnumReturn::_MAX_),
+            _ => Err(EnumTypeError::ParseEnumError(format!("Invalid value for enum 'TestImportEnumReturn': {}", (v  as i32).to_string()))),
+        }
+    }
+}

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_module/mod.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_module/mod.rs
@@ -15,11 +15,15 @@ pub use serialization::{
     ArgsImportedMethod,
     deserialize_another_method_result,
     serialize_another_method_args,
-    ArgsAnotherMethod
+    ArgsAnotherMethod,
+    deserialize_returns_array_of_enums_result,
+    serialize_returns_array_of_enums_args,
+    ArgsReturnsArrayOfEnums
 };
 
 use crate::TestImportObject;
 use crate::TestImportEnum;
+use crate::TestImportEnumReturn;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TestImportModule<'a> {
@@ -53,5 +57,16 @@ impl<'a> TestImportModule<'a> {
             args,
         )?;
         deserialize_another_method_result(result.as_slice()).map_err(|e| e.to_string())
+    }
+
+    pub fn returns_array_of_enums(&self, args: &ArgsReturnsArrayOfEnums) -> Result<Vec<Option<TestImportEnumReturn>>, String> {
+        let uri = self.uri;
+        let args = serialize_returns_array_of_enums_args(args).map_err(|e| e.to_string())?;
+        let result = subinvoke::wrap_subinvoke(
+            uri,
+            "returnsArrayOfEnums",
+            args,
+        )?;
+        deserialize_returns_array_of_enums_result(result.as_slice()).map_err(|e| e.to_string())
     }
 }

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/mod.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/mod.rs
@@ -32,6 +32,12 @@ pub use imported::test_import_enum::{
     sanitize_test_import_enum_value,
     TestImportEnum
 };
+pub use imported::test_import_enum_return::{
+    get_test_import_enum_return_key,
+    get_test_import_enum_return_value,
+    sanitize_test_import_enum_return_value,
+    TestImportEnumReturn
+};
 pub use imported::test_import_env::TestImportEnv;
 pub use imported::test_import_module::TestImportModule;
 pub mod test_import;

--- a/packages/test-cases/cases/wrappers/wasm-rs/map-type/schema.graphql
+++ b/packages/test-cases/cases/wrappers/wasm-rs/map-type/schema.graphql
@@ -17,9 +17,18 @@ type Module {
   returnNestedMap(
     foo: Map! @annotate(type: "Map<String!, Map<String!, Int!>!>!")
   ): Map! @annotate(type: "Map<String!, Map<String!, Int!>!>!")
+
+  returnMapOfEnum(
+    map: Map! @annotate(type: "Map<String!, MyEnum!>!")
+  ): Map! @annotate(type: "Map<String!, MyEnum!>!")
 }
 
 type CustomMap {
   map: Map! @annotate(type: "Map<String!, Int!>!")
   nestedMap: Map! @annotate(type: "Map<String!, Map<String!, Int!>!>!")
+}
+
+enum MyEnum {
+  ONE
+  TWO
 }

--- a/packages/test-cases/cases/wrappers/wasm-rs/map-type/schema.import.graphql
+++ b/packages/test-cases/cases/wrappers/wasm-rs/map-type/schema.import.graphql
@@ -15,9 +15,18 @@ type Module {
   returnNestedMap(
     foo: Map! @annotate(type: "Map<String!, Map<String!, Int!>!>!")
   ): Map! @annotate(type: "Map<String!, Map<String!, Int!>!>!")
+
+  returnMapOfEnum(
+    map: Map! @annotate(type: "Map<String!, MyEnum!>!")
+  ): Map! @annotate(type: "Map<String!, MyEnum!>!")
 }
 
 type CustomMap {
   map: Map! @annotate(type: "Map<String!, Int!>!")
   nestedMap: Map! @annotate(type: "Map<String!, Map<String!, Int!>!>!")
+}
+
+enum MyEnum {
+  ONE
+  TWO
 }

--- a/packages/test-cases/cases/wrappers/wasm-rs/map-type/src/lib.rs
+++ b/packages/test-cases/cases/wrappers/wasm-rs/map-type/src/lib.rs
@@ -17,3 +17,7 @@ pub fn return_custom_map(args: ArgsReturnCustomMap) -> CustomMap {
 pub fn return_nested_map(args: ArgsReturnNestedMap) -> Map<String, Map<String, i32>> {
     args.foo
 }
+
+pub fn return_map_of_enum(args: ArgsReturnMapOfEnum) -> Map<String, MyEnum> {
+    args.map
+}


### PR DESCRIPTION
Enum imports are now added in serialization modules when the enum is a subtype of an array (`Vec`) or map

Closes https://github.com/polywrap/toolchain/issues/1313