### PR TITLE
chore: use 0.0.1-pre.9 for test cases wrappers

### DIFF
--- a/packages/test-cases/index.ts
+++ b/packages/test-cases/index.ts
@@ -26,7 +26,7 @@ export async function fetchWrappers(): Promise<void> {
     zip.extractAllTo(destination, /*overwrite*/ true);
   }
 
-  const tag = "0.0.1-pre.7"
+  const tag = "0.0.1-pre.9"
   const repoName = "wasm-test-harness"
   const url = `https://github.com/polywrap/${repoName}/releases/download/${tag}/wrappers`;
 


### PR DESCRIPTION
after achieving the type safety in wrappers, a [new release has been done in the wrap test harness](https://github.com/polywrap/wrap-test-harness/releases/tag/0.0.1-pre.9) - this PR aims to update the toolchain to use the latest test cases