### PR TITLE
fix: add BuildOptions to build method in IClientConfigBuilder

### DIFF
--- a/packages/js/client-config-builder/README.md
+++ b/packages/js/client-config-builder/README.md
@@ -428,9 +428,10 @@ A complete example using all or most of the available methods.
   /**
    * Build a sanitized core client configuration that can be passed to the PolywrapClient or PolywrapCoreClient constructors
    *
+   * @param options - Use a custom wrapper cache or resolver
    * @returns CoreClientConfig that results from applying all the steps in the builder pipeline
    */
-  build(): CoreClientConfig;
+  build(options?: BuildOptions): CoreClientConfig;
 ```
 
 ## Bundles

--- a/packages/js/client-config-builder/src/ClientConfigBuilder.ts
+++ b/packages/js/client-config-builder/src/ClientConfigBuilder.ts
@@ -1,7 +1,6 @@
 import { getDefaultConfig } from "./bundles";
 import { BaseClientConfigBuilder } from "./BaseClientConfigBuilder";
-import { IClientConfigBuilder } from "./types";
-import { BuilderConfig } from "./types";
+import { BuildOptions, IClientConfigBuilder, BuilderConfig } from "./types";
 
 import {
   CoreClientConfig,
@@ -9,12 +8,10 @@ import {
   InterfaceImplementations,
   IUriPackage,
   IUriRedirect,
-  IUriResolver,
   IUriWrapper,
   Uri,
 } from "@polywrap/core-js";
 import {
-  IWrapperCache,
   PackageToWrapperCacheResolver,
   RecursiveResolver,
   StaticResolver,
@@ -22,13 +19,6 @@ import {
 } from "@polywrap/uri-resolvers-js";
 import { ExtendableUriResolver } from "@polywrap/uri-resolver-extensions-js";
 
-type BuildOptions =
-  | {
-      wrapperCache: IWrapperCache;
-    }
-  | {
-      resolver: IUriResolver<unknown>;
-    };
 export class ClientConfigBuilder extends BaseClientConfigBuilder {
   // $start: ClientConfigBuilder-constructor
   /**

--- a/packages/js/client-config-builder/src/types/BuildOptions.ts
+++ b/packages/js/client-config-builder/src/types/BuildOptions.ts
@@ -1,0 +1,10 @@
+import { IWrapperCache } from "@polywrap/uri-resolvers-js";
+import { IUriResolver } from "@polywrap/core-js";
+
+export type BuildOptions =
+  | {
+      wrapperCache: IWrapperCache;
+    }
+  | {
+      resolver: IUriResolver<unknown>;
+    };

--- a/packages/js/client-config-builder/src/types/IClientConfigBuilder.ts
+++ b/packages/js/client-config-builder/src/types/IClientConfigBuilder.ts
@@ -1,4 +1,5 @@
-import { BuilderConfig } from "./configs/BuilderConfig";
+import { BuilderConfig } from "./configs";
+import { BuildOptions } from "./BuildOptions";
 
 import { CoreClientConfig, Wrapper, IWrapPackage } from "@polywrap/core-js";
 import { UriResolverLike } from "@polywrap/uri-resolvers-js";
@@ -10,9 +11,10 @@ export interface IClientConfigBuilder {
   /**
    * Build a sanitized core client configuration that can be passed to the PolywrapClient or PolywrapCoreClient constructors
    *
+   * @param options - Use a custom wrapper cache or resolver
    * @returns CoreClientConfig that results from applying all the steps in the builder pipeline
    */
-  build(): CoreClientConfig;
+  build(options?: BuildOptions): CoreClientConfig;
   // $end
 
   // $start: IClientConfigBuilder-add

--- a/packages/js/client-config-builder/src/types/index.ts
+++ b/packages/js/client-config-builder/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./configs";
 export * from "./IClientConfigBuilder";
+export * from "./BuildOptions";


### PR DESCRIPTION
This makes it possible to add a custom cache or resolver without casting.

Before:
```ts
const builder: IClientConfigBuilder = new ClientConfigBuilder().addInterface(...);
const config = (builder as ClientConfigBuilder).build(resolver);
```

After:
```ts
const builder: IClientConfigBuilder = new ClientConfigBuilder().addInterface(...);
const config = builder.build(resolver);
```