### PR TITLE
0.9 Fix: WrapError now correctly parsing Rust unwrap errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Polywrap Origin (0.9.6)
+## Bugs
+* [PR-1558](https://github.com/polywrap/toolchain/pull/1558) `@polywrap/core-js` WrapError now correctly parsing Rust unwrap errors.
+
 # Polywrap Origin (0.9.5)
 ## Bugs
 * [PR-1541](https://github.com/polywrap/toolchain/pull/1541) `polywrap` CLI: Update build images to use the latest multi-platform versions.

--- a/packages/js/core/src/types/WrapError.ts
+++ b/packages/js/core/src/types/WrapError.ts
@@ -87,7 +87,7 @@ export class WrapError extends Error {
 
   private static re = new RegExp(
     [
-      /^(?:[A-Za-z_: ]*; )?WrapError: (?<reason>(?:.|\r|\n)*)/.source,
+      /^(?:[A-Za-z_:()` ]*;? "?)?WrapError: (?<reason>(?:.|\r|\n)*)/.source,
       // there is some padding added to the number of words expected in an error code
       /(?:\r\n|\r|\n)code: (?<code>1?[0-9]{1,2}|2[0-4][0-9]|25[0-5]) (?:[A-Z]+ ?){1,5}/
         .source,
@@ -99,12 +99,14 @@ export class WrapError extends Error {
         .source,
       /(?:(?:\r\n|\r|\n)uriResolutionStack: (?<resolutionStack>\[(?:.|\r|\n)+]))?/
         .source,
-      /(?:(?:\r\n|\r|\n){2}This exception was caused by the following exception:(?:\r\n|\r|\n)(?<cause>(?:.|\r|\n)+))?$/
+      /(?:(?:\r\n|\r|\n){2}This exception was caused by the following exception:(?:\r\n|\r|\n)(?<cause>(?:.|\r|\n)+))?/
         .source,
+      /"?$/.source,
     ].join("")
   );
 
   static parse(error: string): WrapError | undefined {
+    error = WrapError.sanitizeUnwrappedRustResult(error);
     const delim = "\n\nAnother exception was encountered during execution:\n";
     const errorStrings = error.split(delim);
 
@@ -135,6 +137,19 @@ export class WrapError extends Error {
 
   toString(): string {
     return `${this.name}: ${this.message}`;
+  }
+
+  // remove escape characters that may have been added by Rust
+  private static sanitizeUnwrappedRustResult(error: string): string {
+    if (
+      error.startsWith(
+        '__wrap_abort: called `Result::unwrap()` on an `Err` value: "'
+      )
+    ) {
+      error = error.replace(/\\"/g, '"');
+      error = error.replace(/\\n/g, "\n");
+    }
+    return error;
   }
 
   // parse a single WrapError, where the 'prev' property is undefined

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/Cargo.toml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test-case-simple-subinvoke"
+version = "0.1.0"
+description = "test-case-simple-subinvoke wrapper"
+authors = [
+  "Kobby Pentangeli <kobbypentangeli@gmail.com>",
+  "Jordan Ellis <jelli@dorg.tech>"
+]
+repository = "https://github.com/polywrap/monorepo"
+license = "MIT"
+edition = "2021"
+
+[dependencies]
+polywrap-wasm-rs = { path = "../../../../../../wasm/rs" }
+serde = { version = "1.0", features = ["derive"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 's'
+lto = true
+panic = 'abort'

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/polywrap.build.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/polywrap.build.yaml
@@ -1,0 +1,7 @@
+format: 0.2.0
+strategies:
+  image:
+    name: test-case-simple-subinvoke-0
+linked_packages:
+  - name: polywrap-wasm-rs
+    path: ../../../../../../wasm/rs

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/polywrap.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/polywrap.yaml
@@ -1,0 +1,12 @@
+format: 0.2.0
+project:
+  name: test-case-simple-subinvoke
+  type: wasm/rust
+source:
+  schema: ./schema.graphql
+  module: ./Cargo.toml
+  import_abis:
+    - uri: ens/bad-util.eth
+      abi: ../1-subinvoke/build/wrap.info
+extensions:
+  build: ./polywrap.build.yaml

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/schema.graphql
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/schema.graphql
@@ -1,0 +1,5 @@
+#import * into BadUtil from "ens/bad-util.eth"
+
+type Module {
+  subInvokeWillThrow(a: Int!, b: Int!): Int!
+}

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/src/lib.rs
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/0-subinvoke/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod wrap;
+pub use wrap::{*, imported::bad_util_module::ArgsIThrow };
+
+pub fn sub_invoke_will_throw(args: ArgsSubInvokeWillThrow) -> i32 {
+    let sub_invoke_result = BadUtilModule::i_throw( &ArgsIThrow { a: 0 }).unwrap();
+    args.a + args.b + sub_invoke_result
+}

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/Cargo.toml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test-case-simple-subinvoke"
+version = "0.1.0"
+description = "test-case-simple-subinvoke wrapper"
+authors = [
+  "Kobby Pentangeli <kobbypentangeli@gmail.com>",
+  "Jordan Ellis <jelli@dorg.tech>"
+]
+repository = "https://github.com/polywrap/monorepo"
+license = "MIT"
+edition = "2021"
+
+[dependencies]
+polywrap-wasm-rs = { path = "../../../../../../wasm/rs" }
+serde = { version = "1.0", features = ["derive"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 's'
+lto = true
+panic = 'abort'

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/polywrap.build.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/polywrap.build.yaml
@@ -1,0 +1,7 @@
+format: 0.2.0
+strategies:
+  image:
+    name: test-case-simple-subinvoke-1
+linked_packages:
+  - name: polywrap-wasm-rs
+    path: ../../../../../../wasm/rs

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/polywrap.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/polywrap.yaml
@@ -1,0 +1,9 @@
+format: 0.2.0
+project:
+  name: test-case-simple-subinvoke
+  type: wasm/rust
+source:
+  schema: ./schema.graphql
+  module: ./Cargo.toml
+extensions:
+  build: ./polywrap.build.yaml

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/schema.graphql
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/schema.graphql
@@ -1,0 +1,3 @@
+type Module {
+  iThrow(a: Int!): Int!
+}

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/src/lib.rs
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/1-subinvoke/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod wrap;
+pub use wrap::*;
+
+pub fn i_throw(args: ArgsIThrow) -> i32 {
+  if 2 == 2 {
+    panic!("I threw an error!");
+  }
+  args.a + 1
+}

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/Cargo.toml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test-case-simple-invoke"
+version = "0.1.0"
+description = "test-case-simple-invoke wrapper"
+authors = [
+  "Kobby Pentangeli <kobbypentangeli@gmail.com>",
+  "Jordan Ellis <jelli@dorg.tech>"
+]
+repository = "https://github.com/polywrap/monorepo"
+license = "MIT"
+edition = "2021"
+
+[dependencies]
+polywrap-wasm-rs = { path = "../../../../../../wasm/rs" }
+serde = { version = "1.0", features = ["derive"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 's'
+lto = true
+panic = 'abort'

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/polywrap.build.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/polywrap.build.yaml
@@ -1,0 +1,7 @@
+format: 0.2.0
+strategies:
+  image:
+    name: test-case-simple-invoke
+linked_packages:
+  - name: polywrap-wasm-rs
+    path: ../../../../../../wasm/rs

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/polywrap.yaml
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/polywrap.yaml
@@ -1,0 +1,14 @@
+format: 0.2.0
+project:
+  name: test-case-simple-invoke
+  type: wasm/rust
+source:
+  schema: ./schema.graphql
+  module: ./Cargo.toml
+  import_abis:
+    - uri: ens/bad-math.eth
+      abi: ../0-subinvoke/build/wrap.info
+    - uri: ens/not-found.eth
+      abi: ../0-subinvoke/build/wrap.info
+extensions:
+  build: ./polywrap.build.yaml

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/schema.graphql
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/schema.graphql
@@ -1,0 +1,7 @@
+#import * into BadMath from "ens/bad-math.eth"
+#import * into NotFound from "ens/not-found.eth"
+
+type Module {
+  throwsInTwoSubinvokeLayers(a: Int!, b: Int!): Int!
+  subWrapperNotFound(a: Int!, b: Int!): Int!
+}

--- a/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/src/lib.rs
+++ b/packages/test-cases/cases/wrappers/wasm-rs/subinvoke-error/invoke/src/lib.rs
@@ -1,0 +1,18 @@
+pub mod wrap;
+pub use wrap::{*, imported::bad_math_module, imported::not_found_module};
+
+pub fn throws_in_two_subinvoke_layers(args: ArgsThrowsInTwoSubinvokeLayers) -> i32 {
+  let imported_args = bad_math_module::ArgsSubInvokeWillThrow {
+    a: args.a,
+    b: args.b
+  };
+  BadMathModule::sub_invoke_will_throw(&imported_args).unwrap()
+}
+
+pub fn sub_wrapper_not_found(args: ArgsSubWrapperNotFound) -> i32 {
+  let imported_args = not_found_module::ArgsSubInvokeWillThrow {
+    a: args.a,
+    b: args.b
+  };
+  NotFoundModule::sub_invoke_will_throw(&imported_args).unwrap()
+}


### PR DESCRIPTION
This is the fix in https://github.com/polywrap/toolchain/pull/1556 applied to 0.9.