### PR TITLE
update concurrent plugin interface uri

### DIFF
--- a/packages/js/client-config-builder/README.md
+++ b/packages/js/client-config-builder/README.md
@@ -541,7 +541,7 @@ export const defaultPackages = {
 
 export const defaultInterfaces = {
   uriResolver: "wrap://ens/uri-resolver.core.polywrap.eth",
-  concurrent: "wrap://ens/goerli/interface.concurrent.wrappers.eth",
+  concurrent: "wrap://ens/wrappers.polywrap.eth:concurrent@1.0.0",
   logger: "wrap://ens/wrappers.polywrap.eth:logger@1.0.0",
 };
 

--- a/packages/js/client-config-builder/package.json
+++ b/packages/js/client-config-builder/package.json
@@ -34,7 +34,7 @@
     "@polywrap/logger-plugin-js": "0.10.0",
     "@polywrap/uri-resolver-extensions-js": "0.10.0-pre.7",
     "@polywrap/uri-resolvers-js": "0.10.0-pre.7",
-    "concurrent-plugin-js": "0.1.1",
+    "concurrent-plugin-js": "0.1.2",
     "doc-snippets": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/js/client-config-builder/src/bundles/getDefaultConfig.ts
+++ b/packages/js/client-config-builder/src/bundles/getDefaultConfig.ts
@@ -46,7 +46,7 @@ export const defaultPackages = {
 
 export const defaultInterfaces = {
   uriResolver: "wrap://ens/uri-resolver.core.polywrap.eth",
-  concurrent: "wrap://ens/goerli/interface.concurrent.wrappers.eth",
+  concurrent: "wrap://ens/wrappers.polywrap.eth:concurrent@1.0.0",
   logger: "wrap://ens/wrappers.polywrap.eth:logger@1.0.0",
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6253,6 +6253,14 @@ concurrent-plugin-js@0.1.1:
     "@polywrap/core-js" "0.10.0-pre.5"
     "@polywrap/msgpack-js" "0.10.0-pre.5"
 
+concurrent-plugin-js@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/concurrent-plugin-js/-/concurrent-plugin-js-0.1.2.tgz#206b9f12723fb99d79a4c03c0f28b427deca6ff4"
+  integrity sha512-MWpw9uuQtQ/IerG2CtGjFm+UTmDy0D+D7HZh4hW5PYTk4SbcYBVJtK6n7Yk3tg8NE3rcXLnRxLBoW7UbO2o5hw==
+  dependencies:
+    "@polywrap/core-js" "0.10.0-pre.7"
+    "@polywrap/msgpack-js" "0.10.0-pre.7"
+
 config-chain@^1.1.12:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"


### PR DESCRIPTION
This PR updates the concurrent plugin to use an ENS text record URI