### PR TITLE
(fix) Add gateway URI to deploy.yaml template on interface

### DIFF
--- a/packages/templates/wasm/interface/README.md
+++ b/packages/templates/wasm/interface/README.md
@@ -6,8 +6,8 @@
 `nvm install && nvm use`  
 `yarn`  
 
-## Start Test Environment
-`yarn test:env:up`  
+## Build
+`yarn build`
 
 ## Build & Deploy Polywrap
 `yarn deploy` 

--- a/packages/templates/wasm/interface/polywrap.deploy.yaml
+++ b/packages/templates/wasm/interface/polywrap.deploy.yaml
@@ -3,3 +3,5 @@ stages:
   ipfs_deploy:
     package: ipfs
     uri: fs/./build
+    config:
+      gatewayUri: "https://ipfs.wrappers.io"


### PR DESCRIPTION
I've found that when creating a new interface from the template there was a missing config that didn't allow me to deploy.

I've added the new config parameter and the required step on the README.