### PR TITLE
chore: rename & deploy interface wrappers

### DIFF
--- a/packages/interfaces/file-system/deployment.json
+++ b/packages/interfaces/file-system/deployment.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "ipfs_deploy",
+    "steps": [
+      {
+        "name": "ipfs_deploy",
+        "id": "ipfs_deploy.ipfs_deploy",
+        "input": "wrap://fs/./build",
+        "result": "wrap://ipfs/QmZ6YX5S2YAscHWBqiEveGkZ4VxUuTDehMrf3ZzkQoLFwj"
+      }
+    ]
+  }
+]

--- a/packages/interfaces/file-system/polywrap.deploy.yaml
+++ b/packages/interfaces/file-system/polywrap.deploy.yaml
@@ -1,5 +1,9 @@
-format: "0.1"
-stages:
+format: 0.2.0
+jobs:
   ipfs_deploy:
-    package: ipfs
-    uri: fs/./build
+    steps:
+      - name: ipfs_deploy
+        package: ipfs
+        uri: fs/./build
+        config:
+          gatewayUri: https://ipfs.wrappers.io

--- a/packages/interfaces/file-system/polywrap.yaml
+++ b/packages/interfaces/file-system/polywrap.yaml
@@ -1,6 +1,6 @@
 format: 0.2.0
 project:
-  name: FileSystem
+  name: file-system-interface
   type: interface
 source:
   schema: ./src/schema.graphql

--- a/packages/interfaces/http/deployment.json
+++ b/packages/interfaces/http/deployment.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "ipfs_deploy",
+    "steps": [
+      {
+        "name": "ipfs_deploy",
+        "id": "ipfs_deploy.ipfs_deploy",
+        "input": "wrap://fs/./build",
+        "result": "wrap://ipfs/QmVTcwX6SoGuon4Qa4oK3uYTiTJxMB1eWtrKZfAof4Kd5r"
+      }
+    ]
+  }
+]

--- a/packages/interfaces/http/polywrap.deploy.yaml
+++ b/packages/interfaces/http/polywrap.deploy.yaml
@@ -1,5 +1,9 @@
-format: 0.1.0
-stages:
+format: 0.2.0
+jobs:
   ipfs_deploy:
-    package: ipfs
-    uri: fs/./build
+    steps:
+      - name: ipfs_deploy
+        package: ipfs
+        uri: fs/./build
+        config:
+          gatewayUri: https://ipfs.wrappers.io

--- a/packages/interfaces/http/polywrap.yaml
+++ b/packages/interfaces/http/polywrap.yaml
@@ -1,6 +1,6 @@
 format: 0.2.0
 project:
-  name: HTTP
+  name: http-interface
   type: interface
 source:
   schema: ./src/schema.graphql

--- a/packages/interfaces/ipfs/deployment.json
+++ b/packages/interfaces/ipfs/deployment.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "ipfs_deploy",
+    "steps": [
+      {
+        "name": "ipfs_deploy",
+        "id": "ipfs_deploy.ipfs_deploy",
+        "input": "wrap://fs/./build",
+        "result": "wrap://ipfs/Qmba4wKrawQy9SMAnFcXmGLpU1YKfH9xk6hiJkqS1wsJLC"
+      }
+    ]
+  }
+]

--- a/packages/interfaces/ipfs/polywrap.deploy.yaml
+++ b/packages/interfaces/ipfs/polywrap.deploy.yaml
@@ -1,5 +1,9 @@
-format: "0.1"
-stages:
+format: 0.2.0
+jobs:
   ipfs_deploy:
-    package: ipfs
-    uri: fs/./build
+    steps:
+      - name: ipfs_deploy
+        package: ipfs
+        uri: fs/./build
+        config:
+          gatewayUri: https://ipfs.wrappers.io

--- a/packages/interfaces/ipfs/polywrap.yaml
+++ b/packages/interfaces/ipfs/polywrap.yaml
@@ -1,6 +1,6 @@
 format: 0.2.0
 project:
-  name: IPFS
+  name: ipfs-interface
   type: interface
 source:
   schema: ./src/schema.graphql

--- a/packages/interfaces/logger/deployment.json
+++ b/packages/interfaces/logger/deployment.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "ipfs_deploy",
+    "steps": [
+      {
+        "name": "ipfs_deploy",
+        "id": "ipfs_deploy.ipfs_deploy",
+        "input": "wrap://fs/./build",
+        "result": "wrap://ipfs/QmWtN2YQBpY1o1x7B6opHRYwSgdpphR36RUm19PibF4Ecs"
+      }
+    ]
+  }
+]

--- a/packages/interfaces/logger/polywrap.deploy.yaml
+++ b/packages/interfaces/logger/polywrap.deploy.yaml
@@ -1,5 +1,9 @@
-format: 0.1.0
-stages:
+format: 0.2.0
+jobs:
   ipfs_deploy:
-    package: ipfs
-    uri: fs/./build
+    steps:
+      - name: ipfs_deploy
+        package: ipfs
+        uri: fs/./build
+        config:
+          gatewayUri: https://ipfs.wrappers.io

--- a/packages/interfaces/logger/polywrap.yaml
+++ b/packages/interfaces/logger/polywrap.yaml
@@ -1,6 +1,6 @@
 format: 0.2.0
 project:
-  name: Logger
+  name: logger-interface
   type: interface
 source:
   schema: ./src/schema.graphql

--- a/packages/interfaces/uri-resolver/deployment.json
+++ b/packages/interfaces/uri-resolver/deployment.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "ipfs_deploy",
+    "steps": [
+      {
+        "name": "ipfs_deploy",
+        "id": "ipfs_deploy.ipfs_deploy",
+        "input": "wrap://fs/./build",
+        "result": "wrap://ipfs/QmdzuimfnMXgBWeKWEyswBkWq47AW9GCdXBDCmcUPn1mBj"
+      }
+    ]
+  }
+]

--- a/packages/interfaces/uri-resolver/polywrap.deploy.yaml
+++ b/packages/interfaces/uri-resolver/polywrap.deploy.yaml
@@ -1,5 +1,9 @@
-format: "0.1"
-stages:
+format: 0.2.0
+jobs:
   ipfs_deploy:
-    package: ipfs
-    uri: fs/./build
+    steps:
+      - name: ipfs_deploy
+        package: ipfs
+        uri: fs/./build
+        config:
+          gatewayUri: https://ipfs.wrappers.io

--- a/packages/interfaces/uri-resolver/polywrap.yaml
+++ b/packages/interfaces/uri-resolver/polywrap.yaml
@@ -1,6 +1,6 @@
 format: 0.2.0
 project:
-  name: UriResolver
+  name: uri-resolver-interface
   type: interface
 source:
   schema: ./src/schema.graphql


### PR DESCRIPTION
These interfaces have published to the following URIs:
`ens/dev.polywrap.eth:file-system-interface@1.0.0`
`ens/dev.polywrap.eth:http-interface@1.0.0`
`ens/dev.polywrap.eth:ipfs-interface@1.0.0`
`ens/dev.polywrap.eth:logger-interface@1.0.0`
`ens/dev.polywrap.eth:uri-resolver-interface@1.0.0`

I will make another PR after this that:
- Adds the "ens-text-record-resolver" to the default client configuration.
- Use the above URIs within the plugin schemas that implement them.