### PR TITLE
fix: update vm-base-rs global deps

### DIFF
--- a/packages/cli/src/lib/defaults/build-strategies/wasm/rust/image/Dockerfile.mustache
+++ b/packages/cli/src/lib/defaults/build-strategies/wasm/rust/image/Dockerfile.mustache
@@ -6,7 +6,10 @@ RUN rustup target add wasm32-unknown-unknown
 WORKDIR /build-deps
 
 # Install curl
-RUN apk add curl build-base pkgconfig openssl-dev bash
+RUN apk add curl pkgconfig openssl-dev bash
+
+# Install clang
+RUN apk add clang llvm build-base
 
 # Install wasm-opt
 RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-linux.tar.gz | tar -xz \

--- a/packages/cli/src/lib/defaults/build-strategies/wasm/rust/vm/Dockerfile
+++ b/packages/cli/src/lib/defaults/build-strategies/wasm/rust/vm/Dockerfile
@@ -6,7 +6,10 @@ RUN rustup target add wasm32-unknown-unknown
 WORKDIR /build-deps
 
 # Install curl
-RUN apk add curl build-base pkgconfig openssl-dev bash
+RUN apk add curl pkgconfig openssl-dev bash
+
+# Install clang
+RUN apk add clang llvm build-base
 
 # Install wasm-opt
 RUN curl -L https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-linux.tar.gz | tar -xz \


### PR DESCRIPTION
We need to install clang as a global dependency within the rust base image, so that building/linking native c libraries can be done within builds. One example of this is within the substrate wrapper: https://github.com/polywrap/integrations/tree/main/protocol/substrate/rpc-wrapper

These dependencies used to exist, but were removed here: https://github.com/polywrap/toolchain/pull/1485

This lead to an error when building the the substrate wrapper, which this PR fixes.

I've already republished the `polywrap/vm-base-rs:latest` tag, but we still need to:
- [ ] Build/publish this image for all CPU-arch flavors (amd64, arm, etc). We should setup CD to do this build/publishing automatically.
- [ ] Create a patch release of Polywrap `0.9.5`, which implements the same CPU-arch + version selection logic for the build images, which has been added to `0.10.0` in the PR above. This will ensure that changes to the `latest` tag do not modify behavior for `0.9` users.
- [ ] Allow developers to customize the base image when building with the "vm" strategy. This will allow them to resolve problems similar to this themselves without requiring a republish to the official polywrap docker hub repository. I've started this work here, but it needs to be finished: https://github.com/polywrap/toolchain/pull/1370