### PR TITLE
Fix: Update CLI message with getCustomConfig

### DIFF
--- a/packages/cli/lang/en.json
+++ b/packages/cli/lang/en.json
@@ -135,7 +135,7 @@
   "commands_test_error_validatorNotFound": "validate script not found at: {path}",
   "commands_test_error_outputFileMissing": "{option} option missing {argument} argument",
   "commands_test_error_clientConfigMissingPath": "{option} option missing {argument} argument",
-  "commands_test_error_clientConfigModuleMissingExport": "Custom client config module missing named export 'getClientConfig' at {module}",
+  "commands_test_error_clientConfigModuleMissingExport": "Custom client config module missing named export 'getCustomConfig' at {module}",
   "commands_test_error_clientConfigInvalidFileExt": "Custom client config file: {module} must be a JS/TS file",
   "commands_test_error_clientConfigNotObject": "Custom client config must be an object",
   "commands_test_error_redirectsExportNotArray": "Exported redirects must be an array",

--- a/packages/cli/lang/es.json
+++ b/packages/cli/lang/es.json
@@ -135,7 +135,7 @@
   "commands_test_error_validatorNotFound": "validate script not found at: {path}",
   "commands_test_error_outputFileMissing": "{option} option missing {argument} argument",
   "commands_test_error_clientConfigMissingPath": "{option} option missing {argument} argument",
-  "commands_test_error_clientConfigModuleMissingExport": "Custom client config module missing named export 'getClientConfig' at {module}",
+  "commands_test_error_clientConfigModuleMissingExport": "Custom client config module missing named export 'getCustomConfig' at {module}",
   "commands_test_error_clientConfigInvalidFileExt": "Custom client config file: {module} must be a JS/TS file",
   "commands_test_error_clientConfigNotObject": "Custom client config must be an object",
   "commands_test_error_redirectsExportNotArray": "Exported redirects must be an array",


### PR DESCRIPTION
With latest changes, when passing a custom client to the CLI, it expects that the JS/TS files exports `getCustomConfig` function instead of `getClientConfig` (Check [here](https://github.com/polywrap/toolchain/blob/origin-0.10-dev/packages/cli/src/lib/option-parsers/client-config.ts#L41)). 

This PR aims to show the correct message when the user doesn't define this function