### PR TITLE
fix: handle null return values from uri resolver extensions

### DIFF
--- a/packages/js/core/src/interfaces/uri-resolver.ts
+++ b/packages/js/core/src/interfaces/uri-resolver.ts
@@ -4,8 +4,8 @@ import { Tracer } from "@polywrap/tracing-js";
 import { Result } from "@polywrap/result";
 
 export interface MaybeUriOrManifest {
-  uri?: string;
-  manifest?: Uint8Array;
+  uri?: string | null;
+  manifest?: Uint8Array | null;
 }
 
 export const module = {
@@ -32,8 +32,8 @@ export const module = {
       invoker: Invoker,
       wrapper: Uri,
       path: string
-    ): Promise<Result<Uint8Array | undefined, WrapError>> => {
-      return invoker.invoke<Uint8Array | undefined>({
+    ): Promise<Result<Uint8Array | null, WrapError>> => {
+      return invoker.invoke<Uint8Array | null>({
         uri: wrapper.uri,
         method: "getFile",
         args: {

--- a/packages/js/uri-resolver-extensions/src/UriResolverExtensionFileReader.ts
+++ b/packages/js/uri-resolver-extensions/src/UriResolverExtensionFileReader.ts
@@ -34,7 +34,7 @@ export class UriResolverExtensionFileReader implements IFileReader {
       path
     );
     if (!result.ok) return result;
-    if (result.value === undefined) {
+    if (!result.value) {
       return ResultErr(new Error(`File not found at ${path}`));
     }
     return {


### PR DESCRIPTION
@krisbitney this actually helps debug the issue where the ENS text records were not resolving correctly. I'm working on getting that fixed right now, and came across this, as it was masking the problem occurring a few invocation layers deep.