### PR TITLE
Fix: export WrapperResolver from uri-resolvers-js

### DIFF
--- a/packages/js/uri-resolvers/src/index.ts
+++ b/packages/js/uri-resolvers/src/index.ts
@@ -2,5 +2,6 @@ export * from "./aggregator";
 export * from "./cache";
 export * from "./redirects";
 export * from "./packages";
+export * from "./wrappers";
 export * from "./helpers";
 export * from "./static";


### PR DESCRIPTION
`WrapperResolver` is not currently exported from `@polywrap/uri-resolvers-js`. This PR adds it to the export list.

Closes https://github.com/polywrap/toolchain/issues/1492