### PR TITLE
Fix: remove unused imorts from zip.ts in http infra module

### DIFF
--- a/packages/cli/src/lib/defaults/infra-modules/http/server/src/utils/zip.ts
+++ b/packages/cli/src/lib/defaults/infra-modules/http/server/src/utils/zip.ts
@@ -1,7 +1,5 @@
 import JSZip from "jszip";
-import sanitize from "sanitize-filename";
 import fse from "fs-extra";
-import path from "path";
 
 export class Zip {
   private _zip: JSZip;


### PR DESCRIPTION
These unused imports cause TS errors, preventing the infra from building and starting.

Originally fixed by @pileks: https://github.com/polywrap/toolchain/pull/1480/commits/30d57f1f7370eb9aa98953cdd6d2ccce9cc6974d