### PR TITLE
Fix: improved check for Rust error string santiziation

### DIFF
--- a/packages/js/core/src/types/WrapError.ts
+++ b/packages/js/core/src/types/WrapError.ts
@@ -145,7 +145,7 @@ export class WrapError extends Error {
   private static sanitizeUnwrappedRustResult(error: string): string {
     if (
       error.startsWith(
-        '__wrap_abort: called `Result::unwrap()` on an `Err` value: "'
+        "__wrap_abort: called `Result::unwrap()` on an `Err` value: "
       )
     ) {
       error = error.replace(/\\"/g, '"');


### PR DESCRIPTION
This will hopefully ensure Rust error strings are properly sanitized when unwrap is called on a Result error