### PR TITLE
CLI - building interfaces uses a hidden, "empty" build strategy

### DIFF
--- a/packages/cli/lang/en.json
+++ b/packages/cli/lang/en.json
@@ -19,6 +19,7 @@
   "commands_build_options_w": "Automatically rebuild when changes are made (default: false)",
   "commands_build_options_s": "Strategy to use for building the wrapper",
   "commands_build_options_s_strategy": "strategy",
+  "commands_build_info_interface_no_strategy": "Interface projects do not use build strategies. Building without a strategy...",
   "commands_infra_description": "Modular Infrastructure-As-Code Orchestrator",
   "commands_infra_actions_subtitle": "Infra allows you to execute the following commands:",
   "commands_infra_options_options": "options",

--- a/packages/cli/lang/es.json
+++ b/packages/cli/lang/es.json
@@ -19,6 +19,7 @@
   "commands_build_options_w": "Automatically rebuild when changes are made (default: false)",
   "commands_build_options_s": "Strategy to use for building the wrapper",
   "commands_build_options_s_strategy": "strategy",
+  "commands_build_info_interface_no_strategy": "Interface projects do not use build strategies. Building without a strategy...",
   "commands_infra_description": "Modular Infrastructure-As-Code Orchestrator",
   "commands_infra_actions_subtitle": "Infra allows you to execute the following commands:",
   "commands_infra_options_options": "options",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -12,6 +12,7 @@ import {
   parseDirOption,
   parseClientConfigOption,
   parseManifestFileOption,
+  Logger,
 } from "../lib";
 import { CodeGenerator } from "../lib/codegen";
 import {
@@ -20,6 +21,7 @@ import {
   SupportedStrategies,
   DockerImageBuildStrategy,
   LocalBuildStrategy,
+  EmptyBuildStrategy,
 } from "../lib/build-strategies";
 
 import path from "path";
@@ -108,11 +110,20 @@ async function validateManifestModules(polywrapManifest: PolywrapManifest) {
   }
 }
 
-function createBuildStrategy(
+async function createBuildStrategy(
   strategy: BuildCommandOptions["strategy"],
   outputDir: string,
-  project: PolywrapProject
-): BuildStrategy {
+  project: PolywrapProject,
+  logger: Logger
+): Promise<BuildStrategy> {
+  const isInterfaceProject =
+    (await project.getManifest()).project.type === "interface";
+
+  if (isInterfaceProject) {
+    logger.info(intlMsg.commands_build_info_interface_no_strategy());
+    return new EmptyBuildStrategy({ outputDir, project });
+  }
+
   switch (strategy) {
     case SupportedStrategies.LOCAL:
       return new LocalBuildStrategy({ outputDir, project });
@@ -151,7 +162,12 @@ async function run(options: BuildCommandOptions) {
   const polywrapManifest = await project.getManifest();
   await validateManifestModules(polywrapManifest);
 
-  const buildStrategy = createBuildStrategy(strategy, outputDir, project);
+  const buildStrategy = await createBuildStrategy(
+    strategy,
+    outputDir,
+    project,
+    logger
+  );
 
   const schemaComposer = new SchemaComposer({
     project,

--- a/packages/cli/src/lib/build-strategies/strategies/EmptyStrategy.ts
+++ b/packages/cli/src/lib/build-strategies/strategies/EmptyStrategy.ts
@@ -5,5 +5,7 @@ export class EmptyBuildStrategy extends BuildStrategy<void> {
     return "empty";
   }
 
-  public async buildSources(): Promise<void> {}
+  public async buildSources(): Promise<void> {
+    return;
+  }
 }

--- a/packages/cli/src/lib/build-strategies/strategies/EmptyStrategy.ts
+++ b/packages/cli/src/lib/build-strategies/strategies/EmptyStrategy.ts
@@ -1,0 +1,9 @@
+import { BuildStrategy } from "../BuildStrategy";
+
+export class EmptyBuildStrategy extends BuildStrategy<void> {
+  getStrategyName(): string {
+    return "empty";
+  }
+
+  public async buildSources(): Promise<void> {}
+}

--- a/packages/cli/src/lib/build-strategies/strategies/index.ts
+++ b/packages/cli/src/lib/build-strategies/strategies/index.ts
@@ -1,3 +1,4 @@
 export * from "./DockerVMStrategy";
 export * from "./LocalStrategy";
 export * from "./DockerImageStrategy";
+export * from "./EmptyStrategy";


### PR DESCRIPTION
Closes #1355 

Targetting `0.9` as it seems like a non-breaking change.

The idea behind this fix is that building Interface projects doesn't require a `BuildStrategy` at all.
The `-s` argument is essentially ignored for Interface projects, and a hidden `EmptyBuildStrategy` is used, which does nothing.
Additionally, an `info` message is rendered to the user.

Users can't explicitly use this strategy.