### PR TITLE
Fix: ganache now works properly on Apple CPU

### DIFF
--- a/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/eth/Dockerfile
+++ b/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/eth/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:16
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Fixed by using full node image instead of node-alpine in ganache Docker image file