### PR TITLE
Fix: top-level `docker` property is now removed from build manifest during migration

### DIFF
--- a/packages/js/manifests/polywrap/src/formats/polywrap.build/migrators/0.1.0_to_0.2.0.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap.build/migrators/0.1.0_to_0.2.0.ts
@@ -5,7 +5,8 @@ import { BuildManifest as NewManifest } from "../0.2.0";
 
 export function migrate(old: OldManifest): NewManifest {
   return {
-    ...old,
+    config: old.config,
+    linked_packages: old.linked_packages,
     __type: "BuildManifest",
     format: "0.2.0",
     strategies: {

--- a/packages/js/manifests/polywrap/src/formats/polywrap/migrators/0.2.0_to_0.3.0.ts
+++ b/packages/js/manifests/polywrap/src/formats/polywrap/migrators/0.2.0_to_0.3.0.ts
@@ -1,6 +1,7 @@
-import { ILogger } from "@polywrap/logging-js";
 import { PolywrapManifest as OldManifest } from "../0.2.0";
 import { PolywrapManifest as NewManifest } from "../0.3.0";
+
+import { ILogger } from "@polywrap/logging-js";
 
 export function migrate(migrate: OldManifest, logger?: ILogger): NewManifest {
   if (migrate.extensions?.meta) {
@@ -21,8 +22,11 @@ export function migrate(migrate: OldManifest, logger?: ILogger): NewManifest {
     );
     delete migrate.extensions.infra;
   }
+  const hasExtensions =
+    migrate.extensions && Object.keys(migrate.extensions).length > 0;
   return {
     ...migrate,
     format: "0.3.0",
+    extensions: hasExtensions ? migrate.extensions : undefined,
   };
 }


### PR DESCRIPTION
This PR fixes a bug where the top-level `docker` property of build manifest version 0.1.0 was not being dropped during migration, causing migrated build manifests to fail validation.

I added too much detail to the issue I created for this, before realizing I could the bug in less time than it took to create the issue 😂. Check it out for more information: https://github.com/polywrap/toolchain/issues/1691

Closes https://github.com/polywrap/toolchain/issues/1691

I also fixed an issue where removal of extensions in the project manifest could lead to an empty object assigned to the `extensions` property.

<img width="698" alt="Screenshot 2023-04-15 at 11 20 10 AM" src="https://user-images.githubusercontent.com/39842820/232210868-6821e3cf-1cd3-48ab-93bd-0d23c8db404b.png">
