### PR TITLE
fix: build vm strategy for the arm machine

### DIFF
--- a/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
+++ b/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
@@ -221,7 +221,7 @@ export class DockerVMBuildStrategy extends BuildStrategy<void> {
               `${path.resolve(
                 this._volumePaths.linkedPackages
               )}:/linked-packages`,
-              `${CONFIGS[language].baseImage}:${process.arch}}`,
+              `${CONFIGS[language].baseImage}:${process.arch}`,
               "/bin/bash",
               "-c",
               '"chmod -R 777 /project && chmod -R 777 /linked-packages"',

--- a/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
+++ b/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
@@ -194,7 +194,7 @@ export class DockerVMBuildStrategy extends BuildStrategy<void> {
                 this._volumePaths.linkedPackages
               )}:/linked-packages`,
               cacheVolume,
-              `${CONFIGS[language].baseImage}:latest`,
+              `${CONFIGS[language].baseImage}:${process.arch}`,
               "/bin/bash",
               "--verbose",
               "/project/polywrap-build.sh",
@@ -221,7 +221,7 @@ export class DockerVMBuildStrategy extends BuildStrategy<void> {
               `${path.resolve(
                 this._volumePaths.linkedPackages
               )}:/linked-packages`,
-              `${CONFIGS[language].baseImage}:latest`,
+              `${CONFIGS[language].baseImage}:${process.arch}}`,
               "/bin/bash",
               "-c",
               '"chmod -R 777 /project && chmod -R 777 /linked-packages"',

--- a/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
+++ b/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
@@ -29,16 +29,19 @@ const DEFAULTS_DIR = path.join(
 export interface VMConfig {
   defaultIncludes: string[];
   baseImage: string;
+  version: string;
 }
 
 const CONFIGS: Record<BuildableLanguage, VMConfig> = {
   "wasm/rust": {
     defaultIncludes: ["Cargo.toml", "Cargo.lock"],
     baseImage: "polywrap/vm-base-rs",
+    version: "0.2.0",
   },
   "wasm/assemblyscript": {
     defaultIncludes: ["package.json", "package-lock.json", "yarn.lock"],
     baseImage: "polywrap/vm-base-as",
+    version: "0.1.0",
   },
 };
 
@@ -194,7 +197,7 @@ export class DockerVMBuildStrategy extends BuildStrategy<void> {
                 this._volumePaths.linkedPackages
               )}:/linked-packages`,
               cacheVolume,
-              `${CONFIGS[language].baseImage}:${process.arch}`,
+              `${CONFIGS[language].baseImage}:${process.arch}-${CONFIGS[language].version}`,
               "/bin/bash",
               "--verbose",
               "/project/polywrap-build.sh",
@@ -221,7 +224,7 @@ export class DockerVMBuildStrategy extends BuildStrategy<void> {
               `${path.resolve(
                 this._volumePaths.linkedPackages
               )}:/linked-packages`,
-              `${CONFIGS[language].baseImage}:${process.arch}`,
+              `${CONFIGS[language].baseImage}:${process.arch}-${CONFIGS[language].version}`,
               "/bin/bash",
               "-c",
               '"chmod -R 777 /project && chmod -R 777 /linked-packages"',

--- a/packages/cli/src/lib/defaults/build-strategies/wasm/rust/image/Dockerfile.mustache
+++ b/packages/cli/src/lib/defaults/build-strategies/wasm/rust/image/Dockerfile.mustache
@@ -1,4 +1,4 @@
-FROM rust:1.65.0 as base
+FROM rust:1.66-alpine as base
 
 # Install the wasm32 rust build target
 RUN rustup target add wasm32-unknown-unknown
@@ -6,8 +6,7 @@ RUN rustup target add wasm32-unknown-unknown
 WORKDIR /build-deps
 
 # Install curl
-RUN apt-get update
-RUN apt-get -y install curl clang llvm build-essential
+RUN apk add curl build-base pkgconfig openssl-dev bash
 
 # Install wasm-opt
 RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-linux.tar.gz | tar -xz \

--- a/packages/cli/src/lib/defaults/build-strategies/wasm/rust/vm/Dockerfile
+++ b/packages/cli/src/lib/defaults/build-strategies/wasm/rust/vm/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65.0 as base
+FROM rust:1.66-alpine as base
 
 # Install the wasm32 rust build target
 RUN rustup target add wasm32-unknown-unknown
@@ -6,8 +6,7 @@ RUN rustup target add wasm32-unknown-unknown
 WORKDIR /build-deps
 
 # Install curl
-RUN apt-get update
-RUN apt-get -y install curl clang llvm build-essential
+RUN apk add curl build-base pkgconfig openssl-dev bash
 
 # Install wasm-opt
 RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-linux.tar.gz | tar -xz \


### PR DESCRIPTION
- Closes: #1397

## Changelog
- feat: docker image uses alpine linux as base image
- fix: VM build strategy now uses image with appropriate architecture to build the wrapper