### PR TITLE
Fix: Map type argument parsing for `WrapError`

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -16,10 +16,10 @@ import {
   parseManifestFileOption,
   parseLogFileOption,
   parseWrapperEnvsOption,
-  typesHandler,
 } from "../lib";
 import { createLogger } from "./utils/createLogger";
 
+import { typesHandler } from "@polywrap/core-js";
 import path from "path";
 import yaml from "yaml";
 import fs from "fs";

--- a/packages/cli/src/lib/helpers/workflow-validator.ts
+++ b/packages/cli/src/lib/helpers/workflow-validator.ts
@@ -3,6 +3,7 @@ import { Logger } from "../logging";
 import { intlMsg } from "../intl";
 import { Status, WorkflowOutput } from "../workflow";
 
+import { typesHandler } from "@polywrap/core-js";
 import path from "path";
 import fs from "fs";
 import os from "os";
@@ -13,20 +14,6 @@ export function cueExists(logger: Logger): boolean {
   const { stdout } = runCommandSync("cue", ["version"], logger);
   return stdout ? stdout.startsWith("cue version ") : false;
 }
-
-export const typesHandler = (_: unknown, value: unknown): unknown => {
-  if (value instanceof Map) {
-    return Array.from(value).reduce(
-      (obj: Record<string, unknown>, [key, value]) => {
-        obj[key] = value;
-        return obj;
-      },
-      {}
-    );
-  }
-
-  return value;
-};
 
 export function validateOutput(
   output: WorkflowOutput,

--- a/packages/cli/src/lib/workflow/util.ts
+++ b/packages/cli/src/lib/workflow/util.ts
@@ -1,7 +1,7 @@
 import { intlMsg } from "../intl";
 import { WorkflowOutput } from "./types";
-import { typesHandler } from "../helpers";
 
+import { typesHandler } from "@polywrap/core-js";
 import path from "path";
 import fs from "fs";
 import { WorkflowJobs } from "@polywrap/polywrap-manifest-types-js";

--- a/packages/js/core/src/__tests__/typesHandler.spec.ts
+++ b/packages/js/core/src/__tests__/typesHandler.spec.ts
@@ -1,0 +1,60 @@
+import { typesHandler } from "../utils";
+
+describe('typesHandler', () => {
+  it('should return the original value if it is not a Map', () => {
+    const value = { a: 1 };
+    expect(typesHandler(undefined, value)).toEqual(value);
+  });
+
+  it('should return an empty object if the Map keys are not of type string', () => {
+    const value = new Map([[1, 'one'], [2, 'two']]);
+    expect(typesHandler(undefined, value)).toEqual({});
+  });
+
+  it('should convert empty Map into empty object', () => {
+    const value = new Map();
+    const expected = {};
+    expect(typesHandler(undefined, value)).toEqual(expected);
+  });
+
+  it('should convert Map object with string keys into object with key-value pairs', () => {
+    const value = new Map([['a', 1], ['b', 2]]);
+    const expected = { a: 1, b: 2 };
+    expect(typesHandler(undefined, value)).toEqual(expected);
+  });
+
+  it('should correctly stringify a Map object with string keys', () => {
+    const myObject = {
+      myMap: new Map([['a', 1], ['b', 2]])
+    };
+    const expected = '{\n  "myMap": {\n    "a": 1,\n    "b": 2\n  }\n}';
+
+    const stringified = JSON.stringify(myObject, typesHandler, 2);
+    expect(stringified).toEqual(expected);
+  });
+
+  it('should correctly stringify a Map object with non-string values', () => {
+    const myObject = {
+      myMap: new Map([['a', { foo: 'bar' }]])
+    };
+    const expected = '{\n  "myMap": {\n    "a": {\n      "foo": "bar"\n    }\n  }\n}';
+
+    const stringified = JSON.stringify(myObject, typesHandler, 2);
+
+    console.log(expected)
+    console.log(stringified)
+
+    expect(stringified).toEqual(expected);
+  });
+
+  it('should correctly stringify a non-Map object', () => {
+    const myObject = {
+      foo: 'bar',
+      baz: 42
+    };
+    const expected = '{\n  "foo": "bar",\n  "baz": 42\n}';
+
+    const stringified = JSON.stringify(myObject, typesHandler, 2);
+    expect(stringified).toEqual(expected);
+  });
+});

--- a/packages/js/core/src/__tests__/typesHandler.spec.ts
+++ b/packages/js/core/src/__tests__/typesHandler.spec.ts
@@ -41,9 +41,6 @@ describe('typesHandler', () => {
 
     const stringified = JSON.stringify(myObject, typesHandler, 2);
 
-    console.log(expected)
-    console.log(stringified)
-
     expect(stringified).toEqual(expected);
   });
 

--- a/packages/js/core/src/utils/index.ts
+++ b/packages/js/core/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./combinePaths";
 export * from "./getEnvFromUriHistory";
 export * from "./is-buffer";
+export * from "./typesHandler";

--- a/packages/js/core/src/utils/typesHandler.ts
+++ b/packages/js/core/src/utils/typesHandler.ts
@@ -1,12 +1,23 @@
+/**
+ * Converts a Map object with string keys into an object with key-value pairs
+ * that can be stringified using JSON.stringify. Returns an empty object if the
+ * keys are not of type string. Returns the original value if it is not a Map.
+ *
+ * @param _ Unused.
+ * @param value The value from the object to be stringified.
+ * @returns The converted object or the original value if it is not a Map
+ * or if the Map's keys are not of type string.
+ */
 export const typesHandler = (_: unknown, value: unknown): unknown => {
   if (value instanceof Map) {
-    return Array.from(value).reduce(
-      (obj: Record<string, unknown>, [key, value]) => {
-        obj[key] = value;
-        return obj;
-      },
-      {}
-    );
+    const obj: Record<string, unknown> = {};
+    const firstKey = value.keys().next().value;
+    if (typeof firstKey === "string") {
+      for (const [k, v] of value.entries()) {
+        obj[k] = v;
+      }
+    }
+    return obj;
   }
 
   return value;

--- a/packages/js/core/src/utils/typesHandler.ts
+++ b/packages/js/core/src/utils/typesHandler.ts
@@ -1,0 +1,13 @@
+export const typesHandler = (_: unknown, value: unknown): unknown => {
+  if (value instanceof Map) {
+    return Array.from(value).reduce(
+      (obj: Record<string, unknown>, [key, value]) => {
+        obj[key] = value;
+        return obj;
+      },
+      {}
+    );
+  }
+
+  return value;
+};

--- a/packages/js/wasm/src/WasmWrapper.ts
+++ b/packages/js/wasm/src/WasmWrapper.ts
@@ -19,6 +19,7 @@ import {
   WrapError,
   WrapErrorCode,
   ErrorSource,
+  typesHandler,
 } from "@polywrap/core-js";
 import { Result, ResultErr, ResultOk } from "@polywrap/result";
 
@@ -141,7 +142,7 @@ export class WasmWrapper implements Wrapper {
           code: WrapErrorCode.WRAPPER_READ_FAIL,
           uri: options.uri.uri,
           method,
-          args: JSON.stringify(WasmWrapper._decodeArgs(args), null, 2),
+          args: JSON.stringify(WasmWrapper._decodeArgs(args), typesHandler, 2),
         });
         return ResultErr(error);
       }
