### PR TITLE
Fix: WrapError now correctly parsing Rust unwrap errors

### DIFF
--- a/packages/js/client/src/__tests__/core/error-structure.spec.ts
+++ b/packages/js/client/src/__tests__/core/error-structure.spec.ts
@@ -218,14 +218,14 @@ describe("Error structure", () => {
     });
   });
 
-  describe.only("Wasm wrapper - RS", () => {
+  describe("Wasm wrapper - RS", () => {
     let client: PolywrapClient;
 
     beforeAll(async () => {
-      await buildWrapper(invalidTypesWrapperRSPath);
-      await buildWrapper(badUtilWrapperRSPath);
-      await buildWrapper(badMathWrapperRSPath);
-      await buildWrapper(subinvokeErrorWrapperRSPath);
+      // await buildWrapper(invalidTypesWrapperRSPath);
+      // await buildWrapper(badUtilWrapperRSPath);
+      // await buildWrapper(badMathWrapperRSPath);
+      // await buildWrapper(subinvokeErrorWrapperRSPath);
 
       client = new PolywrapClient({
         redirects: [
@@ -241,7 +241,7 @@ describe("Error structure", () => {
       })
     });
 
-    test.only("Subinvoke a wrapper that is not found", async () => {
+    test("Subinvoke a wrapper that is not found", async () => {
       const result = await client.invoke<number>({
         uri: subinvokeErrorWrapperRSUri.uri,
         method: "subWrapperNotFound",
@@ -254,15 +254,13 @@ describe("Error structure", () => {
       expect(result.ok).toBeFalsy();
       if (result.ok) throw Error("should never happen");
 
-      console.log(JSON.stringify(result.error, null, 2));
-
       expect(result.error?.name).toEqual("WrapError");
       expect(result.error?.code).toEqual(WrapErrorCode.WRAPPER_INVOKE_ABORTED);
       expect(result.error?.reason.startsWith("SubInvocation exception encountered")).toBeTruthy();
-      expect(result.error?.uri.endsWith("packages/test-cases/cases/wrappers/wasm-as/subinvoke-error/invoke/build")).toBeTruthy();
+      expect(result.error?.uri.endsWith("packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/build")).toBeTruthy();
       expect(result.error?.method).toEqual("subWrapperNotFound");
       expect(result.error?.args).toEqual("{\n  \"a\": 1,\n  \"b\": 1\n}");
-      expect(result.error?.source).toEqual({ file: "~lib/@polywrap/wasm-as/containers/Result.ts", row: 171, col: 13 });
+      expect(result.error?.source).toEqual({ file: "src/lib.rs", row: 17, col: 57 });
 
       expect(result.error?.innerError instanceof WrapError).toBeTruthy();
       const prev = result.error?.innerError as WrapError;
@@ -334,10 +332,10 @@ describe("Error structure", () => {
       expect(result.error?.name).toEqual("WrapError");
       expect(result.error?.code).toEqual(WrapErrorCode.WRAPPER_INVOKE_ABORTED);
       expect(result.error?.reason.startsWith("SubInvocation exception encountered")).toBeTruthy();
-      expect(result.error?.uri.endsWith("packages/test-cases/cases/wrappers/wasm-as/subinvoke-error/invoke/build")).toBeTruthy();
+      expect(result.error?.uri.endsWith("packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/build")).toBeTruthy();
       expect(result.error?.method).toEqual("throwsInTwoSubinvokeLayers");
       expect(result.error?.args).toEqual("{\n  \"a\": 1,\n  \"b\": 1\n}");
-      expect(result.error?.source).toEqual({ file: "~lib/@polywrap/wasm-as/containers/Result.ts", row: 171, col: 13 });
+      expect(result.error?.source).toEqual({ file: "src/lib.rs", row: 9, col: 56 });
 
       expect(result.error?.innerError instanceof WrapError).toBeTruthy();
       const prev = result.error?.innerError as WrapError;
@@ -347,7 +345,7 @@ describe("Error structure", () => {
       expect(prev.uri).toEqual("wrap://ens/bad-math.eth");
       expect(prev.method).toEqual("subInvokeWillThrow");
       expect(prev.args).toEqual("{\n  \"0\": 130,\n  \"1\": 161,\n  \"2\": 97,\n  \"3\": 1,\n  \"4\": 161,\n  \"5\": 98,\n  \"6\": 1\n}");
-      expect(prev.source).toEqual({ file: "~lib/@polywrap/wasm-as/containers/Result.ts", row: 171, col: 13 });
+      expect(prev.source).toEqual({ file: "src/lib.rs", row: 5, col: 75 });
 
       expect(prev.innerError instanceof WrapError).toBeTruthy();
       const prevOfPrev = prev.innerError as WrapError;
@@ -357,7 +355,7 @@ describe("Error structure", () => {
       expect(prevOfPrev.uri.endsWith("wrap://ens/bad-util.eth")).toBeTruthy();
       expect(prevOfPrev.method).toEqual("iThrow");
       expect(prevOfPrev.args).toEqual("{\n  \"0\": 129,\n  \"1\": 161,\n  \"2\": 97,\n  \"3\": 0\n}");
-      expect(prevOfPrev.source).toEqual({ file: "src/index.ts", row: 5, col: 5 });
+      expect(prevOfPrev.source).toEqual({ file: "src/lib.rs", row: 6, col: 5 });
     });
   });
 

--- a/packages/js/client/src/__tests__/core/error-structure.spec.ts
+++ b/packages/js/client/src/__tests__/core/error-structure.spec.ts
@@ -222,10 +222,10 @@ describe("Error structure", () => {
     let client: PolywrapClient;
 
     beforeAll(async () => {
-      // await buildWrapper(invalidTypesWrapperRSPath);
-      // await buildWrapper(badUtilWrapperRSPath);
-      // await buildWrapper(badMathWrapperRSPath);
-      // await buildWrapper(subinvokeErrorWrapperRSPath);
+      await buildWrapper(invalidTypesWrapperRSPath);
+      await buildWrapper(badUtilWrapperRSPath);
+      await buildWrapper(badMathWrapperRSPath);
+      await buildWrapper(subinvokeErrorWrapperRSPath);
 
       client = new PolywrapClient({
         redirects: [

--- a/packages/js/client/src/__tests__/core/error-structure.spec.ts
+++ b/packages/js/client/src/__tests__/core/error-structure.spec.ts
@@ -24,36 +24,44 @@ const incompatibleWrapperPath = `${GetPathToTestWrappers()}/wasm-as/simple-depre
 const incompatibleWrapperUri = new Uri(`fs/${incompatibleWrapperPath}`);
 
 // RS
-const invalidTypesWrapperPath = `${GetPathToTestWrappers()}/wasm-rs/invalid-types`;
-const invalidTypesWrapperUri = new Uri(`fs/${invalidTypesWrapperPath}/build`);
+const invalidTypesWrapperRSPath = `${GetPathToTestWrappers()}/wasm-rs/invalid-types`;
+const invalidTypesWrapperRSUri = new Uri(`fs/${invalidTypesWrapperRSPath}/build`);
+
+const subinvokeErrorWrapperRSPath = `${GetPathToTestWrappers()}/wasm-rs/subinvoke-error/invoke`;
+const subinvokeErrorWrapperRSUri = new Uri(`fs/${subinvokeErrorWrapperRSPath}/build`);
+
+const badMathWrapperRSPath = `${GetPathToTestWrappers()}/wasm-rs/subinvoke-error/0-subinvoke`;
+const badMathWrapperRSUri = new Uri(`fs/${badMathWrapperRSPath}/build`);
+
+const badUtilWrapperRSPath = `${GetPathToTestWrappers()}/wasm-rs/subinvoke-error/1-subinvoke`;
+const badUtilWrapperRSUri = new Uri(`fs/${badUtilWrapperRSPath}/build`);
+
 
 describe("Error structure", () => {
 
-  let client: PolywrapClient;
+  describe("Wasm wrapper - AS", () => {
+    let client: PolywrapClient;
 
-  beforeAll(async () => {
-    await buildWrapper(simpleWrapperPath);
-    await buildWrapper(badUtilWrapperPath);
-    await buildWrapper(badMathWrapperPath);
-    await buildWrapper(subinvokeErrorWrapperPath);
-    await buildWrapper(invalidTypesWrapperPath);
+    beforeAll(async () => {
+      await buildWrapper(simpleWrapperPath);
+      await buildWrapper(badUtilWrapperPath);
+      await buildWrapper(badMathWrapperPath);
+      await buildWrapper(subinvokeErrorWrapperPath);
 
-    client = new PolywrapClient({
-      packages: [mockPluginRegistration("plugin/mock")],
-      redirects: [
-        {
-          from: Uri.from("ens/bad-math.eth"),
-          to: badMathWrapperUri,
-        },
-        {
-          from: Uri.from("ens/bad-util.eth"),
-          to: badUtilWrapperUri,
-        }
-      ]
-    })
-  });
+      client = new PolywrapClient({
+        redirects: [
+          {
+            from: Uri.from("ens/bad-math.eth"),
+            to: badMathWrapperUri,
+          },
+          {
+            from: Uri.from("ens/bad-util.eth"),
+            to: badUtilWrapperUri,
+          }
+        ]
+      })
+    });
 
-  describe("URI resolution", () => {
     test("Invoke a wrapper that is not found", async () => {
       const result = await client.invoke<string>({
         uri: simpleWrapperUri.uri + "-not-found",
@@ -102,10 +110,8 @@ describe("Error structure", () => {
       expect(prev.uri).toEqual("wrap://ens/not-found.eth");
       expect(prev.resolutionStack).toBeTruthy();
     });
-  });
 
-  describe("Wasm wrapper", () => {
-    test("Invoke a wrapper with malformed arguments - as", async () => {
+    test("Invoke a wrapper with malformed arguments", async () => {
       const result = await client.invoke<string>({
         uri: simpleWrapperUri.uri,
         method: "simpleMethod",
@@ -124,27 +130,6 @@ describe("Error structure", () => {
       expect(result.error?.method).toEqual("simpleMethod");
       expect(result.error?.args).toEqual("{\n  \"arg\": 3\n}");
       expect(result.error?.source).toEqual({ file: "~lib/@polywrap/wasm-as/msgpack/ReadDecoder.ts", row: 167, col: 5 });
-    });
-
-    test("Invoke a wrapper with malformed arguments - rs", async () => {
-      const result = await client.invoke<string>({
-        uri: invalidTypesWrapperUri.uri,
-        method: "boolMethod",
-        args: {
-          arg: 3,
-        },
-      });
-
-      expect(result.ok).toBeFalsy();
-      if (result.ok) throw Error("should never happen");
-
-      expect(result.error?.name).toEqual("WrapError");
-      expect(result.error?.code).toEqual(WrapErrorCode.WRAPPER_INVOKE_ABORTED);
-      expect(result.error?.reason.startsWith("__wrap_abort:")).toBeTruthy();
-      expect(result.error?.uri.endsWith("packages/test-cases/cases/wrappers/wasm-rs/invalid-types/build")).toBeTruthy();
-      expect(result.error?.method).toEqual("boolMethod");
-      expect(result.error?.args).toEqual("{\n  \"arg\": 3\n}");
-      expect(result.error?.source).toEqual({ file: "src/wrap/module/wrapped.rs", row: 38, col: 13 });
     });
 
     test("Invoke a wrapper method that doesn't exist", async () => {
@@ -233,7 +218,158 @@ describe("Error structure", () => {
     });
   });
 
+  describe.only("Wasm wrapper - RS", () => {
+    let client: PolywrapClient;
+
+    beforeAll(async () => {
+      await buildWrapper(invalidTypesWrapperRSPath);
+      await buildWrapper(badUtilWrapperRSPath);
+      await buildWrapper(badMathWrapperRSPath);
+      await buildWrapper(subinvokeErrorWrapperRSPath);
+
+      client = new PolywrapClient({
+        redirects: [
+          {
+            from: Uri.from("ens/bad-math.eth"),
+            to: badMathWrapperRSUri,
+          },
+          {
+            from: Uri.from("ens/bad-util.eth"),
+            to: badUtilWrapperRSUri,
+          }
+        ]
+      })
+    });
+
+    test.only("Subinvoke a wrapper that is not found", async () => {
+      const result = await client.invoke<number>({
+        uri: subinvokeErrorWrapperRSUri.uri,
+        method: "subWrapperNotFound",
+        args: {
+          a: 1,
+          b: 1,
+        },
+      });
+
+      expect(result.ok).toBeFalsy();
+      if (result.ok) throw Error("should never happen");
+
+      console.log(JSON.stringify(result.error, null, 2));
+
+      expect(result.error?.name).toEqual("WrapError");
+      expect(result.error?.code).toEqual(WrapErrorCode.WRAPPER_INVOKE_ABORTED);
+      expect(result.error?.reason.startsWith("SubInvocation exception encountered")).toBeTruthy();
+      expect(result.error?.uri.endsWith("packages/test-cases/cases/wrappers/wasm-as/subinvoke-error/invoke/build")).toBeTruthy();
+      expect(result.error?.method).toEqual("subWrapperNotFound");
+      expect(result.error?.args).toEqual("{\n  \"a\": 1,\n  \"b\": 1\n}");
+      expect(result.error?.source).toEqual({ file: "~lib/@polywrap/wasm-as/containers/Result.ts", row: 171, col: 13 });
+
+      expect(result.error?.innerError instanceof WrapError).toBeTruthy();
+      const prev = result.error?.innerError as WrapError;
+      expect(prev.name).toEqual("WrapError");
+      expect(prev.code).toEqual(WrapErrorCode.URI_NOT_FOUND);
+      expect(prev.reason).toEqual("Unable to find URI wrap://ens/not-found.eth.");
+      expect(prev.uri).toEqual("wrap://ens/not-found.eth");
+      expect(prev.resolutionStack).toBeTruthy();
+    });
+
+    test("Invoke a wrapper with malformed arguments", async () => {
+      const result = await client.invoke<string>({
+        uri: invalidTypesWrapperRSUri.uri,
+        method: "boolMethod",
+        args: {
+          arg: 3,
+        },
+      });
+
+      expect(result.ok).toBeFalsy();
+      if (result.ok) throw Error("should never happen");
+
+      expect(result.error?.name).toEqual("WrapError");
+      expect(result.error?.code).toEqual(WrapErrorCode.WRAPPER_INVOKE_ABORTED);
+      expect(result.error?.reason.startsWith("__wrap_abort:")).toBeTruthy();
+      expect(result.error?.uri.endsWith("packages/test-cases/cases/wrappers/wasm-rs/invalid-types/build")).toBeTruthy();
+      expect(result.error?.method).toEqual("boolMethod");
+      expect(result.error?.args).toEqual("{\n  \"arg\": 3\n}");
+      expect(result.error?.source).toEqual({ file: "src/wrap/module/wrapped.rs", row: 38, col: 13 });
+    });
+
+    test("Invoke a wrapper method that doesn't exist", async () => {
+      const result = await client.invoke<string>({
+        uri: invalidTypesWrapperRSUri.uri,
+        method: "complexMethod",
+        args: {
+          arg: "test",
+        },
+      });
+
+      expect(result.ok).toBeFalsy();
+      if (result.ok) throw Error("should never happen");
+
+      expect(result.error?.name).toEqual("WrapError");
+      expect(result.error?.code).toEqual(WrapErrorCode.WRAPPER_INVOKE_FAIL);
+      expect(result.error?.reason.startsWith("Could not find invoke function")).toBeTruthy();
+      expect(result.error?.uri.endsWith("packages/test-cases/cases/wrappers/wasm-rs/invalid-types/build")).toBeTruthy();
+      expect(result.error?.method).toEqual("complexMethod");
+      expect(result.error?.args).toEqual("{\n  \"arg\": \"test\"\n}");
+      expect(result.error?.toString().split(
+        WrapErrorCode.WRAPPER_INVOKE_FAIL.valueOf().toString()
+      ).length).toEqual(2);
+      expect(result.error?.innerError).toBeUndefined();
+    });
+
+    test("Subinvoke error two layers deep", async () => {
+      const result = await client.invoke<number>({
+        uri: subinvokeErrorWrapperRSUri.uri,
+        method: "throwsInTwoSubinvokeLayers",
+        args: {
+          a: 1,
+          b: 1,
+        },
+      });
+
+      expect(result.ok).toBeFalsy();
+      if (result.ok) throw Error("should never happen");
+
+      expect(result.error?.name).toEqual("WrapError");
+      expect(result.error?.code).toEqual(WrapErrorCode.WRAPPER_INVOKE_ABORTED);
+      expect(result.error?.reason.startsWith("SubInvocation exception encountered")).toBeTruthy();
+      expect(result.error?.uri.endsWith("packages/test-cases/cases/wrappers/wasm-as/subinvoke-error/invoke/build")).toBeTruthy();
+      expect(result.error?.method).toEqual("throwsInTwoSubinvokeLayers");
+      expect(result.error?.args).toEqual("{\n  \"a\": 1,\n  \"b\": 1\n}");
+      expect(result.error?.source).toEqual({ file: "~lib/@polywrap/wasm-as/containers/Result.ts", row: 171, col: 13 });
+
+      expect(result.error?.innerError instanceof WrapError).toBeTruthy();
+      const prev = result.error?.innerError as WrapError;
+      expect(prev.name).toEqual("WrapError");
+      expect(prev.code).toEqual(WrapErrorCode.WRAPPER_INVOKE_ABORTED);
+      expect(prev.reason.startsWith("SubInvocation exception encountered")).toBeTruthy();
+      expect(prev.uri).toEqual("wrap://ens/bad-math.eth");
+      expect(prev.method).toEqual("subInvokeWillThrow");
+      expect(prev.args).toEqual("{\n  \"0\": 130,\n  \"1\": 161,\n  \"2\": 97,\n  \"3\": 1,\n  \"4\": 161,\n  \"5\": 98,\n  \"6\": 1\n}");
+      expect(prev.source).toEqual({ file: "~lib/@polywrap/wasm-as/containers/Result.ts", row: 171, col: 13 });
+
+      expect(prev.innerError instanceof WrapError).toBeTruthy();
+      const prevOfPrev = prev.innerError as WrapError;
+      expect(prevOfPrev.name).toEqual("WrapError");
+      expect(prevOfPrev.code).toEqual(WrapErrorCode.WRAPPER_INVOKE_ABORTED);
+      expect(prevOfPrev.reason).toEqual("__wrap_abort: I threw an error!");
+      expect(prevOfPrev.uri.endsWith("wrap://ens/bad-util.eth")).toBeTruthy();
+      expect(prevOfPrev.method).toEqual("iThrow");
+      expect(prevOfPrev.args).toEqual("{\n  \"0\": 129,\n  \"1\": 161,\n  \"2\": 97,\n  \"3\": 0\n}");
+      expect(prevOfPrev.source).toEqual({ file: "src/index.ts", row: 5, col: 5 });
+    });
+  });
+
   describe("Plugin wrapper", () => {
+    let client: PolywrapClient;
+
+    beforeAll(async () => {
+      client = new PolywrapClient({
+        packages: [mockPluginRegistration("plugin/mock")],
+      })
+    });
+
     test("Invoke a plugin wrapper with malformed args", async () => {
       const result = await client.invoke<Uint8Array>({
         uri: defaultInterfaces.fileSystem,

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/Cargo.toml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test-case-simple-subinvoke"
+version = "0.1.0"
+description = "test-case-simple-subinvoke wrapper"
+authors = [
+  "Kobby Pentangeli <kobbypentangeli@gmail.com>",
+  "Jordan Ellis <jelli@dorg.tech>"
+]
+repository = "https://github.com/polywrap/monorepo"
+license = "MIT"
+edition = "2021"
+
+[dependencies]
+polywrap-wasm-rs = { path = "../../../../../../wasm/rs" }
+serde = { version = "1.0", features = ["derive"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 's'
+lto = true
+panic = 'abort'

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/polywrap.build.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/polywrap.build.yaml
@@ -1,0 +1,7 @@
+format: 0.2.0
+strategies:
+  image:
+    name: test-case-simple-subinvoke-0
+linked_packages:
+  - name: polywrap-wasm-rs
+    path: ../../../../../../wasm/rs

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/polywrap.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/polywrap.yaml
@@ -1,0 +1,12 @@
+format: 0.2.0
+project:
+  name: test-case-simple-subinvoke
+  type: wasm/rust
+source:
+  schema: ./schema.graphql
+  module: ./Cargo.toml
+  import_abis:
+    - uri: ens/bad-util.eth
+      abi: ../1-subinvoke/build/wrap.info
+extensions:
+  build: ./polywrap.build.yaml

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/schema.graphql
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/schema.graphql
@@ -1,0 +1,5 @@
+#import * into BadUtil from "ens/bad-util.eth"
+
+type Module {
+  subInvokeWillThrow(a: Int!, b: Int!): Int!
+}

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/src/lib.rs
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod wrap;
+pub use wrap::{*, imported::bad_util_module::ArgsIThrow };
+
+pub fn sub_invoke_will_throw(args: ArgsSubInvokeWillThrow) -> i32 {
+    let sub_invoke_result = BadUtilModule::i_throw( &ArgsIThrow { a: 0 }).unwrap();
+    args.a + args.b + sub_invoke_result
+}

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/Cargo.toml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test-case-simple-subinvoke"
+version = "0.1.0"
+description = "test-case-simple-subinvoke wrapper"
+authors = [
+  "Kobby Pentangeli <kobbypentangeli@gmail.com>",
+  "Jordan Ellis <jelli@dorg.tech>"
+]
+repository = "https://github.com/polywrap/monorepo"
+license = "MIT"
+edition = "2021"
+
+[dependencies]
+polywrap-wasm-rs = { path = "../../../../../../wasm/rs" }
+serde = { version = "1.0", features = ["derive"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 's'
+lto = true
+panic = 'abort'

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/polywrap.build.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/polywrap.build.yaml
@@ -1,0 +1,7 @@
+format: 0.2.0
+strategies:
+  image:
+    name: test-case-simple-subinvoke-1
+linked_packages:
+  - name: polywrap-wasm-rs
+    path: ../../../../../../wasm/rs

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/polywrap.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/polywrap.yaml
@@ -1,0 +1,9 @@
+format: 0.2.0
+project:
+  name: test-case-simple-subinvoke
+  type: wasm/rust
+source:
+  schema: ./schema.graphql
+  module: ./Cargo.toml
+extensions:
+  build: ./polywrap.build.yaml

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/schema.graphql
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/schema.graphql
@@ -1,0 +1,3 @@
+type Module {
+  iThrow(a: Int!): Int!
+}

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/src/lib.rs
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod wrap;
+pub use wrap::*;
+
+pub fn i_throw(args: ArgsIThrow) -> i32 {
+  if 2 == 2 {
+    panic!("I threw an error!");
+  }
+  args.a + 1
+}

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/Cargo.toml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test-case-simple-invoke"
+version = "0.1.0"
+description = "test-case-simple-invoke wrapper"
+authors = [
+  "Kobby Pentangeli <kobbypentangeli@gmail.com>",
+  "Jordan Ellis <jelli@dorg.tech>"
+]
+repository = "https://github.com/polywrap/monorepo"
+license = "MIT"
+edition = "2021"
+
+[dependencies]
+polywrap-wasm-rs = { path = "../../../../../../wasm/rs" }
+serde = { version = "1.0", features = ["derive"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 's'
+lto = true
+panic = 'abort'

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/polywrap.build.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/polywrap.build.yaml
@@ -1,0 +1,7 @@
+format: 0.2.0
+strategies:
+  image:
+    name: test-case-simple-invoke
+linked_packages:
+  - name: polywrap-wasm-rs
+    path: ../../../../../../wasm/rs

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/polywrap.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/polywrap.yaml
@@ -1,0 +1,14 @@
+format: 0.2.0
+project:
+  name: test-case-simple-invoke
+  type: wasm/rust
+source:
+  schema: ./schema.graphql
+  module: ./Cargo.toml
+  import_abis:
+    - uri: ens/bad-math.eth
+      abi: ../0-subinvoke/build/wrap.info
+    - uri: ens/not-found.eth
+      abi: ../0-subinvoke/build/wrap.info
+extensions:
+  build: ./polywrap.build.yaml

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/schema.graphql
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/schema.graphql
@@ -1,0 +1,7 @@
+#import * into BadMath from "ens/bad-math.eth"
+#import * into NotFound from "ens/not-found.eth"
+
+type Module {
+  throwsInTwoSubinvokeLayers(a: Int!, b: Int!): Int!
+  subWrapperNotFound(a: Int!, b: Int!): Int!
+}

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/src/lib.rs
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/src/lib.rs
@@ -1,0 +1,18 @@
+pub mod wrap;
+pub use wrap::{*, imported::bad_math_module, imported::not_found_module};
+
+pub fn throws_in_two_subinvoke_layers(args: ArgsThrowsInTwoSubinvokeLayers) -> i32 {
+  let imported_args = bad_math_module::ArgsSubInvokeWillThrow {
+    a: args.a,
+    b: args.b
+  };
+  BadMathModule::sub_invoke_will_throw(&imported_args).unwrap()
+}
+
+pub fn sub_wrapper_not_found(args: ArgsSubWrapperNotFound) -> i32 {
+  let imported_args = not_found_module::ArgsSubInvokeWillThrow {
+    a: args.a,
+    b: args.b
+  };
+  NotFoundModule::sub_invoke_will_throw(&imported_args).unwrap()
+}


### PR DESCRIPTION
When calling `.unwrap()` on a Rust result that contains an error, Rust will panic with an error message that contains the `Err`. For fidelity to the original `Err`, Rust inserts escape characters in the string. For example, `"\n"` becomes `"\\n"`. This behavior was not being handled correctly by `WrapError`'s string parsing logic.