### PR TITLE
Chore: Improve workflow validation

### DIFF
--- a/packages/cli/src/__tests__/e2e/run.spec.ts
+++ b/packages/cli/src/__tests__/e2e/run.spec.ts
@@ -208,10 +208,10 @@ describe("e2e tests for run command", () => {
 
     const output = parseOutput(stdout);
     expect(output.filter((o => o.status === "SUCCEED"))).toHaveLength(output.length);
-    expect(output.filter((o => o.validation?.startsWith("SUCCEED")))).toHaveLength(output.length);
+    expect(output.filter((o => o.validation?.status.startsWith("SUCCEED")))).toHaveLength(output.length);
   });
 
-  it("Should print error on stderr if validation fails", async () => {
+  it("Should print error on validation if it fails", async () => {
     const testCaseDir = getTestCaseDir(5);
     const args = getCmdArgs(testCaseDir);
     const { exitCode, stdout, stderr } = await runCLI({
@@ -225,8 +225,8 @@ describe("e2e tests for run command", () => {
     const output = parseOutput(stdout);
 
     expect(output[0].status).toBe("SUCCEED");
-    expect(output[0].validation).toBe("FAILED");
-    expect(output[0].error).toBeTruthy();
+    expect(output[0].validation.status).toBe("FAILED");
+    expect(output[0].validation.error).toBeTruthy();
 
     expect(stderr).toBeDefined();
     expect(stderr).not.toBe("");
@@ -263,7 +263,7 @@ describe("e2e tests for run command", () => {
 
     const output = parseOutput(stdout);
     expect(output[0].status).toBe("SUCCEED");
-    expect(output[0].validation).toBe("SUCCEED");
+    expect(output[0].validation.status).toBe("SUCCEED");
     expect(output[0].error).toBeFalsy();
   });
 
@@ -282,7 +282,7 @@ describe("e2e tests for run command", () => {
 
     const output = parseOutput(stdout);
     expect(output.filter((o => o.status === "SUCCEED"))).toHaveLength(output.length);
-    expect(output.filter((o => o.validation?.startsWith("SUCCEED")))).toHaveLength(output.length);
+    expect(output.filter((o => o.validation.status.startsWith("SUCCEED")))).toHaveLength(output.length);
   });
 
   it("Should print error on stderr if job is named 'data' or 'error'", async () => {
@@ -316,7 +316,7 @@ describe("e2e tests for run command", () => {
     const output = parseOutput(stdout);
     expect(output[0].id).toBe("case2.0");
     expect(output[0].status).toBe("SUCCEED");
-    expect(output[0].validation).toBe("SUCCEED");
+    expect(output[0].validation.status).toBe("SUCCEED");
     expect(output[0].error).toBeFalsy();
   });
 });

--- a/packages/cli/src/__tests__/e2e/run.spec.ts
+++ b/packages/cli/src/__tests__/e2e/run.spec.ts
@@ -319,4 +319,19 @@ describe("e2e tests for run command", () => {
     expect(output[0].validation.status).toBe("SUCCEED");
     expect(output[0].error).toBeFalsy();
   });
+
+  it("Should validate expected error", async () => {
+    const testCaseDir = getTestCaseDir(11);
+    const { exitCode, stdout } = await runCLI({
+      args: ["run"],
+      cwd: testCaseDir,
+      cli: polywrapCli,
+    });
+
+    expect(exitCode).toEqual(0);
+
+    const output = parseOutput(stdout);
+    expect(output[0].status).toBe("FAILED");
+    expect(output[0].validation.status).toBe("SUCCEED");
+  })
 });

--- a/packages/cli/src/__tests__/e2e/utils.ts
+++ b/packages/cli/src/__tests__/e2e/utils.ts
@@ -29,7 +29,9 @@ export const parseOutput = (
     const result: Partial<WorkflowOutput> = {};
 
     result.id = output.substring(idIndex + id.length, statusIndex - 1).replace(/[\s-]+/g, "")
-    result.status = output.substring(statusIndex + status.length, dataIndex - 1) as Status;
+
+    const statusEndIndex = dataIndex !== -1 ? dataIndex - 1 : errorIndex - 1
+    result.status = output.substring(statusIndex + status.length, statusEndIndex) as Status;
 
     const validationStatus = validationIndex !== -1 ?
       validationErrorIndex !== -1 ?

--- a/packages/cli/src/__tests__/e2e/utils.ts
+++ b/packages/cli/src/__tests__/e2e/utils.ts
@@ -1,3 +1,5 @@
+import {Status, ValidationResult, WorkflowOutput} from "../../lib";
+
 export const clearStyle = (styled: string) => {
   return styled.replace(
     /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
@@ -5,49 +7,58 @@ export const clearStyle = (styled: string) => {
   );
 };
 
-export interface WorkflowOutput {
-  id: string;
-  data?: unknown;
-  error?: unknown;
-  validation?: string;
-  status: string;
-}
-
 export const parseOutput = (
   outputs: string
 ): Array<WorkflowOutput> => {
   const outputsArr = outputs.split(/-{35}[\t \n]+-{35}/);
   return outputsArr.map((output) => {
     output = output.replace(/-{35}/, "");
-    const idIdx = output.indexOf("ID: ");
-    const statusIdx = output.indexOf("Status: ");
-    const dataIdx = output.indexOf("Data: ");
-    const validationIdx = output.indexOf("Validation: ");
-    const errIdx = output.indexOf("Error: ");
+    const id = "ID: ";
+    const status = "Job status: ";
+    const data = "Data: ";
+    const validation = "Validation status: ";
+    const validationError = "Validation error: ";
+    const error = "Error: ";
+    const idIndex = output.indexOf(id);
+    const statusIndex = output.indexOf(status);
+    const dataIndex = output.indexOf(data);
+    const validationIndex = output.indexOf(validation);
+    const validationErrorIndex = output.indexOf(validationError);
+    const errorIndex = output.indexOf(error);
 
     const result: Partial<WorkflowOutput> = {};
 
-    result.id = output.substring(idIdx + 3, statusIdx - 1).replace(/[\s-]+/g, "")
-    result.status = output.substring(statusIdx + 8, dataIdx - 1);
-    result.validation =
-      validationIdx !== -1
-        ? errIdx !== -1
-          ? output.substring(validationIdx + 12, errIdx).replace(/[\s-]+/g, "")
-          : output.substring(validationIdx + 12).replace(/[\s-]+/g, "")
-        : undefined;
+    result.id = output.substring(idIndex + id.length, statusIndex - 1).replace(/[\s-]+/g, "")
+    result.status = output.substring(statusIndex + status.length, dataIndex - 1) as Status;
 
-    if (dataIdx !== -1) {
-      const data =
-        validationIdx !== -1
-          ? output.substring(dataIdx + 6, validationIdx - 1)
-          : output.substring(dataIdx + 6);
-      result.data = JSON.parse(data);
+    const validationStatus = validationIndex !== -1 ?
+      validationErrorIndex !== -1 ?
+        output.substring(validationIndex + validation.length, validationErrorIndex).replace(/[\s-]+/g, "") :
+        output.substring(validationIndex + validation.length).replace(/[\s-]+/g, "")
+      : undefined
+
+    const validationErrorMessage = validationErrorIndex !== -1 ?
+      output.substring(validationErrorIndex + validationError.length).replace(/[\s-]+/g, "")
+      : undefined
+      if (validationStatus) {
+        result.validation = { status: validationStatus } as ValidationResult
+        if (validationErrorMessage) {
+          result.validation.error = validationErrorMessage
+        }
+      }
+
+    if (dataIndex !== -1) {
+      const outputData =
+        validationIndex !== -1
+          ? output.substring(dataIndex + data.length, validationIndex - 1)
+          : output.substring(dataIndex + data.length);
+      result.data = JSON.parse(outputData);
     }
-    if (errIdx !== -1) {
-      result.error =
-        errIdx !== -1
-          ? output.substring(errIdx + 6).replace(/[\s-]+/g, "")
+    if (errorIndex !== -1) {
+        const message = errorIndex !== -1
+          ? output.substring(errorIndex + error.length).replace(/[\s-]+/g, "")
           : undefined;
+      result.error = new Error(message)
     }
     return result as WorkflowOutput;
   });

--- a/packages/cli/src/__tests__/unit/jobrunner-test-cases.ts
+++ b/packages/cli/src/__tests__/unit/jobrunner-test-cases.ts
@@ -1,5 +1,5 @@
 import { MaybeAsync } from "@polywrap/core-js";
-import { JobResult, JobStatus } from "../../lib";
+import { JobResult, Status } from "../../lib";
 import { PolywrapWorkflow } from "@polywrap/polywrap-manifest-types-js";
 import { GetPathToTestWrappers } from "@polywrap/test-cases";
 import path from "path";
@@ -40,7 +40,7 @@ export const testCases: WorkflowTestCase[] = [
     onExecution: (id: string, jobResult: JobResult) => {
       switch (id) {
         case "ops.0": {
-          expect(jobResult.status).toBe(JobStatus.SUCCEED);
+          expect(jobResult.status).toBe(Status.SUCCEED);
           expect(jobResult.error).toBeFalsy();
           expect(jobResult.data).toBe(20);
           break;
@@ -93,13 +93,13 @@ export const testCases: WorkflowTestCase[] = [
     onExecution: (id: string, jobResult: JobResult) => {
       switch (id) {
         case "ops.0": {
-          expect(jobResult.status).toBe(JobStatus.SUCCEED);
+          expect(jobResult.status).toBe(Status.SUCCEED);
           expect(jobResult.error).toBeFalsy();
           expect(jobResult.data).toBe(20);
           break;
         }
         case "ops.1": {
-          expect(jobResult.status).toBe(JobStatus.SUCCEED);
+          expect(jobResult.status).toBe(Status.SUCCEED);
           expect(jobResult.error).toBeFalsy();
           expect(jobResult.data).toBe(15);
           break;
@@ -171,19 +171,19 @@ export const testCases: WorkflowTestCase[] = [
     onExecution: (id: string, jobResult: JobResult) => {
       switch (id) {
         case "ops.0": {
-          expect(jobResult.status).toBe(JobStatus.SUCCEED);
+          expect(jobResult.status).toBe(Status.SUCCEED);
           expect(jobResult.error).toBeFalsy();
           expect(jobResult.data).toBe(20);
           break;
         }
         case "ops.1": {
-          expect(jobResult.status).toBe(JobStatus.SUCCEED);
+          expect(jobResult.status).toBe(Status.SUCCEED);
           expect(jobResult.error).toBeFalsy();
           expect(jobResult.data).toBe(15);
           break;
         }
         case "ops.subOps.0": {
-          expect(jobResult.status).toBe(JobStatus.SUCCEED);
+          expect(jobResult.status).toBe(Status.SUCCEED);
           expect(jobResult.error).toBeFalsy();
           expect(jobResult.data).toBe(5);
           break;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -91,7 +91,7 @@ const _run = async (options: WorkflowCommandOptions) => {
 
   const workflowOutput: WorkflowOutput[] = [];
 
-  const onExecution = async (id: string, jobResult: JobResult) => {
+  const onExecution = (id: string, jobResult: JobResult) => {
     const { data, error, status } = jobResult;
     const output: WorkflowOutput = {
       id,

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -3,7 +3,7 @@ import {
   intlMsg,
   JobResult,
   JobRunner,
-  JobStatus,
+  Status,
   loadValidationScript,
   loadWorkflowManifest,
   parseClientConfigOption,
@@ -11,7 +11,6 @@ import {
   printJobOutput,
   validateJobNames,
   validateOutput,
-  ValidationResult,
   WorkflowOutput,
   defaultWorkflowManifest,
   parseManifestFileOption,
@@ -92,24 +91,26 @@ const _run = async (options: WorkflowCommandOptions) => {
 
   const workflowOutput: WorkflowOutput[] = [];
 
-  const onExecution = (id: string, jobResult: JobResult) => {
+  const onExecution = async (id: string, jobResult: JobResult) => {
     const { data, error, status } = jobResult;
+    const output: WorkflowOutput = {
+      id,
+      status,
+      data,
+      error,
+      validation: {
+        status: Status.SKIPPED,
+      },
+    };
 
-    if (error !== undefined) {
-      process.exit(1);
-    }
-
-    const output: WorkflowOutput = { id, status, data, error };
-    workflowOutput.push(output);
-
-    let validation: ValidationResult | undefined = undefined;
-    if (status === JobStatus.SUCCEED && validationScript) {
-      validation = validateOutput(output, validationScript, logger);
+    if (validationScript) {
+      validateOutput(output, validationScript, logger);
     }
 
     if (!quiet) {
-      printJobOutput(output, validation);
+      printJobOutput(output);
     }
+    workflowOutput.push(output);
   };
 
   const jobRunner = new JobRunner(client, onExecution);
@@ -118,13 +119,17 @@ const _run = async (options: WorkflowCommandOptions) => {
   if (outputFile) {
     const outputFileExt = path.extname(outputFile).substring(1);
     if (!outputFileExt) throw new Error("Require output file extension");
+    const printableOutput = workflowOutput.map((o) => ({
+      ...o,
+      error: o.error?.message,
+    }));
     switch (outputFileExt) {
       case "yaml":
       case "yml":
-        fs.writeFileSync(outputFile, yaml.stringify(workflowOutput, null, 2));
+        fs.writeFileSync(outputFile, yaml.stringify(printableOutput, null, 2));
         break;
       case "json":
-        fs.writeFileSync(outputFile, JSON.stringify(workflowOutput, null, 2));
+        fs.writeFileSync(outputFile, JSON.stringify(printableOutput, null, 2));
         break;
       default:
         throw new Error(

--- a/packages/cli/src/lib/helpers/workflow-validator.ts
+++ b/packages/cli/src/lib/helpers/workflow-validator.ts
@@ -37,7 +37,6 @@ export function validateOutput(
     JSON.stringify({ data, error: error?.message }, null, 2)
   );
 
-  console.log(`cue vet -d ${selector} ${validateScriptPath} ${jsonOutput}`);
   const { stderr } = runCommandSync(
     `cue vet -d ${selector} ${validateScriptPath} ${jsonOutput}`,
     logger

--- a/packages/cli/src/lib/helpers/workflow-validator.ts
+++ b/packages/cli/src/lib/helpers/workflow-validator.ts
@@ -1,7 +1,7 @@
 import { runCommandSync } from "../system";
 import { Logger } from "../logging";
 import { intlMsg } from "../intl";
-import { JobStatus, ValidationResult, WorkflowOutput } from "../workflow";
+import { Status, WorkflowOutput } from "../workflow";
 
 import path from "path";
 import fs from "fs";
@@ -18,7 +18,7 @@ export function validateOutput(
   output: WorkflowOutput,
   validateScriptPath: string,
   logger: Logger
-): ValidationResult {
+): void {
   if (!cueExists(logger)) {
     console.warn(intlMsg.commands_run_error_cueDoesNotExist());
   }
@@ -32,8 +32,12 @@ export function validateOutput(
   const selector = `${jobId}.\\$${stepId}`;
   const jsonOutput = `${TMPDIR}/${id}.json`;
 
-  fs.writeFileSync(jsonOutput, JSON.stringify({ data, error }, null, 2));
+  fs.writeFileSync(
+    jsonOutput,
+    JSON.stringify({ data, error: error?.message }, null, 2)
+  );
 
+  console.log(`cue vet -d ${selector} ${validateScriptPath} ${jsonOutput}`);
   const { stderr } = runCommandSync(
     `cue vet -d ${selector} ${validateScriptPath} ${jsonOutput}`,
     logger
@@ -44,9 +48,9 @@ export function validateOutput(
   }
 
   if (!stderr) {
-    return { status: JobStatus.SUCCEED };
+    output.validation = { status: Status.SUCCEED };
   } else {
     process.exitCode = 1;
-    return { status: JobStatus.FAILED, stderr: stderr.stderr };
+    output.validation = { status: Status.FAILED, error: stderr.stderr };
   }
 }

--- a/packages/cli/src/lib/workflow/JobRunner.ts
+++ b/packages/cli/src/lib/workflow/JobRunner.ts
@@ -1,4 +1,4 @@
-import { JobResult, JobStatus, Step } from "./types";
+import { JobResult, Status, Step } from "./types";
 
 import { PolywrapClient } from "@polywrap/client-js";
 import { MaybeAsync } from "@polywrap/core-js";
@@ -91,20 +91,20 @@ export class JobRunner {
     const accessors: string[] = reference
       .substring(dataOrErrorIdx + 1)
       .split(".");
-    if (refJobResult.status === JobStatus.SKIPPED) {
+    if (refJobResult.status === Status.SKIPPED) {
       throw new Error(
         `Tried to resolve reference to skipped job ${referenceId} for step ${absJobId}.${stepId}`
       );
     } else if (
       accessors[0] === "data" &&
-      refJobResult.status === JobStatus.FAILED
+      refJobResult.status === Status.FAILED
     ) {
       throw new Error(
         `Tried to resolve data of failed job ${referenceId} for step ${absJobId}.${stepId}`
       );
     } else if (
       accessors[0] === "error" &&
-      refJobResult.status === JobStatus.SUCCEED
+      refJobResult.status === Status.SUCCEED
     ) {
       throw new Error(
         `Tried to resolve error message of successful job ${referenceId} for step ${absJobId}.${stepId}`
@@ -169,7 +169,7 @@ export class JobRunner {
       } catch (e) {
         return {
           error: e,
-          status: JobStatus.SKIPPED,
+          status: Status.SKIPPED,
         };
       }
     }
@@ -192,9 +192,9 @@ export class JobRunner {
     });
 
     if (!invokeResult.ok) {
-      return { error: invokeResult.error, status: JobStatus.FAILED };
+      return { error: invokeResult.error, status: Status.FAILED };
     } else {
-      return { data: invokeResult.value, status: JobStatus.SUCCEED };
+      return { data: invokeResult.value, status: Status.SUCCEED };
     }
   }
 

--- a/packages/cli/src/lib/workflow/index.ts
+++ b/packages/cli/src/lib/workflow/index.ts
@@ -1,8 +1,3 @@
 export * from "./JobRunner";
-export {
-  JobStatus,
-  JobResult,
-  ValidationResult,
-  WorkflowOutput,
-} from "./types";
+export { Status, JobResult, ValidationResult, WorkflowOutput } from "./types";
 export * from "./util";

--- a/packages/cli/src/lib/workflow/types.ts
+++ b/packages/cli/src/lib/workflow/types.ts
@@ -9,7 +9,7 @@ export interface Step {
   config?: ClientConfig;
 }
 
-export enum JobStatus {
+export enum Status {
   SUCCEED = "SUCCEED",
   FAILED = "FAILED",
   SKIPPED = "SKIPPED",
@@ -18,14 +18,15 @@ export enum JobStatus {
 export interface JobResult<TData = unknown> {
   data?: TData;
   error?: Error;
-  status: JobStatus;
+  status: Status;
 }
 
 export interface WorkflowOutput<TData = unknown> extends JobResult<TData> {
   id: string;
+  validation: ValidationResult;
 }
 
 export interface ValidationResult {
-  status: JobStatus;
-  stderr?: string;
+  status: Status;
+  error?: string;
 }

--- a/packages/cli/src/lib/workflow/util.ts
+++ b/packages/cli/src/lib/workflow/util.ts
@@ -1,5 +1,5 @@
 import { intlMsg } from "../intl";
-import { JobStatus, ValidationResult, WorkflowOutput } from "./types";
+import { WorkflowOutput } from "./types";
 
 import path from "path";
 import fs from "fs";
@@ -24,7 +24,7 @@ export function loadValidationScript(
   manifestPath: string,
   cueFilepath: string
 ): string {
-  cueFilepath = path.join(path.dirname(manifestPath), cueFilepath);
+  cueFilepath = path.join(path.join(manifestPath, ".."), cueFilepath);
 
   if (!fs.existsSync(cueFilepath)) {
     console.error(
@@ -38,31 +38,28 @@ export function loadValidationScript(
   return cueFilepath;
 }
 
-export function printJobOutput(
-  output: WorkflowOutput,
-  validation?: ValidationResult
-): void {
+export function printJobOutput(output: WorkflowOutput): void {
   console.log("-----------------------------------");
-
   console.log(`ID: ${output.id}`);
-  console.log(`Status: ${output.status}`);
+  console.log(`Job status: ${output.status}`);
 
   if (output.data !== undefined) {
     console.log(`Data: ${JSON.stringify(output.data, null, 2)}`);
   }
 
   if (output.error) {
-    console.log(`Validation: ${JobStatus.SKIPPED}`);
     console.log(`Error: ${output.error.message}`);
-  } else if (validation) {
-    console.log(`Validation: ${validation.status}`);
-    if (validation.stderr !== undefined) {
-      const msgLines = validation.stderr.split(/\r?\n/);
-      msgLines[1] = `${msgLines[1].split(":").slice(1).join(":")}`;
-      const errMsg = msgLines.slice(0, 2).join("\n");
-      console.log(`Error: ${errMsg}`);
-    }
   }
 
+  console.log(`Validation status: ${output.validation.status}`);
+  if (output.validation.error !== undefined) {
+    console.log(`Validation error: ${parseCmdError(output.validation.error)}`);
+  }
   console.log("-----------------------------------");
 }
+
+const parseCmdError = (error: string) => {
+  const msgLines = error.split(/\r?\n/);
+  msgLines[1] = `${msgLines[1].split(":").slice(1).join(":")}`;
+  return msgLines.slice(0, 2).join("\n");
+};

--- a/packages/test-cases/cases/cli/run/012-validation-error-expected/polywrap.test.yaml
+++ b/packages/test-cases/cases/cli/run/012-validation-error-expected/polywrap.test.yaml
@@ -1,0 +1,11 @@
+name: run-test-wrapper
+format: 0.1.0
+validation: "./validator.cue"
+jobs:
+  cases:
+    steps:
+    - uri: fs/../run-test-wrapper/build
+      method: add
+      args:
+        x: "foo"
+        y: 1

--- a/packages/test-cases/cases/cli/run/012-validation-error-expected/validator.cue
+++ b/packages/test-cases/cases/cli/run/012-validation-error-expected/validator.cue
@@ -1,0 +1,8 @@
+package e2e
+
+cases: {
+  $0: {
+    error: string
+  }
+}
+


### PR DESCRIPTION
Currently, there's an error in how the validation is being handled, blocking us from being able to test any expected error from an invocation. Also, we are making sure that what we show in the console it's the same that what's being output in the file (`json` or `yaml`) by using the same object

edit: note that currently, we are returning the entire object error (https://github.com/polywrap/toolchain/blob/origin/packages/js/wasm/src/WasmWrapper.ts#L175-L181) - this must be changed and will be tracked here https://github.com/polywrap/toolchain/issues/701