### PR TITLE
Add timeout option to http request in plugin

### DIFF
--- a/packages/interfaces/http/src/schema.graphql
+++ b/packages/interfaces/http/src/schema.graphql
@@ -10,6 +10,7 @@ type Request {
   urlParams: Map @annotate(type: "Map<String!, String!>")
   responseType: ResponseType!
   body: String
+  timeout: UInt32
 }
 
 enum ResponseType {

--- a/packages/js/plugins/http/src/util.ts
+++ b/packages/js/plugins/http/src/util.ts
@@ -84,5 +84,9 @@ export function toAxiosRequestConfig(
     config = { ...config, headers: Object.fromEntries(request.headers) };
   }
 
+  if (request.timeout) {
+    config.timeout = request.timeout;
+  }
+
   return config;
 }


### PR DESCRIPTION
This PR adds `timeout` as an option in http requests for the http plugin