### PR TITLE
`ClientConfigBuilder` - move wrapperCache and resolver from constructor to buildCoreConfig

### DIFF
--- a/packages/js/client-config-builder/README.md
+++ b/packages/js/client-config-builder/README.md
@@ -13,12 +13,6 @@ Initialize a ClientConfigBuilder using the [constructor](#constructor)
 ```typescript
   // start with a blank slate (typical usage)
   const builder = new ClientConfigBuilder();
-
-  // instantiate a builder with a custom cache and/or resolver
-  const _builder = new ClientConfigBuilder(
-    new WrapperCache(),
-    RecursiveResolver.from([])
-  );
 ```
 
 ### Configure
@@ -63,7 +57,13 @@ Finally, build a ClientConfig or CoreClientConfig to pass to the PolywrapClient 
   const clientConfig = builder.build();
 
   // accepted by either the PolywrapClient or the PolywrapCoreClient
-  const coreClientConfig = builder.buildCoreConfig();
+  let coreClientConfig = builder.buildCoreConfig();
+
+  // build with a custom cache and/or resolver
+  coreClientConfig = builder.buildCoreConfig(
+    new WrapperCache(),
+    RecursiveResolver.from([])
+  );
 ```
 
 ### Example
@@ -197,14 +197,8 @@ export interface ClientConfig {
 ```ts
   /**
    * Instantiate a ClientConfigBuilder
-   *
-   * @param _wrapperCache?: a wrapper cache to be used in place of the default wrapper cache
-   * @param _resolver?: a uri resolver to be used in place of any added redirects, wrappers, packages, and resolvers when building a CoreClientConfig
    */
-  constructor(
-    private readonly _wrapperCache?: IWrapperCache,
-    private readonly _resolver?: IUriResolver<unknown>
-  ) 
+  constructor() 
 ```
 
 ### add

--- a/packages/js/client-config-builder/examples/quickstart.ts
+++ b/packages/js/client-config-builder/examples/quickstart.ts
@@ -11,15 +11,9 @@ export function initialize(): ClientConfigBuilder {
   // $start: quickstart-initialize
   // start with a blank slate (typical usage)
   const builder = new ClientConfigBuilder();
-
-  // instantiate a builder with a custom cache and/or resolver
-  const _builder = new ClientConfigBuilder(
-    new WrapperCache(),
-    RecursiveResolver.from([])
-  );
   // $end
 
-  return builder ?? _builder;
+  return builder;
 }
 
 export function configure(): ClientConfigBuilder {
@@ -66,7 +60,13 @@ export function build():
   const clientConfig = builder.build();
 
   // accepted by either the PolywrapClient or the PolywrapCoreClient
-  const coreClientConfig = builder.buildCoreConfig();
+  let coreClientConfig = builder.buildCoreConfig();
+
+  // build with a custom cache and/or resolver
+  coreClientConfig = builder.buildCoreConfig(
+    new WrapperCache(),
+    RecursiveResolver.from([])
+  );
   // $end
 
   return builder ?? clientConfig ?? coreClientConfig;

--- a/packages/js/client-config-builder/src/BaseClientConfigBuilder.ts
+++ b/packages/js/client-config-builder/src/BaseClientConfigBuilder.ts
@@ -12,8 +12,9 @@ import {
   IUriRedirect,
   IUriWrapper,
   IUriPackage,
+  IUriResolver,
 } from "@polywrap/core-js";
-import { UriResolverLike } from "@polywrap/uri-resolvers-js";
+import { IWrapperCache, UriResolverLike } from "@polywrap/uri-resolvers-js";
 
 export abstract class BaseClientConfigBuilder implements IClientConfigBuilder {
   protected _config: BuilderConfig = {
@@ -26,7 +27,10 @@ export abstract class BaseClientConfigBuilder implements IClientConfigBuilder {
   };
 
   abstract addDefaults(): IClientConfigBuilder;
-  abstract buildCoreConfig(): CoreClientConfig;
+  abstract buildCoreConfig(
+    wrapperCache?: IWrapperCache,
+    resolver?: IUriResolver<unknown>
+  ): CoreClientConfig;
 
   get config(): BuilderConfig {
     return this._config;

--- a/packages/js/client-config-builder/src/ClientConfigBuilder.ts
+++ b/packages/js/client-config-builder/src/ClientConfigBuilder.ts
@@ -13,10 +13,7 @@ import {
 import { ExtendableUriResolver } from "@polywrap/uri-resolver-extensions-js";
 
 export class ClientConfigBuilder extends BaseClientConfigBuilder {
-  constructor(
-    private readonly wrapperCache?: IWrapperCache,
-    private readonly resolver?: IUriResolver<unknown>
-  ) {
+  constructor() {
     super();
   }
 
@@ -24,14 +21,17 @@ export class ClientConfigBuilder extends BaseClientConfigBuilder {
     return this.add(getDefaultConfig());
   }
 
-  buildCoreConfig(): CoreClientConfig {
+  buildCoreConfig(
+    wrapperCache?: IWrapperCache,
+    resolver?: IUriResolver<unknown>
+  ): CoreClientConfig {
     const clientConfig = this.build();
 
     return {
       envs: clientConfig.envs,
       interfaces: clientConfig.interfaces,
       resolver:
-        this.resolver ??
+        resolver ??
         RecursiveResolver.from(
           PackageToWrapperCacheResolver.from(
             [
@@ -43,7 +43,7 @@ export class ClientConfigBuilder extends BaseClientConfigBuilder {
               ...clientConfig.resolvers,
               new ExtendableUriResolver(),
             ],
-            this.wrapperCache ?? new WrapperCache()
+            wrapperCache ?? new WrapperCache()
           )
         ),
     };

--- a/packages/js/client-config-builder/src/helpers/buildPolywrapCoreClientConfig.ts
+++ b/packages/js/client-config-builder/src/helpers/buildPolywrapCoreClientConfig.ts
@@ -151,11 +151,7 @@ export function buildPolywrapCoreClientConfig<
   noDefaults = false
 ): CoreClientConfig {
   if (!builder) {
-    if (config && "wrapperCache" in config) {
-      builder = new ClientConfigBuilder(config.wrapperCache);
-    } else {
-      builder = new ClientConfigBuilder();
-    }
+    builder = new ClientConfigBuilder();
   }
 
   if (!noDefaults) {
@@ -168,7 +164,9 @@ export function buildPolywrapCoreClientConfig<
     builder.add(sanitizeConfig(config));
   }
 
-  const sanitizedConfig = builder.buildCoreConfig();
+  if (config && "wrapperCache" in config) {
+    return builder.buildCoreConfig(config.wrapperCache);
+  }
 
-  return sanitizedConfig;
+  return builder.buildCoreConfig();
 }


### PR DESCRIPTION
This PR aims to move ClientConfigBuilder constructor arguments into the only place where they are actually used - the `buildCoreConfig` method.

Context from Discord:

@krisbitney mentioned:
I noticed the ClientConfigBuilder constructor accepts a IWrapperCache argument, but the cache is ignored when calling build(). It's only used for buildCoreConfig(). Could this be misleading?

I'm thinking someone could call build() and then not realize they need to put their wrapper cache in a PolywrapClientConfig.

```typescript
// config in constructor will be lost
const clientConfig = new ClientConfigBuilder(new CustomWrapperCache())
  .add(...)
  .build();

// my client doesn't use my custom cache!
const wrongClient = new PolywrapClient(clientConfig);

// Ohhh, it's because I forgot this step
const polywrapClientConfig = {
  ...clientConfig
   wrapperCach: new CustomWrapperCache(),
}

// this client will use the custom cache
const rightClient = new PolywrapClient(polywrapClientConfig);
```

After discussion between @pileks and @nerfZael it was decided that this is likely the best approach.