### PR TITLE
Rust Plugin Bindings: Bytes

### DIFF
--- a/packages/schema/bind/src/bindings/rust/functions.ts
+++ b/packages/schema/bind/src/bindings/rust/functions.ts
@@ -1,6 +1,5 @@
 import { isKeyword } from "./types";
 import { MustacheFn } from "../types";
-import { ScalarDefinition } from "@polywrap/wrap-manifest-types-js";
 
 function replaceAt(str: string, index: number, replacement: string): string {
   return (
@@ -315,9 +314,11 @@ export const serdeKeyword: MustacheFn = () => {
   };
 };
 
-export const serdeAnnotateIfBytes = () => {
-  return (value: ScalarDefinition | undefined): string => {
-    if (value?.type === "Bytes") {
+export const serdeAnnotateIfBytes: MustacheFn = () => {
+  return (value: string, render: (template: string) => string): string => {
+    const scalarType: string | undefined = render(value);
+
+    if (scalarType === "Bytes") {
       return `#[serde(with = "serde_bytes")]\n    `;
     }
     return "";

--- a/packages/schema/bind/src/bindings/rust/functions.ts
+++ b/packages/schema/bind/src/bindings/rust/functions.ts
@@ -1,5 +1,6 @@
 import { isKeyword } from "./types";
 import { MustacheFn } from "../types";
+import { ScalarDefinition } from "@polywrap/wrap-manifest-types-js";
 
 function replaceAt(str: string, index: number, replacement: string): string {
   return (
@@ -309,6 +310,15 @@ export const serdeKeyword: MustacheFn = () => {
     const type = render(value);
     if (isKeyword(type)) {
       return `#[serde(rename = "${type}")]\n    `;
+    }
+    return "";
+  };
+};
+
+export const serdeAnnotateIfBytes = () => {
+  return (value: ScalarDefinition | undefined): string => {
+    if (value?.type === "Bytes") {
+      return `#[serde(with = "serde_bytes")]\n    `;
     }
     return "";
   };

--- a/packages/schema/bind/src/bindings/rust/plugin/templates/module-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/plugin/templates/module-rs.mustache
@@ -12,7 +12,7 @@ use super::types::*;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Args{{#toUpper}}{{name}}{{/toUpper}} {
     {{#arguments}}
-    {{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/arguments}}
 }
 

--- a/packages/schema/bind/src/bindings/rust/plugin/templates/module-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/plugin/templates/module-rs.mustache
@@ -12,7 +12,7 @@ use super::types::*;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Args{{#toUpper}}{{name}}{{/toUpper}} {
     {{#arguments}}
-    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{#scalar}}{{type}}{{/scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/arguments}}
 }
 

--- a/packages/schema/bind/src/bindings/rust/plugin/templates/types-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/plugin/templates/types-rs.mustache
@@ -17,7 +17,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
     {{#properties}}
-    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{#scalar}}{{type}}{{/scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/properties}}
 }
 {{/envType}}
@@ -29,7 +29,7 @@ pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
     {{#properties}}
-    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{#scalar}}{{type}}{{/scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/properties}}
 }
 {{/objectTypes}}
@@ -54,7 +54,7 @@ pub enum {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
     {{#properties}}
-    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{#scalar}}{{type}}{{/scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/properties}}
 }
 {{/importedObjectTypes}}
@@ -66,7 +66,7 @@ pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
     {{#properties}}
-    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{#scalar}}{{type}}{{/scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/properties}}
 }
 {{/importedEnvType}}
@@ -93,7 +93,7 @@ pub enum {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct {{#toUpper}}{{parent.type}}{{/toUpper}}Args{{#toUpper}}{{name}}{{/toUpper}} {
     {{#arguments}}
-    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{#scalar}}{{type}}{{/scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/arguments}}
 }
 

--- a/packages/schema/bind/src/bindings/rust/plugin/templates/types-rs.mustache
+++ b/packages/schema/bind/src/bindings/rust/plugin/templates/types-rs.mustache
@@ -17,7 +17,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
     {{#properties}}
-    {{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/properties}}
 }
 {{/envType}}
@@ -29,7 +29,7 @@ pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
     {{#properties}}
-    {{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/properties}}
 }
 {{/objectTypes}}
@@ -54,7 +54,7 @@ pub enum {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
     {{#properties}}
-    {{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/properties}}
 }
 {{/importedObjectTypes}}
@@ -66,7 +66,7 @@ pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
     {{#properties}}
-    {{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/properties}}
 }
 {{/importedEnvType}}
@@ -93,7 +93,7 @@ pub enum {{#detectKeyword}}{{#toUpper}}{{type}}{{/toUpper}}{{/detectKeyword}} {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct {{#toUpper}}{{parent.type}}{{/toUpper}}Args{{#toUpper}}{{name}}{{/toUpper}} {
     {{#arguments}}
-    {{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
+    {{#serdeAnnotateIfBytes}}{{scalar}}{{/serdeAnnotateIfBytes}}{{#serdeRenameIfCaseMismatch}}{{name}}{{/serdeRenameIfCaseMismatch}}pub {{#detectKeyword}}{{#toLower}}{{name}}{{/toLower}}{{/detectKeyword}}: {{#toWasm}}{{toGraphQLType}}{{/toWasm}},
     {{/arguments}}
 }
 

--- a/packages/test-cases/cases/bind/sanity/output/plugin-rs/types.rs
+++ b/packages/test-cases/cases/bind/sanity/output/plugin-rs/types.rs
@@ -47,7 +47,9 @@ pub struct CustomType {
     pub json: JSON::Value,
     #[serde(rename = "optJson")]
     pub opt_json: Option<JSON::Value>,
+    #[serde(with = "serde_bytes")]
     pub bytes: Vec<u8>,
+    #[serde(with = "serde_bytes")]
     #[serde(rename = "optBytes")]
     pub opt_bytes: Option<Vec<u8>>,
     pub boolean: bool,


### PR DESCRIPTION
Needed for polywrap/rust-client#59

In Rust, `bytes` and an array of uint8 are not different types, they're all just `Vec<u8>`. But in the msgpack specification, they are indeed different (see `bin` family). Therefore, when deserializing a `bin` msgpack type and trying to coerce it to `Vec<u8>`, a mismatch error gets thrown (https://github.com/3Hren/msgpack-rust/issues/249).

This PR adds annotations to use [serde_bytes](https://docs.rs/serde_bytes/latest/serde_bytes/) serialization/deserialization as recommended in the `rmp_serde` issue thread.