### PR TITLE
CLI - `asc` should not be assumed globally available when running `local` build strategy

### DIFF
--- a/packages/cli/src/lib/defaults/build-strategies/wasm/assemblyscript/local/local.sh
+++ b/packages/cli/src/lib/defaults/build-strategies/wasm/assemblyscript/local/local.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 yarn
-asc "$1"/wrap/entry.ts \
+npx asc "$1"/wrap/entry.ts \
   --path ./node_modules \
   --outFile "$2"/wrap.wasm \
   --use abort="$1"/wrap/entry/wrapAbort \


### PR DESCRIPTION
While running tests, I noticed that the `local` build strategy was failing to build, giving me an output of `asc not found`.

Looking into `local.sh` I found out that the default build script assumes that `asc` is present as a global command (e.g. `npm i -g typescript`), whereas my setup did not have this.

I have changed the script to assume that TS is present locally (`yarn` should take care of that) and switched to running it using `npx asc...`

Let me know if this is something we don't want to have.