### PR TITLE
fix: use multi-platform build images

### DIFF
--- a/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
+++ b/packages/cli/src/lib/build-strategies/strategies/DockerVMStrategy.ts
@@ -197,7 +197,7 @@ export class DockerVMBuildStrategy extends BuildStrategy<void> {
                 this._volumePaths.linkedPackages
               )}:/linked-packages`,
               cacheVolume,
-              `${CONFIGS[language].baseImage}:${process.arch}-${CONFIGS[language].version}`,
+              `${CONFIGS[language].baseImage}:${CONFIGS[language].version}`,
               "/bin/bash",
               "--verbose",
               "/project/polywrap-build.sh",
@@ -224,7 +224,7 @@ export class DockerVMBuildStrategy extends BuildStrategy<void> {
               `${path.resolve(
                 this._volumePaths.linkedPackages
               )}:/linked-packages`,
-              `${CONFIGS[language].baseImage}:${process.arch}-${CONFIGS[language].version}`,
+              `${CONFIGS[language].baseImage}:${CONFIGS[language].version}`,
               "/bin/bash",
               "-c",
               '"chmod -R 777 /project && chmod -R 777 /linked-packages"',


### PR DESCRIPTION
Remove arch-specific image selection, just use the tag @ `version` which is now built to be multi-platform. See here:
https://github.com/polywrap/toolchain/blob/c329f046d56c9484f6575d121233e7f905e09e0f/.github/workflows/cd-containers.yaml#L63

https://hub.docker.com/r/polywrap/vm-base-rs/tags
https://hub.docker.com/r/polywrap/vm-base-as/tags