@@ -174,7 +175,7 @@ export class WasmWrapper implements Wrapper {
           code: WrapErrorCode.WRAPPER_INVOKE_ABORTED,
           uri: options.uri.uri,
           method,
-          args: JSON.stringify(WasmWrapper._decodeArgs(args), null, 2),
+          args: JSON.stringify(WasmWrapper._decodeArgs(args), typesHandler, 2),
           source,
           innerError: prev,
         });
@@ -185,7 +186,7 @@ export class WasmWrapper implements Wrapper {
           code: WrapErrorCode.WRAPPER_INTERNAL_ERROR,
           uri: options.uri.uri,
           method,
-          args: JSON.stringify(WasmWrapper._decodeArgs(args), null, 2),
+          args: JSON.stringify(WasmWrapper._decodeArgs(args), typesHandler, 2),
         });
       };
 
@@ -222,7 +223,7 @@ export class WasmWrapper implements Wrapper {
           code: WrapErrorCode.WRAPPER_INVOKE_FAIL,
           uri: options.uri.uri,
           method,
-          args: JSON.stringify(WasmWrapper._decodeArgs(args), null, 2),
+          args: JSON.stringify(WasmWrapper._decodeArgs(args), typesHandler, 2),
         });
         return ResultErr(error);
       }


### PR DESCRIPTION
I moved the typesHandler method to core-js and imported it in the cli & wasm-js packages. I also added unit tests for it.

Closes https://github.com/polywrap/toolchain/issues/1637