### PR TITLE
fix: align @types/node package version, fixing infra command in monorepo

### DIFF
--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
     },
   },
   modulePathIgnorePatterns: [
+    "<rootDir>/build",
     "<rootDir>/src/__tests__/project/.polywrap",
     "<rootDir>/src/__tests__/e2e/build-rs.spec.ts"
   ],

--- a/packages/cli/jest.rs.config.js
+++ b/packages/cli/jest.rs.config.js
@@ -7,6 +7,10 @@ module.exports = {
       diagnostics: false
     },
   },
+  modulePathIgnorePatterns: [
+    "<rootDir>/build",
+    "<rootDir>/src/__tests__/project/.polywrap"
+  ],
   testPathIgnorePatterns: [
     "<rootDir>/src/__tests__/project/.polywrap"
   ],
@@ -14,6 +18,5 @@ module.exports = {
     "<rootDir>/src/__tests__/project/.polywrap"
   ],
   setupFilesAfterEnv: ["./jest.setup.js"],
-  testMatch: ["**/build-rs.spec.ts"],
-  modulePathIgnorePatterns: [],
+  testMatch: ["**/build-rs.spec.ts"]
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -87,7 +87,7 @@
     "@types/fs-extra": "9.0.12",
     "@types/jest": "26.0.8",
     "@types/mustache": "4.0.1",
-    "@types/node": "18.14.2",
+    "@types/node": "^18.14.6",
     "@types/prettier": "2.6.0",
     "@types/rimraf": "3.0.0",
     "cross-env": "7.0.3",

--- a/packages/cli/src/lib/defaults/infra-modules/http/server/package.json
+++ b/packages/cli/src/lib/defaults/infra-modules/http/server/package.json
@@ -27,7 +27,7 @@
     "@types/file-saver": "2.0.5",
     "@types/fs-extra": "7.0.0",
     "@types/jest": "26.0.8",
-    "@types/node": "18.14.2",
+    "@types/node": "^18.14.6",
     "jest": "26.6.3",
     "nodemon": "2.0.19",
     "rimraf": "3.0.2",

--- a/packages/js/os/package.json
+++ b/packages/js/os/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint --color -c ../../../.eslintrc.js src/"
   },
   "devDependencies": {
-    "@types/node": "18.14.2",
+    "@types/node": "^18.14.6",
     "rimraf": "3.0.2",
     "typescript": "4.9.5"
   },

--- a/packages/js/tracing/package.json
+++ b/packages/js/tracing/package.json
@@ -24,7 +24,7 @@
     "@opentelemetry/sdk-trace-web": "1.6.0"
   },
   "devDependencies": {
-    "@types/node": "18.14.2",
+    "@types/node": "^18.14.6",
     "rimraf": "3.0.2",
     "typescript": "4.9.5"
   },

--- a/packages/templates/app/typescript/package.json
+++ b/packages/templates/app/typescript/package.json
@@ -11,7 +11,7 @@
     "@polywrap/client-js": "0.10.0-pre.11"
   },
   "devDependencies": {
-    "@types/node": "18.14.2",
+    "@types/node": "^18.14.6",
     "polywrap": "0.10.0-pre.11",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2474,15 +2474,10 @@
   resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-4.0.1.tgz#e4d421ed2d06d463b120621774185a5cd1b92d77"
   integrity sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw==
 
-"@types/node@*":
+"@types/node@*", "@types/node@^18.14.6":
   version "18.14.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.6.tgz#ae1973dd2b1eeb1825695bb11ebfb746d27e3e93"
   integrity sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==
-
-"@types/node@18.14.2":
-  version "18.14.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.2.tgz#c076ed1d7b6095078ad3cf21dfeea951842778b1"
-  integrity sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
This should fix CI, where the CLI's `infra` command is failing.