### PR TITLE
cli(infra): fix ens infra module

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -89,7 +89,7 @@
     "@types/fs-extra": "9.0.12",
     "@types/jest": "26.0.8",
     "@types/mustache": "4.0.1",
-    "@types/node": "12.12.26",
+    "@types/node": "16.11.68",
     "@types/prettier": "2.6.0",
     "@types/rimraf": "3.0.0",
     "cross-env": "7.0.3",

--- a/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/ens/Dockerfile
+++ b/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/ens/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15.3-alpine
+FROM node:16-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/ens/scripts/package.json
+++ b/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/ens/scripts/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "rimraf": "3.0.2",
     "ts-node": "8.10.2",
-    "typescript": "4.1.6"
+    "typescript": "4.9.5"
   }
 }


### PR DESCRIPTION
if we try to start the infra module `eth-ens-ipfs` it will fail throwing an error related w/ts, this is a known issue: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64262 this PR aims to fix this