### PR TITLE
feat: typescript codegen - export imported method arg interfaces

### DIFF
--- a/packages/schema/bind/src/bindings/typescript/app/templates/types-ts.mustache
+++ b/packages/schema/bind/src/bindings/typescript/app/templates/types-ts.mustache
@@ -88,7 +88,7 @@ export type {{#detectKeyword}}{{type}}{{/detectKeyword}} = {{type}}Enum | {{type
 {{#methods}}
 
 /* URI: "{{parent.uri}}" */
-interface {{parent.type}}_Args_{{name}} {
+export interface {{parent.type}}_Args_{{name}} {
   {{#arguments}}
   {{name}}{{^required}}?{{/required}}: {{#toTypescript}}{{toGraphQLType}}{{/toTypescript}};
   {{/arguments}}

--- a/packages/schema/bind/src/bindings/typescript/plugin/templates/module-ts.mustache
+++ b/packages/schema/bind/src/bindings/typescript/plugin/templates/module-ts.mustache
@@ -1,8 +1,10 @@
 /// NOTE: This is an auto-generated file.
 ///       All modifications will be overwritten.
 
+// @ts-ignore
 import * as Types from "./types";
 
+// @ts-ignore
 import { CoreClient, MaybeAsync } from "@polywrap/core-js";
 import { PluginModule } from "@polywrap/plugin-js";
 {{#moduleType}}

--- a/packages/schema/bind/src/bindings/typescript/plugin/templates/types-ts.mustache
+++ b/packages/schema/bind/src/bindings/typescript/plugin/templates/types-ts.mustache
@@ -99,7 +99,7 @@ export type {{#detectKeyword}}{{type}}{{/detectKeyword}} = {{type}}Enum | {{type
 {{#importedModuleTypes}}
 {{#methods}}
 /* URI: "{{parent.uri}}" */
-interface {{parent.type}}_Args_{{name}} {
+export interface {{parent.type}}_Args_{{name}} {
   {{#arguments}}
   {{name}}{{^required}}?{{/required}}: {{#toTypescript}}{{toGraphQLType}}{{/toTypescript}};
   {{/arguments}}

--- a/packages/test-cases/cases/bind/sanity/output/app-ts/types.ts
+++ b/packages/test-cases/cases/bind/sanity/output/app-ts/types.ts
@@ -155,7 +155,7 @@ export type TestImport_Enum_Return = TestImport_Enum_ReturnEnum | TestImport_Enu
 /// Imported Modules START ///
 
 /* URI: "testimport.uri.eth" */
-interface TestImport_Module_Args_importedMethod {
+export interface TestImport_Module_Args_importedMethod {
   str: Types.String;
   optStr?: Types.String | null;
   u: Types.UInt;
@@ -172,12 +172,12 @@ interface TestImport_Module_Args_importedMethod {
 }
 
 /* URI: "testimport.uri.eth" */
-interface TestImport_Module_Args_anotherMethod {
+export interface TestImport_Module_Args_anotherMethod {
   arg: Array<Types.String>;
 }
 
 /* URI: "testimport.uri.eth" */
-interface TestImport_Module_Args_returnsArrayOfEnums {
+export interface TestImport_Module_Args_returnsArrayOfEnums {
   arg: Types.String;
 }
 

--- a/packages/test-cases/cases/bind/sanity/output/plugin-ts/module.ts
+++ b/packages/test-cases/cases/bind/sanity/output/plugin-ts/module.ts
@@ -1,8 +1,10 @@
 /// NOTE: This is an auto-generated file.
 ///       All modifications will be overwritten.
 
+// @ts-ignore
 import * as Types from "./types";
 
+// @ts-ignore
 import { CoreClient, MaybeAsync } from "@polywrap/core-js";
 import { PluginModule } from "@polywrap/plugin-js";
 

--- a/packages/test-cases/cases/bind/sanity/output/plugin-ts/types.ts
+++ b/packages/test-cases/cases/bind/sanity/output/plugin-ts/types.ts
@@ -169,7 +169,7 @@ export type TestImport_Enum_Return = TestImport_Enum_ReturnEnum | TestImport_Enu
 /// Imported Modules START ///
 
 /* URI: "testimport.uri.eth" */
-interface TestImport_Module_Args_importedMethod {
+export interface TestImport_Module_Args_importedMethod {
   str: Types.String;
   optStr?: Types.String | null;
   u: Types.UInt;
@@ -186,12 +186,12 @@ interface TestImport_Module_Args_importedMethod {
 }
 
 /* URI: "testimport.uri.eth" */
-interface TestImport_Module_Args_anotherMethod {
+export interface TestImport_Module_Args_anotherMethod {
   arg: Array<Types.String>;
 }
 
 /* URI: "testimport.uri.eth" */
-interface TestImport_Module_Args_returnsArrayOfEnums {
+export interface TestImport_Module_Args_returnsArrayOfEnums {
   arg: Types.String;
 }
 

--- a/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/module.ts
@@ -1,8 +1,10 @@
 /// NOTE: This is an auto-generated file.
 ///       All modifications will be overwritten.
 
+// @ts-ignore
 import * as Types from "./types";
 
+// @ts-ignore
 import { CoreClient, MaybeAsync } from "@polywrap/core-js";
 import { PluginModule } from "@polywrap/plugin-js";
 

--- a/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/001-sanity/expected/wrap/types.ts
@@ -159,7 +159,7 @@ export interface Ethereum_Access {
 /// Imported Modules START ///
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractView {
+export interface Ethereum_Module_Args_callContractView {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -167,7 +167,7 @@ interface Ethereum_Module_Args_callContractView {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractStatic {
+export interface Ethereum_Module_Args_callContractStatic {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -176,72 +176,72 @@ interface Ethereum_Module_Args_callContractStatic {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getBalance {
+export interface Ethereum_Module_Args_getBalance {
   address: Types.String;
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeParams {
+export interface Ethereum_Module_Args_encodeParams {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeFunction {
+export interface Ethereum_Module_Args_encodeFunction {
   method: Types.String;
   args?: Array<Types.String> | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityPack {
+export interface Ethereum_Module_Args_solidityPack {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityKeccak256 {
+export interface Ethereum_Module_Args_solidityKeccak256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_soliditySha256 {
+export interface Ethereum_Module_Args_soliditySha256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerAddress {
+export interface Ethereum_Module_Args_getSignerAddress {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerBalance {
+export interface Ethereum_Module_Args_getSignerBalance {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerTransactionCount {
+export interface Ethereum_Module_Args_getSignerTransactionCount {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getGasPrice {
+export interface Ethereum_Module_Args_getGasPrice {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateTransactionGas {
+export interface Ethereum_Module_Args_estimateTransactionGas {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateContractCallGas {
+export interface Ethereum_Module_Args_estimateContractCallGas {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -250,22 +250,22 @@ interface Ethereum_Module_Args_estimateContractCallGas {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_checkAddress {
+export interface Ethereum_Module_Args_checkAddress {
   address: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toWei {
+export interface Ethereum_Module_Args_toWei {
   eth: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toEth {
+export interface Ethereum_Module_Args_toEth {
   wei: Types.BigInt;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_awaitTransaction {
+export interface Ethereum_Module_Args_awaitTransaction {
   txHash: Types.String;
   confirmations: Types.UInt32;
   timeout: Types.UInt32;
@@ -273,7 +273,7 @@ interface Ethereum_Module_Args_awaitTransaction {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_waitForEvent {
+export interface Ethereum_Module_Args_waitForEvent {
   address: Types.String;
   event: Types.String;
   args?: Array<Types.String> | null;
@@ -282,17 +282,17 @@ interface Ethereum_Module_Args_waitForEvent {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getNetwork {
+export interface Ethereum_Module_Args_getNetwork {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_requestAccounts {
+export interface Ethereum_Module_Args_requestAccounts {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethod {
+export interface Ethereum_Module_Args_callContractMethod {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -301,7 +301,7 @@ interface Ethereum_Module_Args_callContractMethod {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethodAndWait {
+export interface Ethereum_Module_Args_callContractMethodAndWait {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -310,19 +310,19 @@ interface Ethereum_Module_Args_callContractMethodAndWait {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransaction {
+export interface Ethereum_Module_Args_sendTransaction {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransactionAndWait {
+export interface Ethereum_Module_Args_sendTransactionAndWait {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_deployContract {
+export interface Ethereum_Module_Args_deployContract {
   abi: Types.String;
   bytecode: Types.String;
   args?: Array<Types.String> | null;
@@ -330,19 +330,19 @@ interface Ethereum_Module_Args_deployContract {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessage {
+export interface Ethereum_Module_Args_signMessage {
   message: Types.String;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessageBytes {
+export interface Ethereum_Module_Args_signMessageBytes {
   bytes: Types.Bytes;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendRPC {
+export interface Ethereum_Module_Args_sendRPC {
   method: Types.String;
   params: Array<Types.String>;
   connection?: Types.Ethereum_Connection | null;

--- a/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/module.ts
@@ -1,8 +1,10 @@
 /// NOTE: This is an auto-generated file.
 ///       All modifications will be overwritten.
 
+// @ts-ignore
 import * as Types from "./types";
 
+// @ts-ignore
 import { CoreClient, MaybeAsync } from "@polywrap/core-js";
 import { PluginModule } from "@polywrap/plugin-js";
 

--- a/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/002-single-module/expected/wrap/types.ts
@@ -159,7 +159,7 @@ export interface Ethereum_Access {
 /// Imported Modules START ///
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractView {
+export interface Ethereum_Module_Args_callContractView {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -167,7 +167,7 @@ interface Ethereum_Module_Args_callContractView {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractStatic {
+export interface Ethereum_Module_Args_callContractStatic {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -176,72 +176,72 @@ interface Ethereum_Module_Args_callContractStatic {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getBalance {
+export interface Ethereum_Module_Args_getBalance {
   address: Types.String;
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeParams {
+export interface Ethereum_Module_Args_encodeParams {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeFunction {
+export interface Ethereum_Module_Args_encodeFunction {
   method: Types.String;
   args?: Array<Types.String> | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityPack {
+export interface Ethereum_Module_Args_solidityPack {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityKeccak256 {
+export interface Ethereum_Module_Args_solidityKeccak256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_soliditySha256 {
+export interface Ethereum_Module_Args_soliditySha256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerAddress {
+export interface Ethereum_Module_Args_getSignerAddress {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerBalance {
+export interface Ethereum_Module_Args_getSignerBalance {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerTransactionCount {
+export interface Ethereum_Module_Args_getSignerTransactionCount {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getGasPrice {
+export interface Ethereum_Module_Args_getGasPrice {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateTransactionGas {
+export interface Ethereum_Module_Args_estimateTransactionGas {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateContractCallGas {
+export interface Ethereum_Module_Args_estimateContractCallGas {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -250,22 +250,22 @@ interface Ethereum_Module_Args_estimateContractCallGas {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_checkAddress {
+export interface Ethereum_Module_Args_checkAddress {
   address: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toWei {
+export interface Ethereum_Module_Args_toWei {
   eth: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toEth {
+export interface Ethereum_Module_Args_toEth {
   wei: Types.BigInt;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_awaitTransaction {
+export interface Ethereum_Module_Args_awaitTransaction {
   txHash: Types.String;
   confirmations: Types.UInt32;
   timeout: Types.UInt32;
@@ -273,7 +273,7 @@ interface Ethereum_Module_Args_awaitTransaction {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_waitForEvent {
+export interface Ethereum_Module_Args_waitForEvent {
   address: Types.String;
   event: Types.String;
   args?: Array<Types.String> | null;
@@ -282,17 +282,17 @@ interface Ethereum_Module_Args_waitForEvent {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getNetwork {
+export interface Ethereum_Module_Args_getNetwork {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_requestAccounts {
+export interface Ethereum_Module_Args_requestAccounts {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethod {
+export interface Ethereum_Module_Args_callContractMethod {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -301,7 +301,7 @@ interface Ethereum_Module_Args_callContractMethod {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethodAndWait {
+export interface Ethereum_Module_Args_callContractMethodAndWait {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -310,19 +310,19 @@ interface Ethereum_Module_Args_callContractMethodAndWait {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransaction {
+export interface Ethereum_Module_Args_sendTransaction {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransactionAndWait {
+export interface Ethereum_Module_Args_sendTransactionAndWait {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_deployContract {
+export interface Ethereum_Module_Args_deployContract {
   abi: Types.String;
   bytecode: Types.String;
   args?: Array<Types.String> | null;
@@ -330,19 +330,19 @@ interface Ethereum_Module_Args_deployContract {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessage {
+export interface Ethereum_Module_Args_signMessage {
   message: Types.String;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessageBytes {
+export interface Ethereum_Module_Args_signMessageBytes {
   bytes: Types.Bytes;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendRPC {
+export interface Ethereum_Module_Args_sendRPC {
   method: Types.String;
   params: Array<Types.String>;
   connection?: Types.Ethereum_Connection | null;

--- a/packages/test-cases/cases/cli/plugin/codegen/003-env/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/003-env/expected/wrap/module.ts
@@ -1,8 +1,10 @@
 /// NOTE: This is an auto-generated file.
 ///       All modifications will be overwritten.
 
+// @ts-ignore
 import * as Types from "./types";
 
+// @ts-ignore
 import { CoreClient, MaybeAsync } from "@polywrap/core-js";
 import { PluginModule } from "@polywrap/plugin-js";
 

--- a/packages/test-cases/cases/cli/plugin/codegen/004-env-sanitization/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/004-env-sanitization/expected/wrap/module.ts
@@ -1,8 +1,10 @@
 /// NOTE: This is an auto-generated file.
 ///       All modifications will be overwritten.
 
+// @ts-ignore
 import * as Types from "./types";
 
+// @ts-ignore
 import { CoreClient, MaybeAsync } from "@polywrap/core-js";
 import { PluginModule } from "@polywrap/plugin-js";
 

--- a/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/module.ts
@@ -1,8 +1,10 @@
 /// NOTE: This is an auto-generated file.
 ///       All modifications will be overwritten.
 
+// @ts-ignore
 import * as Types from "./types";
 
+// @ts-ignore
 import { CoreClient, MaybeAsync } from "@polywrap/core-js";
 import { PluginModule } from "@polywrap/plugin-js";
 

--- a/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/005-custom-config/expected/wrap/types.ts
@@ -159,7 +159,7 @@ export interface Ethereum_Access {
 /// Imported Modules START ///
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractView {
+export interface Ethereum_Module_Args_callContractView {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -167,7 +167,7 @@ interface Ethereum_Module_Args_callContractView {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractStatic {
+export interface Ethereum_Module_Args_callContractStatic {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -176,72 +176,72 @@ interface Ethereum_Module_Args_callContractStatic {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getBalance {
+export interface Ethereum_Module_Args_getBalance {
   address: Types.String;
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeParams {
+export interface Ethereum_Module_Args_encodeParams {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeFunction {
+export interface Ethereum_Module_Args_encodeFunction {
   method: Types.String;
   args?: Array<Types.String> | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityPack {
+export interface Ethereum_Module_Args_solidityPack {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityKeccak256 {
+export interface Ethereum_Module_Args_solidityKeccak256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_soliditySha256 {
+export interface Ethereum_Module_Args_soliditySha256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerAddress {
+export interface Ethereum_Module_Args_getSignerAddress {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerBalance {
+export interface Ethereum_Module_Args_getSignerBalance {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerTransactionCount {
+export interface Ethereum_Module_Args_getSignerTransactionCount {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getGasPrice {
+export interface Ethereum_Module_Args_getGasPrice {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateTransactionGas {
+export interface Ethereum_Module_Args_estimateTransactionGas {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateContractCallGas {
+export interface Ethereum_Module_Args_estimateContractCallGas {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -250,22 +250,22 @@ interface Ethereum_Module_Args_estimateContractCallGas {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_checkAddress {
+export interface Ethereum_Module_Args_checkAddress {
   address: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toWei {
+export interface Ethereum_Module_Args_toWei {
   eth: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toEth {
+export interface Ethereum_Module_Args_toEth {
   wei: Types.BigInt;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_awaitTransaction {
+export interface Ethereum_Module_Args_awaitTransaction {
   txHash: Types.String;
   confirmations: Types.UInt32;
   timeout: Types.UInt32;
@@ -273,7 +273,7 @@ interface Ethereum_Module_Args_awaitTransaction {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_waitForEvent {
+export interface Ethereum_Module_Args_waitForEvent {
   address: Types.String;
   event: Types.String;
   args?: Array<Types.String> | null;
@@ -282,17 +282,17 @@ interface Ethereum_Module_Args_waitForEvent {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getNetwork {
+export interface Ethereum_Module_Args_getNetwork {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_requestAccounts {
+export interface Ethereum_Module_Args_requestAccounts {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethod {
+export interface Ethereum_Module_Args_callContractMethod {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -301,7 +301,7 @@ interface Ethereum_Module_Args_callContractMethod {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethodAndWait {
+export interface Ethereum_Module_Args_callContractMethodAndWait {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -310,19 +310,19 @@ interface Ethereum_Module_Args_callContractMethodAndWait {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransaction {
+export interface Ethereum_Module_Args_sendTransaction {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransactionAndWait {
+export interface Ethereum_Module_Args_sendTransactionAndWait {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_deployContract {
+export interface Ethereum_Module_Args_deployContract {
   abi: Types.String;
   bytecode: Types.String;
   args?: Array<Types.String> | null;
@@ -330,19 +330,19 @@ interface Ethereum_Module_Args_deployContract {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessage {
+export interface Ethereum_Module_Args_signMessage {
   message: Types.String;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessageBytes {
+export interface Ethereum_Module_Args_signMessageBytes {
   bytes: Types.Bytes;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendRPC {
+export interface Ethereum_Module_Args_sendRPC {
   method: Types.String;
   params: Array<Types.String>;
   connection?: Types.Ethereum_Connection | null;

--- a/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/module.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/module.ts
@@ -1,8 +1,10 @@
 /// NOTE: This is an auto-generated file.
 ///       All modifications will be overwritten.
 
+// @ts-ignore
 import * as Types from "./types";
 
+// @ts-ignore
 import { CoreClient, MaybeAsync } from "@polywrap/core-js";
 import { PluginModule } from "@polywrap/plugin-js";
 

--- a/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/types.ts
+++ b/packages/test-cases/cases/cli/plugin/codegen/006-custom-manifest-file/expected/wrap/types.ts
@@ -159,7 +159,7 @@ export interface Ethereum_Access {
 /// Imported Modules START ///
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractView {
+export interface Ethereum_Module_Args_callContractView {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -167,7 +167,7 @@ interface Ethereum_Module_Args_callContractView {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractStatic {
+export interface Ethereum_Module_Args_callContractStatic {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -176,72 +176,72 @@ interface Ethereum_Module_Args_callContractStatic {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getBalance {
+export interface Ethereum_Module_Args_getBalance {
   address: Types.String;
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeParams {
+export interface Ethereum_Module_Args_encodeParams {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_encodeFunction {
+export interface Ethereum_Module_Args_encodeFunction {
   method: Types.String;
   args?: Array<Types.String> | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityPack {
+export interface Ethereum_Module_Args_solidityPack {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_solidityKeccak256 {
+export interface Ethereum_Module_Args_solidityKeccak256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_soliditySha256 {
+export interface Ethereum_Module_Args_soliditySha256 {
   types: Array<Types.String>;
   values: Array<Types.String>;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerAddress {
+export interface Ethereum_Module_Args_getSignerAddress {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerBalance {
+export interface Ethereum_Module_Args_getSignerBalance {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getSignerTransactionCount {
+export interface Ethereum_Module_Args_getSignerTransactionCount {
   blockTag?: Types.BigInt | null;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getGasPrice {
+export interface Ethereum_Module_Args_getGasPrice {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateTransactionGas {
+export interface Ethereum_Module_Args_estimateTransactionGas {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_estimateContractCallGas {
+export interface Ethereum_Module_Args_estimateContractCallGas {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -250,22 +250,22 @@ interface Ethereum_Module_Args_estimateContractCallGas {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_checkAddress {
+export interface Ethereum_Module_Args_checkAddress {
   address: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toWei {
+export interface Ethereum_Module_Args_toWei {
   eth: Types.String;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_toEth {
+export interface Ethereum_Module_Args_toEth {
   wei: Types.BigInt;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_awaitTransaction {
+export interface Ethereum_Module_Args_awaitTransaction {
   txHash: Types.String;
   confirmations: Types.UInt32;
   timeout: Types.UInt32;
@@ -273,7 +273,7 @@ interface Ethereum_Module_Args_awaitTransaction {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_waitForEvent {
+export interface Ethereum_Module_Args_waitForEvent {
   address: Types.String;
   event: Types.String;
   args?: Array<Types.String> | null;
@@ -282,17 +282,17 @@ interface Ethereum_Module_Args_waitForEvent {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_getNetwork {
+export interface Ethereum_Module_Args_getNetwork {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_requestAccounts {
+export interface Ethereum_Module_Args_requestAccounts {
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethod {
+export interface Ethereum_Module_Args_callContractMethod {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -301,7 +301,7 @@ interface Ethereum_Module_Args_callContractMethod {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_callContractMethodAndWait {
+export interface Ethereum_Module_Args_callContractMethodAndWait {
   address: Types.String;
   method: Types.String;
   args?: Array<Types.String> | null;
@@ -310,19 +310,19 @@ interface Ethereum_Module_Args_callContractMethodAndWait {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransaction {
+export interface Ethereum_Module_Args_sendTransaction {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendTransactionAndWait {
+export interface Ethereum_Module_Args_sendTransactionAndWait {
   tx: Types.Ethereum_TxRequest;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_deployContract {
+export interface Ethereum_Module_Args_deployContract {
   abi: Types.String;
   bytecode: Types.String;
   args?: Array<Types.String> | null;
@@ -330,19 +330,19 @@ interface Ethereum_Module_Args_deployContract {
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessage {
+export interface Ethereum_Module_Args_signMessage {
   message: Types.String;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_signMessageBytes {
+export interface Ethereum_Module_Args_signMessageBytes {
   bytes: Types.Bytes;
   connection?: Types.Ethereum_Connection | null;
 }
 
 /* URI: "ens/ethereum.polywrap.eth" */
-interface Ethereum_Module_Args_sendRPC {
+export interface Ethereum_Module_Args_sendRPC {
   method: Types.String;
   params: Array<Types.String>;
   connection?: Types.Ethereum_Connection | null;


### PR DESCRIPTION
This is a required feature for the new ethereum provider js plugin. You can find the workaround that was created for this here: https://github.com/polywrap/ethereum/blob/main/provider/implementations/js/scripts/fix-bindings.ts