### PR TITLE
cli/create: remove node & react from supported langs in app template

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -176,8 +176,8 @@ polywrap create wasm assemblyscript my-wrapper
 # Create an interface project using assemblyscript called "my-project"
 polywrap create wasm interface my-interface
 
-# Create a React app project using Typescript called "my-react-app"
-polywrap create app typescript-react my-react-app
+# Create a project using Typescript called "my-react-app"
+polywrap create app typescript my-app
 
 # Create a Plugin wrapper project using Typescript called "my-plugin"
 polywrap create plugin typescript my-plugin

--- a/packages/cli/src/__tests__/e2e/create.spec.ts
+++ b/packages/cli/src/__tests__/e2e/create.spec.ts
@@ -15,7 +15,7 @@ Commands:
   wasm [options] <language> <name>    Create a Polywrap wasm wrapper langs:
                                       assemblyscript, rust, interface
   app [options] <language> <name>     Create a Polywrap application langs:
-                                      typescript-node, typescript-react
+                                      typescript
   plugin [options] <language> <name>  Create a Polywrap plugin langs:
                                       typescript
   help [command]                      display help for command

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -18,7 +18,7 @@ const pathStr = intlMsg.commands_create_options_o_path();
 
 export const supportedLangs = {
   wasm: ["assemblyscript", "rust", "interface"] as const,
-  app: ["typescript-node", "typescript-react"] as const,
+  app: ["typescript"] as const,
   plugin: ["typescript"] as const,
 };
 
@@ -174,24 +174,23 @@ async function run(
     }
   }
 
-  await generateProjectTemplate(command, language, projectDir)
-    .then(() => {
-      let readyMessage;
-      if (command === "wasm") {
-        readyMessage = intlMsg.commands_create_readyProtocol();
-      } else if (command === "app") {
-        readyMessage = intlMsg.commands_create_readyApp();
-      } else if (command === "plugin") {
-        readyMessage = intlMsg.commands_create_readyPlugin();
-      }
-      logger.info(`🔥 ${readyMessage} 🔥`);
-      process.exit(0);
-    })
-    .catch((err) => {
-      const commandFailError = intlMsg.commands_create_error_commandFail({
-        error: JSON.stringify(err, null, 2),
-      });
-      logger.error(commandFailError);
-      process.exit(1);
+  try {
+    await generateProjectTemplate(command, language, projectDir);
+    let readyMessage;
+    if (command === "wasm") {
+      readyMessage = intlMsg.commands_create_readyProtocol();
+    } else if (command === "app") {
+      readyMessage = intlMsg.commands_create_readyApp();
+    } else if (command === "plugin") {
+      readyMessage = intlMsg.commands_create_readyPlugin();
+    }
+    logger.info(`🔥 ${readyMessage} 🔥`);
+    process.exit(0);
+  } catch (err) {
+    const commandFailError = intlMsg.commands_create_error_commandFail({
+      error: JSON.stringify(err, null, 2),
     });
+    logger.error(commandFailError);
+    process.exit(1);
+  }
 }

--- a/packages/js/cli/src/__tests__/commands.spec.ts
+++ b/packages/js/cli/src/__tests__/commands.spec.ts
@@ -97,7 +97,7 @@ const testData: CommandTestCaseData<CommandTypings> = {
   create: {
     app: [{
       cwd: fs.mkdtempSync(path.join(os.tmpdir(), "cli-js-create-test")),
-      arguments: ["typescript-node", "test-app"],
+      arguments: ["typescript", "test-app"],
       after: (test) => {
         if (!test.cwd)
           throw Error("This shouldn't happen");

--- a/packages/templates/app/typescript/package.json
+++ b/packages/templates/app/typescript/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "templates-app-typescript-node",
-  "description": "Polywrap App TypeScript Node Template",
+  "name": "templates-app-typescript",
+  "description": "Polywrap App TypeScript Template",
   "private": true,
   "version": "0.10.0-pre.7",
   "scripts": {


### PR DESCRIPTION
in a previous PR the `typescript-node` and `typescript-react` templates have been removed from `app` (https://github.com/polywrap/toolchain/pull/1500); this aims to update the create command with these changes.

the ci did not catch this because we're directly downloading the latest version from npm (0.9.4) when running the create command. this makes me think that decoupling templates from toolchain might be a necessary thing to do sooner than later (so these things don't go to production without us noticing)