### PR TITLE
Fix: display decoded args when errors are thrown in subinvocations

### DIFF
--- a/packages/js/client/src/__tests__/core/error-structure.spec.ts
+++ b/packages/js/client/src/__tests__/core/error-structure.spec.ts
@@ -217,9 +217,7 @@ describe("Error structure", () => {
         ).toBeTruthy();
         expect(prev.uri).toEqual("wrap://ens/imported-invoke.eth");
         expect(prev.method).toEqual("invokeThrowError");
-        expect(prev.args).toEqual(
-          '{\n  "0": 129,\n  "1": 161,\n  "2": 97,\n  "3": 163,\n  "4": 72,\n  "5": 101,\n  "6": 121\n}'
-        );
+        expect(prev.args).toEqual('{\n  "a": "Hey"\n}' );
         expect(prev.source).toEqual({
           file: "~lib/@polywrap/wasm-as/containers/Result.ts",
           row: 171,
@@ -235,9 +233,7 @@ describe("Error structure", () => {
           prevOfPrev.uri.endsWith("wrap://ens/imported-subinvoke.eth")
         ).toBeTruthy();
         expect(prevOfPrev.method).toEqual("subinvokeThrowError");
-        expect(prev.args).toEqual(
-          '{\n  "0": 129,\n  "1": 161,\n  "2": 97,\n  "3": 163,\n  "4": 72,\n  "5": 101,\n  "6": 121\n}'
-        );
+        expect(prev.args).toEqual('{\n  "a": "Hey"\n}');
         expect(prevOfPrev.source).toEqual({
           file: "src/index.ts",
           row: 8,
@@ -428,9 +424,7 @@ describe("Error structure", () => {
         ).toBeTruthy();
         expect(prev.uri).toEqual("wrap://ens/imported-invoke.eth");
         expect(prev.method).toEqual("invokeThrowError");
-        expect(prev.args).toEqual(
-          '{\n  "0": 129,\n  "1": 161,\n  "2": 97,\n  "3": 163,\n  "4": 72,\n  "5": 101,\n  "6": 121\n}'
-        );
+        expect(prev.args).toEqual('{\n  "a": "Hey"\n}');
         expect(prev.source).toEqual({ file: "src/lib.rs", row: 10, col: 129 });
 
         expect(prev.innerError instanceof WrapError).toBeTruthy();
@@ -442,9 +436,7 @@ describe("Error structure", () => {
           prevOfPrev.uri.endsWith("wrap://ens/imported-subinvoke.eth")
         ).toBeTruthy();
         expect(prevOfPrev.method).toEqual("subinvokeThrowError");
-        expect(prevOfPrev.args).toEqual(
-          '{\n  "0": 129,\n  "1": 161,\n  "2": 97,\n  "3": 163,\n  "4": 72,\n  "5": 101,\n  "6": 121\n}'
-        );
+        expect(prevOfPrev.args).toEqual('{\n  "a": "Hey"\n}');
         expect(prevOfPrev.source).toEqual({
           file: "src/lib.rs",
           row: 9,

--- a/packages/js/core/README.md
+++ b/packages/js/core/README.md
@@ -707,8 +707,6 @@ export type UriPackageOrWrapper = UriValue | UriPackageValue | UriWrapperValue;
 
 ```ts
 /** An implementation of the IUriResolutionContext interface */
-// $start: UriResolutionContext
-/** An implementation of the IUriResolutionContext interface */
 export class UriResolutionContext implements IUriResolutionContext {
 ```
 

--- a/packages/js/core/src/uri-resolution/UriResolutionContext.ts
+++ b/packages/js/core/src/uri-resolution/UriResolutionContext.ts
@@ -4,8 +4,6 @@ import { Uri } from "../types";
 
 // $start: UriResolutionContext
 /** An implementation of the IUriResolutionContext interface */
-// $start: UriResolutionContext
-/** An implementation of the IUriResolutionContext interface */
 export class UriResolutionContext implements IUriResolutionContext {
   // $end
   private _resolvingUriMap: Map<string, boolean>;

--- a/packages/js/wasm/src/WasmWrapper.ts
+++ b/packages/js/wasm/src/WasmWrapper.ts
@@ -6,7 +6,7 @@ import { WRAP_MODULE_PATH } from "./constants";
 import { createWasmWrapper } from "./helpers/createWasmWrapper";
 
 import { WrapManifest } from "@polywrap/wrap-manifest-types-js";
-import { msgpackEncode } from "@polywrap/msgpack-js";
+import { msgpackDecode, msgpackEncode } from "@polywrap/msgpack-js";
 import { AsyncWasmInstance } from "@polywrap/asyncify-js";
 import {
   CoreClient,
@@ -141,7 +141,7 @@ export class WasmWrapper implements Wrapper {
           code: WrapErrorCode.WRAPPER_READ_FAIL,
           uri: options.uri.uri,
           method,
-          args: JSON.stringify(args, null, 2),
+          args: JSON.stringify(WasmWrapper._decodeArgs(args), null, 2),
         });
         return ResultErr(error);
       }
@@ -174,7 +174,7 @@ export class WasmWrapper implements Wrapper {
           code: WrapErrorCode.WRAPPER_INVOKE_ABORTED,
           uri: options.uri.uri,
           method,
-          args: JSON.stringify(args, null, 2),
+          args: JSON.stringify(WasmWrapper._decodeArgs(args), null, 2),
           source,
           innerError: prev,
         });
@@ -185,7 +185,7 @@ export class WasmWrapper implements Wrapper {
           code: WrapErrorCode.WRAPPER_INTERNAL_ERROR,
           uri: options.uri.uri,
           method,
-          args: JSON.stringify(args, null, 2),
+          args: JSON.stringify(WasmWrapper._decodeArgs(args), null, 2),
         });
       };
 
@@ -204,7 +204,7 @@ export class WasmWrapper implements Wrapper {
 
       const exports = instance.exports as WrapExports;
 
-      const result = await exports._wrap_invoke(
+      const result = exports._wrap_invoke(
         state.method.length,
         state.args.byteLength,
         state.env.byteLength
@@ -222,13 +222,21 @@ export class WasmWrapper implements Wrapper {
           code: WrapErrorCode.WRAPPER_INVOKE_FAIL,
           uri: options.uri.uri,
           method,
-          args: JSON.stringify(args, null, 2),
+          args: JSON.stringify(WasmWrapper._decodeArgs(args), null, 2),
         });
         return ResultErr(error);
       }
     } catch (error) {
       return ResultErr(error);
     }
+  }
+
+  private static _decodeArgs(
+    args: Uint8Array | Record<string, unknown>
+  ): Record<string, unknown> {
+    return args instanceof Uint8Array
+      ? (msgpackDecode(args) as Record<string, unknown>)
+      : args;
   }
 
   private _processInvokeResult(

--- a/packages/js/wasm/src/WasmWrapper.ts
+++ b/packages/js/wasm/src/WasmWrapper.ts
@@ -204,7 +204,7 @@ export class WasmWrapper implements Wrapper {
 
       const exports = instance.exports as WrapExports;
 
-      const result = exports._wrap_invoke(
+      const result = await exports._wrap_invoke(
         state.method.length,
         state.args.byteLength,
         state.env.byteLength


### PR DESCRIPTION
Args used to be displayed as-is in error messages when errors were thrown in Wasm wrapper invocations. This meant args for subinvocations were byte arrays. Now the args are always decoded for errors so they are human-readable.