### PR TITLE
fix: add polywrap infura provider to CLI test-env config

### DIFF
--- a/packages/cli/src/lib/test-env/client-config.ts
+++ b/packages/cli/src/lib/test-env/client-config.ts
@@ -43,6 +43,14 @@ export function getTestEnvClientConfig(): Partial<PolywrapClientConfig> {
               testnet: new Connection({
                 provider: ethProvider,
               }),
+              mainnet: new Connection({
+                provider:
+                  "https://mainnet.infura.io/v3/b00b2c2cc09c487685e9fb061256d6a6",
+              }),
+              goerli: new Connection({
+                provider:
+                  "https://goerli.infura.io/v3/b00b2c2cc09c487685e9fb061256d6a6",
+              }),
             },
           }),
         }),

--- a/packages/js/plugins/ethereum/src/index.ts
+++ b/packages/js/plugins/ethereum/src/index.ts
@@ -442,14 +442,14 @@ export class EthereumPlugin extends Module<EthereumPluginConfig> {
     // This behavior is a consequence of how the ens-resolver uses the Ethereum plugin, always specifying the connection network name (e.g. mainnet)
     if (
       !connection?.node &&
-      this.env.connection &&
-      this.env.connection.networkNameOrChainId ===
+      this.env?.connection &&
+      this.env?.connection.networkNameOrChainId ===
         connection?.networkNameOrChainId
     ) {
-      return this._connections.getConnection(this.env.connection);
+      return this._connections.getConnection(this.env?.connection);
     }
 
-    return this._connections.getConnection(connection || this.env.connection);
+    return this._connections.getConnection(connection || this.env?.connection);
   }
 }
 


### PR DESCRIPTION
When building wrappers w/ the CLI, and loading imports, I've been getting warnings from the ethers default RPC provider being used. This fixes that, and uses our infura key instead.