### PR TITLE
Fix ts-node template

### DIFF
--- a/packages/cli/src/__tests__/e2e/build-rs.spec.ts
+++ b/packages/cli/src/__tests__/e2e/build-rs.spec.ts
@@ -5,7 +5,7 @@ import { GetPathToCliTestFiles } from "@polywrap/test-cases";
 import fs from "fs";
 import path from "path";
 
-jest.setTimeout(700000);
+jest.setTimeout(1000000);
 
 describe("e2e tests for build command", () => {
   const testCaseRoot = path.join(GetPathToCliTestFiles(), "wasm/build-cmd/rust");

--- a/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/ens/scripts/package.json
+++ b/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/ens/scripts/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "rimraf": "3.0.2",
     "ts-node": "8.10.2",
-    "typescript": "4.1.6"
+    "typescript": "4.1.6",
+    "@types/node": "17.0.41"
   }
 }

--- a/packages/templates/app/typescript-node/src/index.ts
+++ b/packages/templates/app/typescript-node/src/index.ts
@@ -24,7 +24,12 @@ async function main() {
     values: ["0xB1B7586656116D546033e3bAFF69BFcD6592225E", "500"]
   }, client);
 
-  console.log(`Ethereum_Module.encodeParams:\n${result.data}`);
+  if (!result.ok) {
+    console.log(`Error:\n${result.error}`);
+    return;
+  }
+
+  console.log(`Ethereum_Module.encodeParams:\n${result.value}`);
 }
 
 main()


### PR DESCRIPTION
Fixes included:
- the `ts-node` template had build errors when trying to build it immediately after creating and `codegen`ing, fixed
- [a breaking change in Typescript](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64262) caused the `ens` infra module to not build. Fixed by forcing a Typescript version for 0.9
- fixed up some improperly written IPFS Resolver tests
- increased timeout for Rust build tests (runs fine locally, times out in CI)