### PR TITLE
chore(cli/infra): use truffle ganache docker image

### DIFF
--- a/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/docker-compose.yaml
+++ b/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/docker-compose.yaml
@@ -1,10 +1,9 @@
 version: '3'
 services:
   ganache:
-    build: ./eth
+    image: trufflesuite/ganache:latest
     ports:
       - ${ETHEREUM_PORT:-8545}:8545
-    command: ganache -l 8000000 --networkId 1576478390085 --deterministic --hostname=0.0.0.0
   ipfs:
     build: ./ipfs
     ports:

--- a/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/docker-compose.yaml
+++ b/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3'
 services:
   ganache:
     image: trufflesuite/ganache:latest
+    command: -d
     ports:
       - ${ETHEREUM_PORT:-8545}:8545
   ipfs:

--- a/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/eth/Dockerfile
+++ b/packages/cli/src/lib/defaults/infra-modules/eth-ens-ipfs/eth/Dockerfile
@@ -1,8 +1,0 @@
-FROM node:16
-
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
-RUN npm install -g ganache@latest
-
-CMD ["ganache", "--hostname", "0.0.0.0"]


### PR DESCRIPTION
this PR aims to update the ganache image with the latest from docker. this fix is because when updating the ethers wrap the CI was failing (https://github.com/polywrap/ethers/actions/runs/5965368132/job/16182637986). After digging through we were not being able to communicate with the Ganache instance; I guess it was because an update in the Ganache npm package