### PR TITLE
fix: use String class for imported interface modules

### DIFF
--- a/packages/schema/bind/src/bindings/rust/wasm/templates/imported/module-type/mod-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/wasm/templates/imported/module-type/mod-rs.mustache
@@ -55,24 +55,24 @@ impl {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
 {{/isInterface}}
 {{#isInterface}}
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}}<'a> {
-    {{#isInterface}}uri: &'a str{{/isInterface}}
+pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
+    {{#isInterface}}uri: String;{{/isInterface}}
 }
 
-impl<'a> {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}}<'a> {
+impl {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
     pub const INTERFACE_URI: &'static str = "{{uri}}";
 
-    pub fn new(uri: &'a str) -> {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}}<'a> {
+    pub fn new(uri: String) -> {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
         {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} { uri: uri }
     }
 
     {{#methods}}
     pub fn {{#toLower}}{{name}}{{/toLower}}(&self, args: &Args{{#toUpper}}{{name}}{{/toUpper}}) -> Result<{{#return}}{{#toWasm}}{{toGraphQLType}}{{/toWasm}}{{/return}}, String> {
-        let uri = self.uri;
+        let ref uri = self.uri;
         let args = serialize_{{#toLower}}{{name}}{{/toLower}}_args(args).map_err(|e| e.to_string())?;
         let result = subinvoke::wrap_subinvoke(
             uri,
-            "{{name}}",
+            "{{name}}".as_str(),
             args,
         )?;
         deserialize_{{#toLower}}{{name}}{{/toLower}}_result(result.as_slice()).map_err(|e| e.to_string())

--- a/packages/schema/bind/src/bindings/rust/wasm/templates/imported/module-type/mod-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/wasm/templates/imported/module-type/mod-rs.mustache
@@ -56,14 +56,14 @@ impl {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
 {{#isInterface}}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
-    {{#isInterface}}uri: String;{{/isInterface}}
+    {{#isInterface}}uri: String{{/isInterface}}
 }
 
 impl {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
     pub const INTERFACE_URI: &'static str = "{{uri}}";
 
     pub fn new(uri: String) -> {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
-        {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} { uri: uri }
+        {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} { uri }
     }
 
     {{#methods}}
@@ -71,8 +71,8 @@ impl {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
         let ref uri = self.uri;
         let args = serialize_{{#toLower}}{{name}}{{/toLower}}_args(args).map_err(|e| e.to_string())?;
         let result = subinvoke::wrap_subinvoke(
-            uri,
-            "{{name}}".as_str(),
+            uri.as_str(),
+            "{{name}}",
             args,
         )?;
         deserialize_{{#toLower}}{{name}}{{/toLower}}_result(result.as_slice()).map_err(|e| e.to_string())

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_module/mod.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_module/mod.rs
@@ -27,14 +27,14 @@ use crate::TestImportEnumReturn;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TestImportModule {
-    uri: String;
+    uri: String
 }
 
 impl TestImportModule {
     pub const INTERFACE_URI: &'static str = "testimport.uri.eth";
 
     pub fn new(uri: String) -> TestImportModule {
-        TestImportModule { uri: uri }
+        TestImportModule { uri }
     }
 
     pub fn imported_method(&self, args: &ArgsImportedMethod) -> Result<Option<TestImportObject>, String> {

--- a/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_module/mod.rs
+++ b/packages/test-cases/cases/bind/sanity/output/wasm-rs/imported/test_import_module/mod.rs
@@ -26,22 +26,22 @@ use crate::TestImportEnum;
 use crate::TestImportEnumReturn;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct TestImportModule<'a> {
-    uri: &'a str
+pub struct TestImportModule {
+    uri: String;
 }
 
-impl<'a> TestImportModule<'a> {
+impl TestImportModule {
     pub const INTERFACE_URI: &'static str = "testimport.uri.eth";
 
-    pub fn new(uri: &'a str) -> TestImportModule<'a> {
+    pub fn new(uri: String) -> TestImportModule {
         TestImportModule { uri: uri }
     }
 
     pub fn imported_method(&self, args: &ArgsImportedMethod) -> Result<Option<TestImportObject>, String> {
-        let uri = self.uri;
+        let ref uri = self.uri;
         let args = serialize_imported_method_args(args).map_err(|e| e.to_string())?;
         let result = subinvoke::wrap_subinvoke(
-            uri,
+            uri.as_str(),
             "importedMethod",
             args,
         )?;
@@ -49,10 +49,10 @@ impl<'a> TestImportModule<'a> {
     }
 
     pub fn another_method(&self, args: &ArgsAnotherMethod) -> Result<i32, String> {
-        let uri = self.uri;
+        let ref uri = self.uri;
         let args = serialize_another_method_args(args).map_err(|e| e.to_string())?;
         let result = subinvoke::wrap_subinvoke(
-            uri,
+            uri.as_str(),
             "anotherMethod",
             args,
         )?;
@@ -60,10 +60,10 @@ impl<'a> TestImportModule<'a> {
     }
 
     pub fn returns_array_of_enums(&self, args: &ArgsReturnsArrayOfEnums) -> Result<Vec<Option<TestImportEnumReturn>>, String> {
-        let uri = self.uri;
+        let ref uri = self.uri;
         let args = serialize_returns_array_of_enums_args(args).map_err(|e| e.to_string())?;
         let result = subinvoke::wrap_subinvoke(
-            uri,
+            uri.as_str(),
             "returnsArrayOfEnums",
             args,
         )?;

--- a/packages/test-cases/cases/wrappers/wasm-rs/implementations/test-use-getImpl/src/lib.rs
+++ b/packages/test-cases/cases/wrappers/wasm-rs/implementations/test-use-getImpl/src/lib.rs
@@ -13,8 +13,7 @@ pub fn module_method(args: ArgsModuleMethod) -> ImplementationType {
 
 pub fn abstract_module_method(args: ArgsAbstractModuleMethod) -> String {
     let impls = Interface::get_implementations();
-    let uri: String = impls[0].to_owned();
-    let module = InterfaceModule::new(&uri);
+    let module = InterfaceModule::new(impls[0].clone());
     let method_args = interface_module::serialization::ArgsAbstractModuleMethod {
         arg: interface_argument::InterfaceArgument {
             str: args.arg.str


### PR DESCRIPTION
Using a lifetime for the interface module became quite cumbersome when working on the ethereum wrapper. This is because when an object w/ an internal lifetime is used, that lifetime must be annotated upward in the definition hierarchy. This causes a very unpleasant developer experience where you must annotate a lot of types with the `<'a>` lifetime.

For example, please consider the following code:
```rust
pub fn get_interface() -> InterfaceModule<'a> {
    let impls = Interface::get_implementations();
    IProviderModule::new(impls[0].as_str())
}

struct SomeObject<'a> {
  interface_module: InterfaceModule<'a>;
}

impl SomeObject<'a> {
  ...
}

fn function<'a>(arg: &InterfaceModule<'a>) -> void {
  ...
}
```

The use-case that shined light on this: https://github.com/polywrap/ethereum/blob/main/wrapper/src/polywrap_provider/iprovider.rs

Changing the imported interface to use the String class is much more ergonomic.