### PR TITLE
[0.10] - Add logging to migration actions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,7 @@
     "@polywrap/test-env-js": "0.9.3",
     "@polywrap/wasm-js": "0.9.3",
     "@polywrap/wrap-manifest-types-js": "0.9.3",
+    "@polywrap/logging-js": "0.9.3",
     "axios": "0.21.2",
     "chalk": "4.1.0",
     "chokidar": "3.5.1",

--- a/packages/cli/src/commands/manifest.ts
+++ b/packages/cli/src/commands/manifest.ts
@@ -527,7 +527,7 @@ const runMigrateCommand = async (
 
 function migrateManifestFile(
   manifestFile: string,
-  migrationFn: (input: string, to: string) => string,
+  migrationFn: (input: string, to: string, logger?: Logger) => string,
   to: string,
   logger: Logger
 ): void {
@@ -545,7 +545,7 @@ function migrateManifestFile(
     encoding: "utf-8",
   });
 
-  const outputManifestString = migrationFn(manifestString, to);
+  const outputManifestString = migrationFn(manifestString, to, logger);
 
   // Cache the old manifest file
   const cache = new CacheDirectory({

--- a/packages/cli/src/commands/utils/createLogger.ts
+++ b/packages/cli/src/commands/utils/createLogger.ts
@@ -1,4 +1,6 @@
-import { Logger, LogLevel, ConsoleLog, Logs, FileLog } from "../../lib";
+import { Logger, ConsoleLog, Logs, FileLog } from "../../lib";
+
+import { LogLevel } from "@polywrap/logging-js";
 
 export function createLogger(options: {
   verbose?: boolean;

--- a/packages/cli/src/lib/logging/Log.ts
+++ b/packages/cli/src/lib/logging/Log.ts
@@ -1,9 +1,4 @@
-export enum LogLevel {
-  DEBUG,
-  INFO,
-  WARN,
-  ERROR,
-}
+import { LogLevel } from "@polywrap/logging-js";
 
 export abstract class Log {
   public readonly level: LogLevel;

--- a/packages/cli/src/lib/logging/Logger.ts
+++ b/packages/cli/src/lib/logging/Logger.ts
@@ -1,10 +1,12 @@
-import { Log, LogLevel } from "./Log";
+import { Log } from "./Log";
+
+import { ILogger, LogLevel } from "@polywrap/logging-js";
 
 export interface Logs {
   [name: string]: Log;
 }
 
-export class Logger {
+export class Logger implements ILogger {
   private _logs: Logs;
 
   constructor(logs: Logs) {

--- a/packages/cli/src/lib/logging/logs/ConsoleLog.ts
+++ b/packages/cli/src/lib/logging/logs/ConsoleLog.ts
@@ -1,6 +1,7 @@
-import { Log, LogLevel } from "../Log";
+import { Log } from "../Log";
 
 import chalk from "chalk";
+import { LogLevel } from "@polywrap/logging-js";
 
 export class ConsoleLog extends Log {
   constructor(level: LogLevel) {

--- a/packages/cli/src/lib/logging/logs/FileLog.ts
+++ b/packages/cli/src/lib/logging/logs/FileLog.ts
@@ -1,7 +1,8 @@
-import { Log, LogLevel } from "../Log";
+import { Log } from "../Log";
 
 import fs, { WriteStream } from "fs";
 import path from "path";
+import { LogLevel } from "@polywrap/logging-js";
 
 export class FileLog extends Log {
   private _logFileStream: WriteStream;

--- a/packages/cli/src/lib/manifest/migrate/migrateAnyManifest.ts
+++ b/packages/cli/src/lib/manifest/migrate/migrateAnyManifest.ts
@@ -1,12 +1,14 @@
 /* eslint-disable no-empty */
 
+import { ILogger } from "@polywrap/logging-js";
 import YAML from "yaml";
 
 export function migrateAnyManifest(
   manifestString: string,
   manifestTypeName: string,
-  migrateFn: (manifest: unknown, to: string) => unknown,
-  to: string
+  migrateFn: (manifest: unknown, to: string, logger?: ILogger) => unknown,
+  to: string,
+  logger?: ILogger
 ): string {
   let manifest: unknown | undefined;
   try {
@@ -21,7 +23,7 @@ export function migrateAnyManifest(
     throw Error(`Unable to parse ${manifestTypeName}: ${manifestString}`);
   }
 
-  const newManifest = migrateFn(manifest, to);
+  const newManifest = migrateFn(manifest, to, logger);
 
   const cleanedManifest = JSON.parse(JSON.stringify(newManifest));
   delete cleanedManifest.__type;

--- a/packages/cli/src/lib/manifest/migrate/migrateAppProjectManifest.ts
+++ b/packages/cli/src/lib/manifest/migrate/migrateAppProjectManifest.ts
@@ -1,15 +1,18 @@
 import { migrateAnyManifest } from "./migrateAnyManifest";
 
 import { migrateAppManifest } from "@polywrap/polywrap-manifest-types-js";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrateAppProjectManifest(
   manifestString: string,
-  to: string
+  to: string,
+  logger?: ILogger
 ): string {
   return migrateAnyManifest(
     manifestString,
     "AppManifest",
     migrateAppManifest,
-    to
+    to,
+    logger
   );
 }

--- a/packages/cli/src/lib/manifest/migrate/migrateBuildExtensionManifest.ts
+++ b/packages/cli/src/lib/manifest/migrate/migrateBuildExtensionManifest.ts
@@ -1,15 +1,18 @@
 import { migrateAnyManifest } from "./migrateAnyManifest";
 
 import { migrateBuildManifest } from "@polywrap/polywrap-manifest-types-js";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrateBuildExtensionManifest(
   manifestString: string,
-  to: string
+  to: string,
+  logger?: ILogger
 ): string {
   return migrateAnyManifest(
     manifestString,
     "BuildManifest",
     migrateBuildManifest,
-    to
+    to,
+    logger
   );
 }

--- a/packages/cli/src/lib/manifest/migrate/migrateDeployExtensionManifest.ts
+++ b/packages/cli/src/lib/manifest/migrate/migrateDeployExtensionManifest.ts
@@ -1,15 +1,18 @@
 import { migrateAnyManifest } from "./migrateAnyManifest";
 
 import { migrateDeployManifest } from "@polywrap/polywrap-manifest-types-js";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrateDeployExtensionManifest(
   manifestString: string,
-  to: string
+  to: string,
+  logger?: ILogger
 ): string {
   return migrateAnyManifest(
     manifestString,
     "DeployManifest",
     migrateDeployManifest,
-    to
+    to,
+    logger
   );
 }

--- a/packages/cli/src/lib/manifest/migrate/migrateInfraExtensionManifest.ts
+++ b/packages/cli/src/lib/manifest/migrate/migrateInfraExtensionManifest.ts
@@ -1,15 +1,18 @@
 import { migrateAnyManifest } from "./migrateAnyManifest";
 
 import { migrateInfraManifest } from "@polywrap/polywrap-manifest-types-js";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrateInfraExtensionManifest(
   manifestString: string,
-  to: string
+  to: string,
+  logger?: ILogger
 ): string {
   return migrateAnyManifest(
     manifestString,
     "InfraManifest",
     migrateInfraManifest,
-    to
+    to,
+    logger
   );
 }

--- a/packages/cli/src/lib/manifest/migrate/migrateMetaExtensionManifest.ts
+++ b/packages/cli/src/lib/manifest/migrate/migrateMetaExtensionManifest.ts
@@ -1,15 +1,18 @@
 import { migrateAnyManifest } from "./migrateAnyManifest";
 
 import { migrateMetaManifest } from "@polywrap/polywrap-manifest-types-js";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrateMetaExtensionManifest(
   manifestString: string,
-  to: string
+  to: string,
+  logger?: ILogger
 ): string {
   return migrateAnyManifest(
     manifestString,
     "MetaManifest",
     migrateMetaManifest,
-    to
+    to,
+    logger
   );
 }

--- a/packages/cli/src/lib/manifest/migrate/migratePluginProjectManifest.ts
+++ b/packages/cli/src/lib/manifest/migrate/migratePluginProjectManifest.ts
@@ -1,15 +1,18 @@
 import { migrateAnyManifest } from "./migrateAnyManifest";
 
 import { migratePluginManifest } from "@polywrap/polywrap-manifest-types-js";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migratePluginProjectManifest(
   manifestString: string,
-  to: string
+  to: string,
+  logger?: ILogger
 ): string {
   return migrateAnyManifest(
     manifestString,
     "PluginManifest",
     migratePluginManifest,
-    to
+    to,
+    logger
   );
 }

--- a/packages/cli/src/lib/manifest/migrate/migratePolywrapProjectManifest.ts
+++ b/packages/cli/src/lib/manifest/migrate/migratePolywrapProjectManifest.ts
@@ -1,15 +1,18 @@
 import { migrateAnyManifest } from "./migrateAnyManifest";
 
 import { migratePolywrapManifest } from "@polywrap/polywrap-manifest-types-js";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migratePolywrapProjectManifest(
   manifestString: string,
-  to: string
+  to: string,
+  logger?: ILogger
 ): string {
   return migrateAnyManifest(
     manifestString,
     "PolywrapManifest",
     migratePolywrapManifest,
-    to
+    to,
+    logger
   );
 }

--- a/packages/cli/src/lib/manifest/migrate/migrateTestExtensionManifest.ts
+++ b/packages/cli/src/lib/manifest/migrate/migrateTestExtensionManifest.ts
@@ -1,12 +1,18 @@
 import { migrateAnyManifest } from "./migrateAnyManifest";
 
 import { migratePolywrapWorkflow } from "@polywrap/polywrap-manifest-types-js";
+import { ILogger } from "@polywrap/logging-js";
 
-export function migrateWorkflow(manifestString: string, to: string): string {
+export function migrateWorkflow(
+  manifestString: string,
+  to: string,
+  logger?: ILogger
+): string {
   return migrateAnyManifest(
     manifestString,
     "PolywrapWorkflow",
     migratePolywrapWorkflow,
-    to
+    to,
+    logger
   );
 }

--- a/packages/cli/src/lib/project/manifests/app/load.ts
+++ b/packages/cli/src/lib/project/manifests/app/load.ts
@@ -22,7 +22,7 @@ export async function loadAppManifest(
     }
 
     try {
-      const result = deserializeAppManifest(manifest);
+      const result = deserializeAppManifest(manifest, { logger: logger });
       return Promise.resolve(result);
     } catch (e) {
       return Promise.reject(e);

--- a/packages/cli/src/lib/project/manifests/plugin/load.ts
+++ b/packages/cli/src/lib/project/manifests/plugin/load.ts
@@ -26,7 +26,7 @@ export async function loadPluginManifest(
     }
 
     try {
-      const result = deserializePluginManifest(manifest);
+      const result = deserializePluginManifest(manifest, { logger: logger });
       return Promise.resolve(result);
     } catch (e) {
       return Promise.reject(e);

--- a/packages/cli/src/lib/project/manifests/polywrap/load.ts
+++ b/packages/cli/src/lib/project/manifests/polywrap/load.ts
@@ -42,7 +42,7 @@ export async function loadPolywrapManifest(
     }
 
     try {
-      const result = deserializePolywrapManifest(manifest);
+      const result = deserializePolywrapManifest(manifest, { logger: logger });
       return Promise.resolve(result);
     } catch (e) {
       return Promise.reject(e);
@@ -102,6 +102,7 @@ export async function loadBuildManifest(
 
     return deserializeBuildManifest(manifest, {
       extSchema: extSchema,
+      logger: logger,
     });
   };
 
@@ -137,7 +138,7 @@ export async function loadDeployManifest(
     }
 
     try {
-      let result = deserializeDeployManifest(manifest);
+      let result = deserializeDeployManifest(manifest, { logger: logger });
       result = (loadEnvironmentVariables(
         (result as unknown) as Record<string, unknown>
       ) as unknown) as DeployManifest;
@@ -213,7 +214,7 @@ export async function loadMetaManifest(
     }
 
     try {
-      const result = deserializeMetaManifest(manifest);
+      const result = deserializeMetaManifest(manifest, { logger: logger });
       return Promise.resolve(result);
     } catch (e) {
       return Promise.reject(e);
@@ -252,7 +253,7 @@ export async function loadInfraManifest(
     }
 
     try {
-      let result = deserializeInfraManifest(manifest);
+      let result = deserializeInfraManifest(manifest, { logger: logger });
       result = (loadEnvironmentVariables(
         (result as unknown) as Record<string, unknown>
       ) as unknown) as InfraManifest;
@@ -294,7 +295,7 @@ export async function loadWorkflowManifest(
     }
 
     try {
-      const result = deserializePolywrapWorkflow(manifest);
+      const result = deserializePolywrapWorkflow(manifest, { logger: logger });
       return Promise.resolve(result);
     } catch (e) {
       return Promise.reject(e);

--- a/packages/js/logging/README.md
+++ b/packages/js/logging/README.md
@@ -1,0 +1,8 @@
+# @polywrap/logging-js
+
+An interface to which Loggers within the Polywrap Toolchain must conform.
+
+Contains:
+
+- `ILogger.ts` - the logger interface
+- `LogLevel.ts` - the log levels supported by the logger

--- a/packages/js/logging/package.json
+++ b/packages/js/logging/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@polywrap/logging-js",
+  "description": "Polywrap Core Logging Interface",
+  "version": "0.9.3",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/polywrap/monorepo.git"
+  },
+  "main": "build/index.js",
+  "files": [
+    "build"
+  ],
+  "scripts": {
+    "build": "rimraf ./build && tsc --project tsconfig.build.json",
+    "lint": "eslint --color -c ../../../.eslintrc.js src/"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "rimraf": "3.0.2",
+    "typescript": "4.1.6"
+  },
+  "gitHead": "7346adaf5adb7e6bbb70d9247583e995650d390a",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/js/logging/src/ILogger.ts
+++ b/packages/js/logging/src/ILogger.ts
@@ -1,0 +1,9 @@
+import { LogLevel } from "./LogLevel";
+
+export interface ILogger {
+  log(message: string, level: LogLevel): void;
+  debug(message: string): void;
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}

--- a/packages/js/logging/src/LogLevel.ts
+++ b/packages/js/logging/src/LogLevel.ts
@@ -1,0 +1,6 @@
+export enum LogLevel {
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR,
+}

--- a/packages/js/logging/src/index.ts
+++ b/packages/js/logging/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./ILogger";
+export * from "./LogLevel";

--- a/packages/js/logging/tsconfig.build.json
+++ b/packages/js/logging/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": [
+    "./src/**/__tests__"
+  ]
+}

--- a/packages/js/logging/tsconfig.json
+++ b/packages/js/logging/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig",
+  "compilerOptions": {
+    "outDir": "build",
+    "typeRoots": [
+      "./src/**/*.d.ts"
+    ]
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/packages/js/manifests/polywrap/package.json
+++ b/packages/js/manifests/polywrap/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@polywrap/polywrap-manifest-schemas": "0.9.3",
+    "@polywrap/logging-js": "0.9.3",
     "jsonschema": "1.4.0",
     "semver": "7.3.5",
     "yaml": "2.1.3"

--- a/packages/js/manifests/polywrap/scripts/templates/deserialize-ts.mustache
+++ b/packages/js/manifests/polywrap/scripts/templates/deserialize-ts.mustache
@@ -46,8 +46,11 @@ export function deserialize{{type}}(
   );
 
   if (versionCompare === -1) {
+    // Warn user to migrate their manifest
+    options?.logger?.warn(`{{type}} is using an older version of the manifest format (${any{{type}}.format}). Please update your manifest to the latest version (${latest{{type}}Format}) by using the "polywrap manifest migrate <type>" command.`);
+
     // Upgrade
-    return migrate{{type}}(any{{type}}, latest{{type}}Format);
+    return migrate{{type}}(any{{type}}, latest{{type}}Format, options?.logger);
   } else if (versionCompare === 1) {
     // Downgrade
     throw Error(

--- a/packages/js/manifests/polywrap/scripts/templates/migrate-ts.mustache
+++ b/packages/js/manifests/polywrap/scripts/templates/migrate-ts.mustache
@@ -11,10 +11,12 @@ import {
 } from ".";
 import { findShortestMigrationPath } from "../../migrations";
 import { migrators } from "./migrators";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrate{{#latest}}{{type}}{{/latest}}(
   manifest: Any{{#latest}}{{type}}{{/latest}},
-  to: {{#latest}}{{type}}{{/latest}}Formats
+  to: {{#latest}}{{type}}{{/latest}}Formats,
+  logger?: ILogger
 ): {{#latest}}{{type}}{{/latest}} {
   let from = manifest.format as {{#latest}}{{type}}{{/latest}}Formats;
 
@@ -36,7 +38,7 @@ export function migrate{{#latest}}{{type}}{{/latest}}(
   let newManifest = manifest;
 
   for(const migrator of migrationPath){
-    newManifest = migrator.migrate(newManifest) as Any{{#latest}}{{type}}{{/latest}};
+    newManifest = migrator.migrate(newManifest, logger) as Any{{#latest}}{{type}}{{/latest}};
   }
 
   return newManifest as {{#latest}}{{type}}{{/latest}};

--- a/packages/js/manifests/polywrap/src/deserialize.ts
+++ b/packages/js/manifests/polywrap/src/deserialize.ts
@@ -1,6 +1,8 @@
+import { ILogger } from "@polywrap/logging-js";
 import { Schema as JsonSchema } from "jsonschema";
 
 export interface DeserializeManifestOptions {
   noValidate?: boolean;
   extSchema?: JsonSchema;
+  logger?: ILogger;
 }

--- a/packages/js/manifests/polywrap/src/formats/polywrap.app/deserialize.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.app/deserialize.ts
@@ -46,8 +46,11 @@ export function deserializeAppManifest(
   );
 
   if (versionCompare === -1) {
+    // Warn user to migrate their manifest
+    options?.logger?.warn(`AppManifest is using an older version of the manifest format (${anyAppManifest.format}). Please update your manifest to the latest version (${latestAppManifestFormat}) by using the "polywrap manifest migrate <type>" command.`);
+
     // Upgrade
-    return migrateAppManifest(anyAppManifest, latestAppManifestFormat);
+    return migrateAppManifest(anyAppManifest, latestAppManifestFormat, options?.logger);
   } else if (versionCompare === 1) {
     // Downgrade
     throw Error(

--- a/packages/js/manifests/polywrap/src/formats/polywrap.app/migrate.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.app/migrate.ts
@@ -11,10 +11,12 @@ import {
 } from ".";
 import { findShortestMigrationPath } from "../../migrations";
 import { migrators } from "./migrators";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrateAppManifest(
   manifest: AnyAppManifest,
-  to: AppManifestFormats
+  to: AppManifestFormats,
+  logger?: ILogger
 ): AppManifest {
   let from = manifest.format as AppManifestFormats;
 
@@ -36,7 +38,7 @@ export function migrateAppManifest(
   let newManifest = manifest;
 
   for(const migrator of migrationPath){
-    newManifest = migrator.migrate(newManifest) as AnyAppManifest;
+    newManifest = migrator.migrate(newManifest, logger) as AnyAppManifest;
   }
 
   return newManifest as AppManifest;

--- a/packages/js/manifests/polywrap/src/formats/polywrap.app/migrators/0.1.0_to_0.2.0.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.app/migrators/0.1.0_to_0.2.0.ts
@@ -1,7 +1,18 @@
+import { ILogger } from "@polywrap/logging-js";
 import { AppManifest as OldManifest } from "../0.1.0";
 import { AppManifest as NewManifest } from "../0.2.0";
 
-export function migrate(manifest: OldManifest): NewManifest {
+export function migrate(manifest: OldManifest, logger?: ILogger): NewManifest {
+  if (
+    manifest.import_redirects?.some((x) =>
+      x.schema.includes("build/schema.graphql")
+    )
+  ) {
+    logger?.warn(
+      `Detected a reference to "build/schema.graphql" in "import_redirects". Consider using "build/wrap.info" instead of "build/schema.graphql" in "source.import_abis", schema.graphql is no longer emitted as a build artifact.`
+    );
+  }
+
   return {
     format: "0.2.0",
     project: {
@@ -19,4 +30,4 @@ export function migrate(manifest: OldManifest): NewManifest {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     __type: "AppManifest",
   };
-};
+}

--- a/packages/js/manifests/polywrap/src/formats/polywrap.build/deserialize.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.build/deserialize.ts
@@ -46,8 +46,11 @@ export function deserializeBuildManifest(
   );
 
   if (versionCompare === -1) {
+    // Warn user to migrate their manifest
+    options?.logger?.warn(`BuildManifest is using an older version of the manifest format (${anyBuildManifest.format}). Please update your manifest to the latest version (${latestBuildManifestFormat}) by using the "polywrap manifest migrate <type>" command.`);
+
     // Upgrade
-    return migrateBuildManifest(anyBuildManifest, latestBuildManifestFormat);
+    return migrateBuildManifest(anyBuildManifest, latestBuildManifestFormat, options?.logger);
   } else if (versionCompare === 1) {
     // Downgrade
     throw Error(

--- a/packages/js/manifests/polywrap/src/formats/polywrap.build/migrate.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.build/migrate.ts
@@ -11,10 +11,12 @@ import {
 } from ".";
 import { findShortestMigrationPath } from "../../migrations";
 import { migrators } from "./migrators";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrateBuildManifest(
   manifest: AnyBuildManifest,
-  to: BuildManifestFormats
+  to: BuildManifestFormats,
+  logger?: ILogger
 ): BuildManifest {
   let from = manifest.format as BuildManifestFormats;
 
@@ -36,7 +38,7 @@ export function migrateBuildManifest(
   let newManifest = manifest;
 
   for(const migrator of migrationPath){
-    newManifest = migrator.migrate(newManifest) as AnyBuildManifest;
+    newManifest = migrator.migrate(newManifest, logger) as AnyBuildManifest;
   }
 
   return newManifest as BuildManifest;

--- a/packages/js/manifests/polywrap/src/formats/polywrap.deploy/deserialize.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.deploy/deserialize.ts
@@ -46,8 +46,11 @@ export function deserializeDeployManifest(
   );
 
   if (versionCompare === -1) {
+    // Warn user to migrate their manifest
+    options?.logger?.warn(`DeployManifest is using an older version of the manifest format (${anyDeployManifest.format}). Please update your manifest to the latest version (${latestDeployManifestFormat}) by using the "polywrap manifest migrate <type>" command.`);
+
     // Upgrade
-    return migrateDeployManifest(anyDeployManifest, latestDeployManifestFormat);
+    return migrateDeployManifest(anyDeployManifest, latestDeployManifestFormat, options?.logger);
   } else if (versionCompare === 1) {
     // Downgrade
     throw Error(

--- a/packages/js/manifests/polywrap/src/formats/polywrap.deploy/migrate.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.deploy/migrate.ts
@@ -11,10 +11,12 @@ import {
 } from ".";
 import { findShortestMigrationPath } from "../../migrations";
 import { migrators } from "./migrators";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrateDeployManifest(
   manifest: AnyDeployManifest,
-  to: DeployManifestFormats
+  to: DeployManifestFormats,
+  logger?: ILogger
 ): DeployManifest {
   let from = manifest.format as DeployManifestFormats;
 
@@ -36,7 +38,7 @@ export function migrateDeployManifest(
   let newManifest = manifest;
 
   for(const migrator of migrationPath){
-    newManifest = migrator.migrate(newManifest) as AnyDeployManifest;
+    newManifest = migrator.migrate(newManifest, logger) as AnyDeployManifest;
   }
 
   return newManifest as DeployManifest;

--- a/packages/js/manifests/polywrap/src/formats/polywrap.infra/deserialize.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.infra/deserialize.ts
@@ -46,8 +46,11 @@ export function deserializeInfraManifest(
   );
 
   if (versionCompare === -1) {
+    // Warn user to migrate their manifest
+    options?.logger?.warn(`InfraManifest is using an older version of the manifest format (${anyInfraManifest.format}). Please update your manifest to the latest version (${latestInfraManifestFormat}) by using the "polywrap manifest migrate <type>" command.`);
+
     // Upgrade
-    return migrateInfraManifest(anyInfraManifest, latestInfraManifestFormat);
+    return migrateInfraManifest(anyInfraManifest, latestInfraManifestFormat, options?.logger);
   } else if (versionCompare === 1) {
     // Downgrade
     throw Error(

--- a/packages/js/manifests/polywrap/src/formats/polywrap.infra/migrate.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.infra/migrate.ts
@@ -11,10 +11,12 @@ import {
 } from ".";
 import { findShortestMigrationPath } from "../../migrations";
 import { migrators } from "./migrators";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrateInfraManifest(
   manifest: AnyInfraManifest,
-  to: InfraManifestFormats
+  to: InfraManifestFormats,
+  logger?: ILogger
 ): InfraManifest {
   let from = manifest.format as InfraManifestFormats;
 
@@ -36,7 +38,7 @@ export function migrateInfraManifest(
   let newManifest = manifest;
 
   for(const migrator of migrationPath){
-    newManifest = migrator.migrate(newManifest) as AnyInfraManifest;
+    newManifest = migrator.migrate(newManifest, logger) as AnyInfraManifest;
   }
 
   return newManifest as InfraManifest;

--- a/packages/js/manifests/polywrap/src/formats/polywrap.meta/deserialize.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.meta/deserialize.ts
@@ -46,8 +46,11 @@ export function deserializeMetaManifest(
   );
 
   if (versionCompare === -1) {
+    // Warn user to migrate their manifest
+    options?.logger?.warn(`MetaManifest is using an older version of the manifest format (${anyMetaManifest.format}). Please update your manifest to the latest version (${latestMetaManifestFormat}) by using the "polywrap manifest migrate <type>" command.`);
+
     // Upgrade
-    return migrateMetaManifest(anyMetaManifest, latestMetaManifestFormat);
+    return migrateMetaManifest(anyMetaManifest, latestMetaManifestFormat, options?.logger);
   } else if (versionCompare === 1) {
     // Downgrade
     throw Error(

--- a/packages/js/manifests/polywrap/src/formats/polywrap.meta/migrate.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.meta/migrate.ts
@@ -11,10 +11,12 @@ import {
 } from ".";
 import { findShortestMigrationPath } from "../../migrations";
 import { migrators } from "./migrators";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrateMetaManifest(
   manifest: AnyMetaManifest,
-  to: MetaManifestFormats
+  to: MetaManifestFormats,
+  logger?: ILogger
 ): MetaManifest {
   let from = manifest.format as MetaManifestFormats;
 
@@ -36,7 +38,7 @@ export function migrateMetaManifest(
   let newManifest = manifest;
 
   for(const migrator of migrationPath){
-    newManifest = migrator.migrate(newManifest) as AnyMetaManifest;
+    newManifest = migrator.migrate(newManifest, logger) as AnyMetaManifest;
   }
 
   return newManifest as MetaManifest;

--- a/packages/js/manifests/polywrap/src/formats/polywrap.plugin/deserialize.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.plugin/deserialize.ts
@@ -46,8 +46,11 @@ export function deserializePluginManifest(
   );
 
   if (versionCompare === -1) {
+    // Warn user to migrate their manifest
+    options?.logger?.warn(`PluginManifest is using an older version of the manifest format (${anyPluginManifest.format}). Please update your manifest to the latest version (${latestPluginManifestFormat}) by using the "polywrap manifest migrate <type>" command.`);
+
     // Upgrade
-    return migratePluginManifest(anyPluginManifest, latestPluginManifestFormat);
+    return migratePluginManifest(anyPluginManifest, latestPluginManifestFormat, options?.logger);
   } else if (versionCompare === 1) {
     // Downgrade
     throw Error(

--- a/packages/js/manifests/polywrap/src/formats/polywrap.plugin/migrate.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.plugin/migrate.ts
@@ -11,10 +11,12 @@ import {
 } from ".";
 import { findShortestMigrationPath } from "../../migrations";
 import { migrators } from "./migrators";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migratePluginManifest(
   manifest: AnyPluginManifest,
-  to: PluginManifestFormats
+  to: PluginManifestFormats,
+  logger?: ILogger
 ): PluginManifest {
   let from = manifest.format as PluginManifestFormats;
 
@@ -36,7 +38,7 @@ export function migratePluginManifest(
   let newManifest = manifest;
 
   for(const migrator of migrationPath){
-    newManifest = migrator.migrate(newManifest) as AnyPluginManifest;
+    newManifest = migrator.migrate(newManifest, logger) as AnyPluginManifest;
   }
 
   return newManifest as PluginManifest;

--- a/packages/js/manifests/polywrap/src/formats/polywrap.plugin/migrators/0.1.0_to_0.2.0.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.plugin/migrators/0.1.0_to_0.2.0.ts
@@ -1,7 +1,18 @@
+import { ILogger } from "@polywrap/logging-js";
 import { PluginManifest as OldManifest } from "../0.1.0";
 import { PluginManifest as NewManifest } from "../0.2.0";
 
-export function migrate(manifest: OldManifest): NewManifest {
+export function migrate(manifest: OldManifest, logger?: ILogger): NewManifest {
+  if (
+    manifest.import_redirects?.some((x) =>
+      x.schema.includes("build/schema.graphql")
+    )
+  ) {
+    logger?.warn(
+      `Detected a reference to "build/schema.graphql" in "import_redirects". Consider using "build/wrap.info" instead of "build/schema.graphql" in "source.import_abis", schema.graphql is no longer emitted as a build artifact.`
+    );
+  }
+
   return {
     format: "0.2.0",
     project: {
@@ -20,4 +31,4 @@ export function migrate(manifest: OldManifest): NewManifest {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     __type: "PluginManifest",
   };
-};
+}

--- a/packages/js/manifests/polywrap/src/formats/polywrap.test/deserialize.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.test/deserialize.ts
@@ -46,8 +46,11 @@ export function deserializePolywrapWorkflow(
   );
 
   if (versionCompare === -1) {
+    // Warn user to migrate their manifest
+    options?.logger?.warn(`PolywrapWorkflow is using an older version of the manifest format (${anyPolywrapWorkflow.format}). Please update your manifest to the latest version (${latestPolywrapWorkflowFormat}) by using the "polywrap manifest migrate <type>" command.`);
+
     // Upgrade
-    return migratePolywrapWorkflow(anyPolywrapWorkflow, latestPolywrapWorkflowFormat);
+    return migratePolywrapWorkflow(anyPolywrapWorkflow, latestPolywrapWorkflowFormat, options?.logger);
   } else if (versionCompare === 1) {
     // Downgrade
     throw Error(

--- a/packages/js/manifests/polywrap/src/formats/polywrap.test/migrate.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.test/migrate.ts
@@ -11,10 +11,12 @@ import {
 } from ".";
 import { findShortestMigrationPath } from "../../migrations";
 import { migrators } from "./migrators";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migratePolywrapWorkflow(
   manifest: AnyPolywrapWorkflow,
-  to: PolywrapWorkflowFormats
+  to: PolywrapWorkflowFormats,
+  logger?: ILogger
 ): PolywrapWorkflow {
   let from = manifest.format as PolywrapWorkflowFormats;
 
@@ -36,7 +38,7 @@ export function migratePolywrapWorkflow(
   let newManifest = manifest;
 
   for(const migrator of migrationPath){
-    newManifest = migrator.migrate(newManifest) as AnyPolywrapWorkflow;
+    newManifest = migrator.migrate(newManifest, logger) as AnyPolywrapWorkflow;
   }
 
   return newManifest as PolywrapWorkflow;

--- a/packages/js/manifests/polywrap/src/formats/polywrap/deserialize.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap/deserialize.ts
@@ -46,8 +46,11 @@ export function deserializePolywrapManifest(
   );
 
   if (versionCompare === -1) {
+    // Warn user to migrate their manifest
+    options?.logger?.warn(`PolywrapManifest is using an older version of the manifest format (${anyPolywrapManifest.format}). Please update your manifest to the latest version (${latestPolywrapManifestFormat}) by using the "polywrap manifest migrate <type>" command.`);
+
     // Upgrade
-    return migratePolywrapManifest(anyPolywrapManifest, latestPolywrapManifestFormat);
+    return migratePolywrapManifest(anyPolywrapManifest, latestPolywrapManifestFormat, options?.logger);
   } else if (versionCompare === 1) {
     // Downgrade
     throw Error(

--- a/packages/js/manifests/polywrap/src/formats/polywrap/migrate.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap/migrate.ts
@@ -11,10 +11,12 @@ import {
 } from ".";
 import { findShortestMigrationPath } from "../../migrations";
 import { migrators } from "./migrators";
+import { ILogger } from "@polywrap/logging-js";
 
 export function migratePolywrapManifest(
   manifest: AnyPolywrapManifest,
-  to: PolywrapManifestFormats
+  to: PolywrapManifestFormats,
+  logger?: ILogger
 ): PolywrapManifest {
   let from = manifest.format as PolywrapManifestFormats;
 
@@ -36,7 +38,7 @@ export function migratePolywrapManifest(
   let newManifest = manifest;
 
   for(const migrator of migrationPath){
-    newManifest = migrator.migrate(newManifest) as AnyPolywrapManifest;
+    newManifest = migrator.migrate(newManifest, logger) as AnyPolywrapManifest;
   }
 
   return newManifest as PolywrapManifest;

--- a/packages/js/manifests/polywrap/src/formats/polywrap/migrators/0.1.0_to_0.2.0.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap/migrators/0.1.0_to_0.2.0.ts
@@ -1,7 +1,8 @@
+import { ILogger } from "@polywrap/logging-js";
 import { PolywrapManifest as OldManifest } from "../0.1.0";
 import { PolywrapManifest as NewManifest } from "../0.2.0";
 
-export function migrate(manifest: OldManifest): NewManifest {
+export function migrate(manifest: OldManifest, logger?: ILogger): NewManifest {
   const shouldHaveExtensions =
     manifest.build || manifest.deploy || manifest.meta;
 
@@ -10,6 +11,16 @@ export function migrate(manifest: OldManifest): NewManifest {
     deploy: manifest.deploy,
     meta: manifest.meta,
   };
+
+  if (
+    manifest.import_redirects?.some((x) =>
+      x.schema.includes("build/schema.graphql")
+    )
+  ) {
+    logger?.warn(
+      `Detected a reference to "build/schema.graphql" in "import_redirects". Consider using "build/wrap.info" instead of "build/schema.graphql" in "source.import_abis", schema.graphql is no longer emitted as a build artifact.`
+    );
+  }
 
   return {
     format: "0.2.0",
@@ -30,4 +41,4 @@ export function migrate(manifest: OldManifest): NewManifest {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     __type: "PolywrapManifest",
   };
-};
+}

--- a/packages/js/manifests/polywrap/src/migrations/Migrator.ts
+++ b/packages/js/manifests/polywrap/src/migrations/Migrator.ts
@@ -1,3 +1,4 @@
+import { ILogger } from "@polywrap/logging-js";
 import {
   AnyAppManifest,
   AnyBuildManifest,
@@ -22,5 +23,5 @@ type AnyManifest =
 export type Migrator = {
   from: string;
   to: string;
-  migrate: (manifest: AnyManifest) => AnyManifest;
+  migrate: (manifest: AnyManifest, logger?: ILogger) => AnyManifest;
 };

--- a/packages/js/manifests/polywrap/src/migrations/findShortestMigrationPath.ts
+++ b/packages/js/manifests/polywrap/src/migrations/findShortestMigrationPath.ts
@@ -1,4 +1,4 @@
-import { Migrator } from "./migration";
+import { Migrator } from "./Migrator";
 
 type MigrationWithSearchHistory = [Migrator, Migrator[]];
 

--- a/packages/js/manifests/polywrap/src/migrations/index.ts
+++ b/packages/js/manifests/polywrap/src/migrations/index.ts
@@ -1,2 +1,2 @@
 export * from "./findShortestMigrationPath";
-export * from "./migration";
+export * from "./Migrator";


### PR DESCRIPTION
This PR introduces the `@polywrap/logging-js` package which currently contains the types/interfaces required for packages other than the CLI to interact with logging.

This introduces one caveat - `intlMsg` currently only works on the CLI level.

I'd like to open some discussion as to how we'd want to handle intl in the case where we really do go forward with logging being used in multiple packages.