### PR TITLE
add concurrency plugin to default config

### DIFF
--- a/packages/js/client-config-builder/package.json
+++ b/packages/js/client-config-builder/package.json
@@ -30,7 +30,8 @@
     "@polywrap/ipfs-resolver-plugin-js": "0.10.0-pre.5",
     "@polywrap/logger-plugin-js": "0.10.0",
     "@polywrap/uri-resolver-extensions-js": "0.10.0-pre.5",
-    "@polywrap/uri-resolvers-js": "0.10.0-pre.5"
+    "@polywrap/uri-resolvers-js": "0.10.0-pre.5",
+    "concurrent-plugin-js": "0.1.1"
   },
   "devDependencies": {
     "@types/jest": "26.0.8",

--- a/packages/js/client-config-builder/src/bundles/getDefaultConfig.ts
+++ b/packages/js/client-config-builder/src/bundles/getDefaultConfig.ts
@@ -14,6 +14,7 @@ import { httpResolverPlugin } from "@polywrap/http-resolver-plugin-js";
 import { fileSystemPlugin } from "@polywrap/fs-plugin-js";
 import { loggerPlugin } from "@polywrap/logger-plugin-js";
 import { fileSystemResolverPlugin } from "@polywrap/fs-resolver-plugin-js";
+import { concurrentPromisePlugin } from "concurrent-plugin-js";
 
 export const getDefaultConfig = (): ClientConfig<Uri> => {
   return {
@@ -66,6 +67,10 @@ export const getDefaultConfig = (): ClientConfig<Uri> => {
         interface: new Uri("wrap://ens/wrappers.polywrap.eth:logger@1.0.0"),
         implementations: [new Uri("wrap://plugin/logger")],
       },
+      {
+        interface: new Uri(defaultWrappers.concurrentInterface),
+        implementations: [new Uri("wrap://plugin/concurrent")],
+      },
     ],
     packages: getDefaultPlugins(),
     wrappers: [],
@@ -82,6 +87,7 @@ export const defaultWrappers = {
   sha3: "wrap://ens/goerli/sha3.wrappers.eth",
   uts46: "wrap://ens/goerli/uts46-lite.wrappers.eth",
   graphNode: "wrap://ens/goerli/graph-node.wrappers.eth",
+  concurrentInterface: "wrap://ens/goerli/interface.concurrent.wrappers.eth",
 };
 
 export const getDefaultPlugins = (): IUriPackage<Uri>[] => {
@@ -136,6 +142,10 @@ export const getDefaultPlugins = (): IUriPackage<Uri>[] => {
     {
       uri: new Uri("wrap://ens/ipfs-resolver.polywrap.eth"),
       package: ipfsResolverPlugin({}),
+    },
+    {
+      uri: new Uri("wrap://plugin/concurrent"),
+      package: concurrentPromisePlugin({}),
     },
   ];
 };

--- a/packages/js/client/src/__tests__/core/sanity.spec.ts
+++ b/packages/js/client/src/__tests__/core/sanity.spec.ts
@@ -9,6 +9,7 @@ import { buildWrapper } from "@polywrap/test-env-js";
 import { ResultErr } from "@polywrap/result";
 import { StaticResolver, UriResolverLike } from "@polywrap/uri-resolvers-js";
 import { WasmPackage } from "@polywrap/wasm-js";
+import { defaultWrappers } from "@polywrap/client-config-builder-js";
 
 jest.setTimeout(200000);
 
@@ -31,6 +32,10 @@ describe("sanity", () => {
         {
           interface: new Uri("wrap://ens/wrappers.polywrap.eth:logger@1.0.0"),
           implementations: [new Uri("wrap://plugin/logger")],
+        },
+        {
+          interface: new Uri(defaultWrappers.concurrentInterface),
+          implementations: [new Uri("wrap://plugin/concurrent")],
         },
       ]);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6013,6 +6013,14 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
+concurrent-plugin-js@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/concurrent-plugin-js/-/concurrent-plugin-js-0.1.1.tgz#565a11f8ef57192f27f2f2cf53a2c25cc76bd9a2"
+  integrity sha512-pjOwIYBFAeTSkh0KPwuJr09eZjo/wkazovaFBA/Zg7O17j1jBm6jm34B3JcG71K4Lr/VLYlt901cu29ROsS+7Q==
+  dependencies:
+    "@polywrap/core-js" "0.10.0-pre.5"
+    "@polywrap/msgpack-js" "0.10.0-pre.5"
+
 config-chain@^1.1.12:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"


### PR DESCRIPTION
This PR adds the concurrency plugin and interface to the default client config. 

The concurrency plugin and interface have been moved from the integrations repo to https://github.com/polywrap/concurrent.