### PR TITLE
Revert "In @polywrap/react-js, PolywrapProvider now accepts Partial<PolywrapClientConfig> prop instead of individual config items"

### DIFF
--- a/packages/js/react/src/__tests__/app/SimpleStorage.tsx
+++ b/packages/js/react/src/__tests__/app/SimpleStorage.tsx
@@ -1,7 +1,8 @@
 import { usePolywrapQuery, PolywrapProvider, usePolywrapClient, createPolywrapProvider } from "@polywrap/react";
-import { PolywrapClientConfig } from "@polywrap/client-js";
+import { PluginRegistration } from "@polywrap/client-js";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import React from "react";
+import { Env } from "@polywrap/core-js";
 
 const SimpleStorage = ({ uri }: { uri: string }) => {
   const { execute: deployContract, data: deployData } = usePolywrapQuery<{
@@ -75,14 +76,16 @@ const SimpleStorage = ({ uri }: { uri: string }) => {
 const CustomProvider = createPolywrapProvider("custom");
 
 export const SimpleStorageContainer = ({
-  config,
+  envs,
+  plugins,
   ensUri,
 }: {
-  config: Partial<PolywrapClientConfig>,
+  envs: Env[]
+  plugins: PluginRegistration[];
   ensUri: string;
 }) => (
   <CustomProvider>
-    <PolywrapProvider config={config}>
+    <PolywrapProvider plugins={plugins} envs={envs}>
       <SimpleStorage uri={ensUri} />
     </PolywrapProvider>
   </CustomProvider>

--- a/packages/js/react/src/__tests__/integration.spec.tsx
+++ b/packages/js/react/src/__tests__/integration.spec.tsx
@@ -10,15 +10,16 @@ import {
   providers
 } from "@polywrap/test-env-js";
 import { GetPathToTestWrappers } from "@polywrap/test-cases";
+import { Env, PluginRegistration } from "@polywrap/core-js";
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import React from "react";
 import { render, fireEvent, screen, waitFor } from "@testing-library/react";
-import { PolywrapClientConfig } from "@polywrap/client-js";
 jest.setTimeout(360000);
 
 describe("Polywrap React Integration", () => {
-  let config: Partial<PolywrapClientConfig>
+  let envs: Env[];
+  let plugins: PluginRegistration[];
   let ensUri: string;
   let wrapper: {
     ensDomain: string;
@@ -28,10 +29,9 @@ describe("Polywrap React Integration", () => {
   beforeAll(async () => {
     await initTestEnvironment();
 
-    config = {
-      envs: createEnvs(providers.ipfs),
-      plugins: createPlugins(ensAddresses.ensAddress, providers.ethereum),
-    }
+    envs = createEnvs(providers.ipfs);
+
+    plugins = createPlugins(ensAddresses.ensAddress, providers.ethereum);
 
     wrapper = await buildAndDeployWrapper({
       wrapperAbsPath: `${GetPathToTestWrappers()}/wasm-as/simple-storage`,
@@ -47,7 +47,7 @@ describe("Polywrap React Integration", () => {
   });
 
   it("Deploys, read and write on Smart Contract ", async () => {
-    render(<SimpleStorageContainer config={config} ensUri={ensUri} />);
+    render(<SimpleStorageContainer envs={envs} plugins={plugins} ensUri={ensUri} />);
 
     fireEvent.click(screen.getByText("Deploy"));
     await waitFor(() => screen.getByText(/0x/), { timeout: 30000 });

--- a/packages/js/react/src/__tests__/usePolywrapClient.spec.tsx
+++ b/packages/js/react/src/__tests__/usePolywrapClient.spec.tsx
@@ -6,6 +6,7 @@ import {
 } from "..";
 import { createPlugins, createEnvs } from "./config";
 
+import { Env, PluginRegistration } from "@polywrap/core-js";
 import {
   ensAddresses,
   providers,
@@ -18,23 +19,27 @@ import {
   RenderHookOptions,
   cleanup
 } from "@testing-library/react-hooks";
-import { PolywrapClientConfig } from "@polywrap/client-js";
 
 jest.setTimeout(360000);
 
 describe("usePolywrapClient hook", () => {
+  let envs: Env[];
+  let plugins: PluginRegistration<string>[];
   let WrapperProvider: RenderHookOptions<unknown>;
 
   beforeAll(async () => {
     await initTestEnvironment();
 
-    const config: Partial<PolywrapClientConfig> = {
-      envs: createEnvs(providers.ipfs),
-      plugins: createPlugins(ensAddresses.ensAddress, providers.ethereum),
-    }
+    envs = createEnvs(providers.ipfs);
+
+    plugins = createPlugins(ensAddresses.ensAddress, providers.ethereum);
+
     WrapperProvider = {
       wrapper: PolywrapProvider,
-      initialProps: { config },
+      initialProps: {
+        envs,
+        plugins,
+      },
     };
   });
 

--- a/packages/js/react/src/__tests__/usePolywrapInvoke.spec.tsx
+++ b/packages/js/react/src/__tests__/usePolywrapInvoke.spec.tsx
@@ -6,6 +6,7 @@ import {
 import { UsePolywrapInvokeProps } from "../invoke";
 import { createPlugins, createEnvs } from "./config";
 
+import { Env, PluginRegistration } from "@polywrap/core-js";
 import {
   initTestEnvironment,
   stopTestEnvironment,
@@ -20,12 +21,14 @@ import {
   RenderHookOptions,
   cleanup
 } from "@testing-library/react-hooks";
-import { PolywrapClientConfig } from "@polywrap/client-js";
 
 jest.setTimeout(360000);
 
 describe("usePolywrapInvoke hook", () => {
   let uri: string;
+  let envUri: string;
+  let envs: Env[];
+  let plugins: PluginRegistration<string>[];
   let WrapperProvider: RenderHookOptions<unknown>;
 
   beforeAll(async () => {
@@ -37,14 +40,16 @@ describe("usePolywrapInvoke hook", () => {
 
     const simpleEnvPath = `${GetPathToTestWrappers()}/wasm-as/simple-env-types`;
     await buildWrapper(simpleEnvPath);
+    envUri = `fs/${simpleEnvPath}/build`
 
-    const config: Partial<PolywrapClientConfig> = {
-      envs: createEnvs(providers.ipfs),
-      plugins: createPlugins(ensAddresses.ensAddress, providers.ethereum),
-    }
+    envs = createEnvs(providers.ipfs);
+    plugins = createPlugins(ensAddresses.ensAddress, providers.ethereum);
     WrapperProvider = {
       wrapper: PolywrapProvider,
-      initialProps: { config },
+      initialProps: {
+        envs,
+        plugins,
+      },
     };
   });
 

--- a/packages/js/react/src/__tests__/usePolywrapQuery.spec.tsx
+++ b/packages/js/react/src/__tests__/usePolywrapQuery.spec.tsx
@@ -8,6 +8,7 @@ import {
 } from "../query"
 import { createPlugins, createEnvs } from "./config";
 
+import { Env, PluginRegistration } from "@polywrap/core-js";
 import {
   initTestEnvironment,
   stopTestEnvironment,
@@ -22,12 +23,14 @@ import {
   RenderHookOptions,
   cleanup
 } from "@testing-library/react-hooks";
-import { PolywrapClientConfig } from "@polywrap/client-js";
 
 jest.setTimeout(360000);
 
 describe("usePolywrapQuery hook", () => {
   let uri: string;
+  let envUri: string;
+  let envs: Env[];
+  let plugins: PluginRegistration<string>[];
   let WrapperProvider: RenderHookOptions<unknown>;
 
   beforeAll(async () => {
@@ -39,14 +42,16 @@ describe("usePolywrapQuery hook", () => {
 
     const simpleEnvPath = `${GetPathToTestWrappers()}/wasm-as/simple-env-types`;
     await buildWrapper(simpleEnvPath);
+    envUri = `fs/${simpleEnvPath}/build`
 
-    const config: Partial<PolywrapClientConfig> = {
-      envs: createEnvs(providers.ipfs),
-      plugins: createPlugins(ensAddresses.ensAddress, providers.ethereum),
-    }
+    envs = createEnvs(providers.ipfs);
+    plugins = createPlugins(ensAddresses.ensAddress, providers.ethereum);
     WrapperProvider = {
       wrapper: PolywrapProvider,
-      initialProps: { config },
+      initialProps: {
+        envs,
+        plugins,
+      },
     };
   });
 

--- a/packages/js/react/src/provider.tsx
+++ b/packages/js/react/src/provider.tsx
@@ -15,9 +15,7 @@ interface PolywrapProviderMap {
 
 export const PROVIDERS: PolywrapProviderMap = {};
 
-interface PolywrapProviderProps {
-  config: Partial<PolywrapClientConfig>
-}
+interface PolywrapProviderProps extends Partial<PolywrapClientConfig> { }
 
 export type PolywrapProviderFC = React.FC<PolywrapProviderProps>;
 
@@ -35,7 +33,7 @@ export function createPolywrapProvider(
     ClientContext: React.createContext({} as PolywrapClient)
   };
 
-  return ({ config, children }) => {
+  return ({ envs, redirects, plugins, interfaces, tracerConfig, children }) => {
 
     const [clientCreated, setClientCreated] = React.useState(false);
 
@@ -49,7 +47,7 @@ export function createPolywrapProvider(
       }
 
       // Instantiate the client
-      PROVIDERS[name].client = new PolywrapClient(config);
+      PROVIDERS[name].client = new PolywrapClient({ redirects, plugins, interfaces, envs, tracerConfig });
 
       setClientCreated(true);
 


### PR DESCRIPTION
Reverts polywrap/toolchain#1338

This is being reverted since this is a breaking change, and I'd like to release v0.9.3.

I'll re-open a PR for this to get this into origin-dev-0_10 once the branches are setup, since we now have decided upon a feature/patch branch & release policy to better organize breaking changes.